### PR TITLE
feat(KONFLUX-12331): modify close-advisory-issues for new jira server

### DIFF
--- a/tasks/managed/close-advisory-issues/README.md
+++ b/tasks/managed/close-advisory-issues/README.md
@@ -1,7 +1,7 @@
 # close-advisory-issues
 
 Tekton task to close all issues referenced in the releaseNotes. It is meant to run after the advisory is published. A comment will be added to each closed issue with a link to the advisory it was fixed in.
-Note: This task currently only supports issues in issues.redhat.com due to it requiring authentication. Issues in other servers will be skipped without the task failing.
+Note: This task currently only supports issues in redhat.atlassian.net and issues.redhat.com due to them requiring authentication. Issues in other servers will be skipped without the task failing.
 
 ## Parameters
 

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -11,8 +11,8 @@ spec:
     Tekton task to close all issues referenced in the releaseNotes. It is meant to run after the advisory is published.
     A comment will be added to each closed issue with a link to the advisory it was fixed in.
 
-    Note: This task currently only supports issues in issues.redhat.com due to it requiring authentication.
-    Issues in other servers will be skipped without the task failing.
+    Note: This task currently only supports issues in redhat.atlassian.net and issues.redhat.com due to them requiring
+    authentication. Issues in other servers will be skipped without the task failing.
   params:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
@@ -135,13 +135,15 @@ spec:
         set -eu
 
         ACCESS_TOKEN="$(cat /etc/secrets/token)"
+        EMAIL="$(cat /etc/secrets/email)"
 
         ISSUE_TRACKERS='{
             "Jira": {
                 "api": "rest/api/2/issue",
                 "servers": [
                     "issues.redhat.com",
-                    "jira.atlassian.com"
+                    "jira.atlassian.com",
+                    "redhat.atlassian.net"
                 ]
             },
             "bugzilla": {
@@ -162,19 +164,19 @@ spec:
         for ((i = 0; i < NUM_ISSUES; i++)); do
             issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
             server=$(jq -r '.source' <<< "$issue")
-            if [ "$server" != "issues.redhat.com" ] ; then
+            if [ "$server" = "issues.redhat.com" ] ; then
+                server=redhat.atlassian.net
+            fi
+            if [ "$server" != "redhat.atlassian.net" ] ; then
                 echo "This task currently only supports closing issues on issues.redhat.com"
-                echo "Skipping issue $issue as it is on $server"
+                echo "and redhat.atlassian.net. Skipping issue $issue as it is on $server"
                 continue
             fi
 
-            CURL_ARGS=(
-              -H "Authorization: Bearer $ACCESS_TOKEN"
-              --retry 3
-            )
+            CURL_ARGS=(-u "${EMAIL}:${ACCESS_TOKEN}")
 
             API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$ISSUE_TRACKERS")
-            API_URL="https://$(jq -r '.source' <<< "$issue")/${API}/$(jq -r '.id' <<< "$issue")"
+            API_URL="https://${server}/${API}/$(jq -r '.id' <<< "$issue")"
 
             if [ "$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}" | jq -r '.fields.status.name')" == "Closed" ] ; then
                 echo "Issue $issue is already in Closed state. Skipping it."

--- a/tasks/managed/close-advisory-issues/tests/mocks.sh
+++ b/tasks/managed/close-advisory-issues/tests/mocks.sh
@@ -6,28 +6,28 @@ function curl-with-retry() {
   echo Mock curl called with: $* >&2
   echo $* >> "$(params.dataDir)/mock_curl.txt"
 
-  if [[ "$*" == *"Content-Type"*"https://issues.redhat.com/rest/api/2/issue/ISSUE-123/transitions" ]]
+  if [[ "$*" == *"-u team@domain.com:abcdefg"*"Content-Type"*"https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123/transitions" ]]
   then
     :
-  elif [[ "$*" == *"Content-Type"*"https://issues.redhat.com/rest/api/2/issue/FAIL-999/transitions" ]]
+  elif [[ "$*" == *"-u team@domain.com:abcdefg"*"Content-Type"*"https://redhat.atlassian.net/rest/api/2/issue/FAIL-999/transitions" ]]
   then
     return 1
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/FAIL-999/transitions" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/FAIL-999/transitions" ]]
   then
     echo '{"transitions":[{"id":"91","name":"Closed","description":""},{"id":"11","name":"New"}]}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/ISSUE-123/transitions" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123/transitions" ]]
   then
     echo '{"transitions":[{"id":"91","name":"Closed","description":""},{"id":"11","name":"New"}]}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/NOCLOSE-555/transitions" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/NOCLOSE-555/transitions" ]]
   then
     echo '{"expand":"transitions","transitions":[]}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/CLOSED-987" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/CLOSED-987" ]]
   then
     echo '{"fields":{"status":{"name":"Closed","id":"99"}}}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/FAIL-999/comment" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/FAIL-999/comment" ]]
   then
     echo '{}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/NOCLOSE-555/comment" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/NOCLOSE-555/comment" ]]
   then
     echo '{}'
   else

--- a/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
@@ -7,4 +7,4 @@ yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
@@ -63,7 +63,7 @@ spec:
                     "fixed": [
                       {
                         "id": "FAIL-999",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
@@ -64,7 +64,7 @@ spec:
                     "fixed": [
                       {
                         "id": "NOCLOSE-555",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-jira-conversion.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-jira-conversion.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-close-advisory-issues-closed-issue
+  name: test-close-advisory-issues-jira-conversion
 spec:
   description: |
-    Test for close-advisory-issues where the issue is already closed. Curl should only be
-    called once for the issue
+    Test for close-advisory-issues where an issues.redhat.com issue is converted to
+    redhat.atlassian.net as this is the new server.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -61,12 +61,8 @@ spec:
                   "issues": {
                     "fixed": [
                       {
-                        "id": "CLOSED-987",
-                        "source": "redhat.atlassian.net"
-                      },
-                      {
-                        "id": "12345",
-                        "source": "bugzilla.redhat.com"
+                        "id": "ISSUE-123",
+                        "source": "issues.redhat.com"
                       }
                     ]
                   }
@@ -148,12 +144,11 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                  echo Error: curl was expected to be called 1 time. Actual calls:
+      
+              if grep -q "issues.redhat.com" "$(params.dataDir)/mock_curl.txt" ; then
+                  echo Error: issues.redhat.com should not be queried. Calls:
                   cat "$(params.dataDir)/mock_curl.txt"
                   exit 1
               fi
-
-              [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"CLOSED-987" ]]
       runAfter:
         - run-task

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -60,7 +60,7 @@ spec:
                     "fixed": [
                       {
                         "id": "ISSUE-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",


### PR DESCRIPTION
This commit updates the close-advisory-issues managed task to work with the new red hat jira server. Issues using issues.redhat.com will be queried with the new api server, and issues on the new  server will now be supported.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
