### PR TITLE
docs(KONFLUX-12331): replace jira links

### DIFF
--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -203,7 +203,7 @@ jobs:
           steps.promote.outputs.parsed_tickets_file != ''
         uses: konflux-ci/release-service-automations/jira-ci@2a074bf7270b4212038f4f8e06dff76b8760254b  # main
         with:
-          jira_url: "https://issues.redhat.com"
+          jira_url: "https://redhat.atlassian.net"
           promotion_type: ${{ inputs.promotion-type }}
           metadata_file: ${{ steps.promote.outputs.parsed_tickets_file }}
           jira_token: ${{ secrets.JIRA_TOKEN }}

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
@@ -69,7 +69,7 @@ spec:
 
               collectors='
                 {"collectors":{"managed":{"foo":{"releaseNotes":{"cves":[{"key":"FOO-3444","component":"my-component"}]}},
-                "bar":{"releaseNotes":{"issues":{"fixed":[{"id":"FOO-1234","source":"issues.redhat.com"}]}}}},
+                "bar":{"releaseNotes":{"issues":{"fixed":[{"id":"FOO-1234","source":"redhat.atlassian.net"}]}}}},
                 "tenant":{"foobar":{"releaseNotes":{"foobar":[{"key":"FOO-4333","component":"my-component"}]}}}}}
               '
               kubectl patch Release release-with-data-sample --type=merge --subresource status --patch \
@@ -231,7 +231,7 @@ spec:
                == "$(jq -cr --sort-keys <<< '{"releaseNotes":{"cves":[{"component":"my-component","key":"FOO-3444"}],
                   "foobar":[{"component":"my-component",
                   "key":"FOO-4333"}],"issues":{"fixed":[{"id":"FOO-1234",
-                  "source":"issues.redhat.com"}]}},"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],
+                  "source":"redhat.atlassian.net"}]}},"foo":"bar","rkey":"rvalue","one":{"four":["five","six"],
                   "two":"three"},"singleComponentMode":true}')"
 
               echo Test that the singleComponentMode result was properly set

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
@@ -67,13 +67,13 @@ spec:
                     issues:
                       fixed:
                         - id: "BAR-1234"
-                          source: "issues.redhat.com"
+                          source: "redhat.atlassian.net"
               EOF
               kubectl apply -f release
 
               collectors='
                 {"collectors":{"managed":{"foo":{"releaseNotes":{"cves":[{"key":"FOO-3444","component":"my-component"}]}},
-                "bar":{"releaseNotes":{"issues":{"fixed":[{"id":"FOO-1234","source":"issues.redhat.com"}]}}}},
+                "bar":{"releaseNotes":{"issues":{"fixed":[{"id":"FOO-1234","source":"redhat.atlassian.net"}]}}}},
                 "tenant":{"foobar":{"releaseNotes":{"foobar":[{"key":"FOO-4333","component":"my-component"}]}}}}}
               '
               kubectl patch Release release-with-data-sample --type=merge --subresource status --patch \
@@ -223,8 +223,8 @@ spec:
               test "$(jq -cr --sort-keys . "$(params.dataDir)/$(params.data)")" \
                == "$(jq -cr --sort-keys <<< '{"releaseNotes":{"cves":[{"component":"my-component","key":"FOO-3444"}],
                   "foobar":[{"component":"my-component","key":"FOO-4333"}],
-                  "issues":{"fixed":[{"id":"BAR-1234","source":"issues.redhat.com"},
-                  {"id":"FOO-1234","source":"issues.redhat.com"}]}}}' | jq -cr)"
+                  "issues":{"fixed":[{"id":"BAR-1234","source":"redhat.atlassian.net"},
+                  {"id":"FOO-1234","source":"redhat.atlassian.net"}]}}}' | jq -cr)"
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -474,7 +474,7 @@ spec:
         stagingSecretName="create-advisory-stage-secret"
         stagingErrataSecretName="errata-stage-service-account"
 
-        # See decision in https://issues.redhat.com/browse/HUM-434
+        # See decision in https://redhat.atlassian.net/browse/HUM-434
         # why we only publish image or rpm to main advisory repos
         if [[ "$content_type" =~ ^(image|rpm)$ ]] ; then
 

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -337,10 +337,10 @@ spec:
 
         # This is temporary until we can update to a newer utils image
         # that already has this fix in the Dockerfile.
-        # See https://issues.redhat.com/browse/RELEASE-2091
+        # See https://redhat.atlassian.net/browse/RELEASE-2091
         # The utils image which contains this fix also contains updates
         # to upload_rpm_data and which don't work yet,
-        # see https://issues.redhat.com/browse/RELEASE-2101
+        # see https://redhat.atlassian.net/browse/RELEASE-2101
         export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
         PYXIS_CERT="$(cat /etc/secrets/cert)"


### PR DESCRIPTION
issues.redhat.com is deprecated, so this commit updates any comments or tests using it to use redhat.atlassian.net instead. There is no functionality change with this commit.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
