### PR TITLE
fix(embargo-check): handle Atlassian Cloud security field null value

### DIFF
--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -199,11 +199,13 @@ spec:
                 continue
             fi
 
-            # Public should be true if and only if the security field doesn't exist and the issue is accessible
-            # without authentication
+            # Public should be true if and only if the security field is null/missing and the issue is accessible
+            # without authentication. On Atlassian Cloud, the security field exists but is null for public issues.
+            # Also handle case where OUTPUT is empty (jq returns empty string).
             public=false
+            SECURITY_VALUE=$(jq '.fields.security' <<< "$OUTPUT")
 
-            if ! "$(jq '.fields | has("security")' <<< "$OUTPUT")" ; then
+            if [ -z "$SECURITY_VALUE" ] || [ "$SECURITY_VALUE" = "null" ] ; then
                 echo "Checking if the issue is public - if not, curl will fail with error 401"
                 if curl-with-retry --retry 3 "${API_URL}" > /dev/null; then
                     public=true

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -33,6 +33,9 @@ function curl-with-retry() {
   elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PUBLIC-1" ]] # Public: no security field, works without auth
   then
     echo '{"fields":{"foo":"bar"}}'
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PUBLIC-SECNULL" ]] # Public: security field exists but is null (Atlassian Cloud behavior)
+  then
+    echo '{"fields":{"security":null}}'
   elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PRIVATE-1" ]] # Private: no security field, works with auth but not without
   then
     if [[ "$*" == *"-u "* ]] ; then

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -5,10 +5,11 @@ metadata:
   name: test-embargo-check-rh-issue-public-key-added
 spec:
   description: |
-    Test for embargo-check with 4 issues. Two are private and should have the key added with
-    false (one because it has a security field, one because it can only be seen with
-    authenticated curl). The other two are public because they can be seen without authentication.
-    One is a jira issue and one is a bugzilla bug. Ensure the public keys are all properly added.
+    Test for embargo-check with 5 issues. Two are private and should have the key added with
+    false (one because it has a security field with a value, one because it can only be seen with
+    authenticated curl). The other three are public: one has no security field, one has security
+    field with null value (Atlassian Cloud behavior), and one is a bugzilla bug.
+    Ensure the public keys are all properly added.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -64,6 +65,10 @@ spec:
                     "fixed": [
                       {
                         "id": "PUBLIC-1",
+                        "source": "redhat.atlassian.net"
+                      },
+                      {
+                        "id": "PUBLIC-SECNULL",
                         "source": "redhat.atlassian.net"
                       },
                       {
@@ -175,6 +180,9 @@ spec:
               set -eux
 
               test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PUBLIC-1") | .public' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == true
+
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PUBLIC-SECNULL") | .public' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == true
 
               test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PRIVATE-1") | .public' \


### PR DESCRIPTION
## Describe your changes
On Atlassian Cloud, the Jira API returns "security": null for public issues, whereas Jira Server omitted the field entirely. The previous check using `has("security")` returned true when the field existed (regardless of value), incorrectly marking public issues as private.

Changed the check to evaluate the actual security field value:
- Empty string (jq returns empty when parsing empty/invalid output)
- Literal null (when security field is null or missing)
Both cases now correctly trigger the anonymous accessibility check.

Added unit test for PUBLIC-SECNULL case to verify the fix.

Assisted-by: Cursor AI

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
