### PR TITLE
fix(RELEASE-2338): support flatpaks registry in cleanup_tags

### DIFF
--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -155,7 +155,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+      image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
       computeResources:
         limits:
           memory: 3Gi

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -241,7 +241,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -181,7 +181,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -194,7 +194,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-one-arch.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -165,7 +165,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:66a9265f7e767058f3632124ab39280b62039200da428657fb515d072566fe50
+            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Update utils image in create-pyxis-image task to get a fix for cleanup_tags.

We added support for flatpaks in create_container_image recently, but we missed the cleanup script.

Utils PR:
https://github.com/konflux-ci/release-service-utils/pull/685

## Relevant Jira

RELEASE-2338

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
