### PR TITLE
feat(KONFLUX-12331): modify embargo-check for new jira server

### DIFF
--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -1,7 +1,7 @@
 # embargo-check
 
 Tekton task to check if any issues or CVEs in the releaseNotes key of the data.json are embargoed. It checks the issues by server using curl and checks the CVEs via an InternalRequest. If any issue does not exist or any CVE is embargoed, the task will fail. The task will also fail if a Jira issue listed is for a component that does not exist in the releaseNotes.content.[images|artifacts] section or if said component does not list the CVE from the issue.
-Finally, the task will inject the `public` key to each issue listed for `issues.redhat.com`. This is a boolean value that is set based on the issues visibility.
+Finally, the task will inject the `public` key to each issue listed for `redhat.atlassian.net`. This is a boolean value that is set based on the issues visibility.
 
 ## Parameters
 

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -15,7 +15,7 @@ spec:
     for a component that does not exist in the releaseNotes.content.[images|artifacts] section
     or if said component does not list the CVE from the issue.
 
-    Finally, the task will inject the `public` key to each issue listed for `issues.redhat.com`.
+    Finally, the task will inject the `public` key to each issue listed for `redhat.atlassian.net`.
     This is a boolean value that is set based on the issues visibility.
   params:
     - name: dataPath
@@ -141,6 +141,7 @@ spec:
         #!/usr/bin/env bash
 
         ACCESS_TOKEN="$(cat /etc/secrets/token)"
+        EMAIL="$(cat /etc/secrets/email)"
 
         set -x
 
@@ -149,7 +150,8 @@ spec:
                 "api": "rest/api/2/issue",
                 "servers": [
                     "issues.redhat.com",
-                    "jira.atlassian.com"
+                    "jira.atlassian.com",
+                    "redhat.atlassian.net"
                 ]
             },
             "bugzilla": {
@@ -167,8 +169,9 @@ spec:
         fi
 
         # It is expected for the custom field ids to remain stable, but to get them, you can do:
-        # curl -H "Authorization: Bearer $ACCESS_TOKEN" https://issues.redhat.com/rest/api/2/field
-        CVE_FIELD="customfield_12324749"
+        # curl -u "$email:$token" https://redhat.atlassian.net/rest/api/2/field and look for one with
+        # name "CVE ID"
+        CVE_FIELD="customfield_10667"
 
         RC=0
 
@@ -176,12 +179,15 @@ spec:
         for ((i = 0; i < NUM_ISSUES; i++)); do
             issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
             server=$(jq -r '.source' <<< "$issue")
+            if [ "$server" = "issues.redhat.com" ] ; then
+                server=redhat.atlassian.net
+            fi
             API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$SUPPORTED_ISSUE_TRACKERS")
-            API_URL="https://$(jq -r '.source' <<< "$issue")/${API}/$(jq -r '.id' <<< "$issue")"
+            API_URL="https://${server}/${API}/$(jq -r '.id' <<< "$issue")"
             AUTH_ARGS=()
             set +x # We don't want to leak the ACCESS_TOKEN
-            if [ "$server" = "issues.redhat.com" ] ; then
-                AUTH_ARGS=(-H "Authorization: Bearer $ACCESS_TOKEN")
+            if [ "$server" = "redhat.atlassian.net" ] ; then
+                AUTH_ARGS=(-u "${EMAIL}:${ACCESS_TOKEN}")
             fi
             OUTPUT=$(curl-with-retry --retry 3 "${AUTH_ARGS[@]}" "${API_URL}")
             CURL_RC=$?
@@ -193,11 +199,13 @@ spec:
                 continue
             fi
 
-            # Public should be true if and only if the security field doesn't exist and the issue is accessible
-            # without authentication
+            # Public should be true if and only if the security field is null/missing and the issue is accessible
+            # without authentication. On Atlassian Cloud, the security field exists but is null for public issues.
+            # Also handle case where OUTPUT is empty (jq returns empty string).
             public=false
+            SECURITY_VALUE=$(jq '.fields.security' <<< "$OUTPUT")
 
-            if ! "$(jq '.fields | has("security")' <<< "$OUTPUT")" ; then
+            if [ -z "$SECURITY_VALUE" ] || [ "$SECURITY_VALUE" = "null" ]  ; then
                 echo "Checking if the issue is public - if not, curl will fail with error 401"
                 if curl-with-retry --retry 3 "${API_URL}" > /dev/null; then
                     public=true
@@ -208,8 +216,8 @@ spec:
             jq --argjson i "$i" --argjson public $public '.releaseNotes.issues.fixed[$i].public = $public' \
                 "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
 
-            # Perform additional checks only for issues on issues.redhat.com
-            if [ "$server" != "issues.redhat.com" ] ; then
+            # Perform additional checks only for issues on redhat.atlassian.net
+            if [ "$server" != "redhat.atlassian.net" ] ; then
                 continue
             fi
 

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -13,29 +13,37 @@ function curl-with-retry() {
   elif [[ "$*" == "--retry 3 https://bugzilla.redhat.com/rest/bug/12345" ]]
   then
     :
+  elif [[ "$*" == "--retry 3 https://issues.redhat.com/"* ]]
+  then
+    echo "No calls should be made to issues.redhat.com anymore"
+    echo "The server value should've been translated to redhat.atlassian.net"
+    exit 1
   elif [[ "$*" == "--retry 3 https://jira.atlassian.com/rest/api/2/issue/EMBARGOED-987" ]]
   then
     exit 1
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/MISSINGRH-123" ]]
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/MISSINGRH-123" ]]
   then
     exit 1
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/FEATURE-123" ]] # Not a Vulnerability
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/FEATURE-123" ]] # Not a Vulnerability
   then
     echo '{"fields":{"issuetype":{"name":"Feature"},"security":"a"}}'
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/VULN-123" ]] # Vulnerability
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/VULN-123" ]] # Vulnerability
   then
-    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_12324749":"CVE-123","customfield_12324752":"my-component","security":"a"}}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PUBLIC-1" ]] # Public: no security field, works without auth
+    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_10667":"CVE-123","customfield_12324752":"my-component","security":"a"}}'
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PUBLIC-1" ]] # Public: no security field, works without auth
   then
     echo '{"fields":{"foo":"bar"}}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PRIVATE-1" ]] # Private: no security field, works with auth but not without
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PUBLIC-SECNULL" ]] # Public: security field exists but is null (Atlassian Cloud behavior)
   then
-    if [[ "$*" == *"Authorization: Bearer"* ]] ; then
+    echo '{"fields":{"security":null}}'
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PRIVATE-1" ]] # Private: no security field, works with auth but not without
+  then
+    if [[ "$*" == *"-u "* ]] ; then
       :
     else
       return 1
     fi
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PRIVATE-2" ]] # Private: has security field
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PRIVATE-2" ]] # Private: has security field
   then
     echo '{"fields":{"security":"bar"}}'
   else

--- a/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
@@ -8,4 +8,4 @@ yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/embargo-check/tests/test-embargo-check-jira-conversion.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-jira-conversion.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-embargo-check-nonexistent-rh-issue
-  annotations:
-    test/assert-task-failure: "run-task"
+  name: test-embargo-check-jira-conversion
 spec:
-  description: Test for embargo-check where a redhat.atlassian.net issue cannot be found
+  description: |
+    Test for embargo-check that ensures issues provided as issues.redhat.com use
+    the redhat.atlassian.net endpoints instead
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -61,12 +61,29 @@ spec:
                   "issues": {
                     "fixed": [
                       {
-                        "id": "MISSINGRH-123",
-                        "source": "redhat.atlassian.net"
+                        "id": "VULN-123",
+                        "source": "issues.redhat.com"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "images": [
+                      {
+                        "component": "my-other-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/other-repo"
                       },
                       {
-                        "id": "12345",
-                        "source": "bugzilla.redhat.com"
+                        "component": "my-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/repo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "packages": []
+                            }
+                          }
+                        }
                       }
                     ]
                   }
@@ -107,3 +124,51 @@ spec:
           value: "main"
       runAfter:
         - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if grep -q "issues.redhat.com" "$(params.dataDir)/mock_curl.txt" ; then
+                  echo Error: issues.redhat.com should not be queried. Calls:
+                  cat "$(params.dataDir)/mock_curl.txt"
+                  exit 1
+              fi
+      runAfter:
+        - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: test-embargo-check-non-vuln-rh-issue
 spec:
-  description: Test for embargo-check with a issues.redhat.com issue that is not of type Vulnerability
+  description: Test for embargo-check with a redhat.atlassian.net issue that is not of type Vulnerability
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -64,7 +64,7 @@ spec:
                       },
                       {
                         "id": "FEATURE-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       }
                     ]
                   }

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -5,10 +5,11 @@ metadata:
   name: test-embargo-check-rh-issue-public-key-added
 spec:
   description: |
-    Test for embargo-check with 4 issues. Two are private and should have the key added with
-    false (one because it has a security field, one because it can only be seen with
-    authenticated curl). The other two are public because they can be seen without authentication.
-    One is a jira issue and one is a bugzilla bug. Ensure the public keys are all properly added.
+    Test for embargo-check with 5 issues. Two are private and should have the key added with
+    false (one because it has a security field with a value, one because it can only be seen with
+    authenticated curl). The other three are public: one has no security field, one has security
+    field with null value (Atlassian Cloud behavior), and one is a bugzilla bug.
+    Ensure the public keys are all properly added.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -64,15 +65,19 @@ spec:
                     "fixed": [
                       {
                         "id": "PUBLIC-1",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
+                      },
+                      {
+                        "id": "PUBLIC-SECNULL",
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "PRIVATE-1",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "PRIVATE-2",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",
@@ -175,6 +180,9 @@ spec:
               set -eux
 
               test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PUBLIC-1") | .public' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == true
+
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PUBLIC-SECNULL") | .public' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == true
 
               test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PRIVATE-1") | .public' \

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-embargo-check-rh-issue-artifact
 spec:
   description: |
-    Test for embargo-check where a issues.redhat.com issue lists CVE-123 as a CVE and that
+    Test for embargo-check where a redhat.atlassian.net issue lists CVE-123 as a CVE and that
     CVE is listed in one component of releaseNotes.content.artifacts.
   params:
     - name: ociStorage
@@ -62,7 +62,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Test for embargo-check where a issues.redhat.com issue lists CVE-123 as a CVE, but the images
+    Test for embargo-check where a redhat.atlassian.net issue lists CVE-123 as a CVE, but the images
     section does not list CVE-123 for any component. The task should fail.
   params:
     - name: ociStorage
@@ -64,7 +64,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-embargo-check-rh-issue
 spec:
   description: |
-    Test for embargo-check where a issues.redhat.com issue lists CVE-123 as a CVE and that
+    Test for embargo-check where a redhat.atlassian.net issue lists CVE-123 as a CVE and that
     CVE is listed in one component of releaseNotes.content.images.
   params:
     - name: ociStorage
@@ -62,7 +62,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",


### PR DESCRIPTION
This commit updates the embargo-check managed task to work with the new red hat jira server. Issues using issues.redhat.com will be queried with the new api server, and issues on the new server will work now.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
