### PR TITLE
feat(KONFLUX-12331): support new jira server

### DIFF
--- a/tasks/managed/close-advisory-issues/README.md
+++ b/tasks/managed/close-advisory-issues/README.md
@@ -1,7 +1,7 @@
 # close-advisory-issues
 
 Tekton task to close all issues referenced in the releaseNotes. It is meant to run after the advisory is published. A comment will be added to each closed issue with a link to the advisory it was fixed in.
-Note: This task currently only supports issues in issues.redhat.com due to it requiring authentication. Issues in other servers will be skipped without the task failing.
+Note: This task currently only supports issues in redhat.atlassian.net and issues.redhat.com due to them requiring authentication. Issues in other servers will be skipped without the task failing.
 
 ## Parameters
 

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -11,8 +11,8 @@ spec:
     Tekton task to close all issues referenced in the releaseNotes. It is meant to run after the advisory is published.
     A comment will be added to each closed issue with a link to the advisory it was fixed in.
 
-    Note: This task currently only supports issues in issues.redhat.com due to it requiring authentication.
-    Issues in other servers will be skipped without the task failing.
+    Note: This task currently only supports issues in redhat.atlassian.net and issues.redhat.com due to them requiring
+    authentication. Issues in other servers will be skipped without the task failing.
   params:
     - name: dataPath
       description: Path to the JSON string of the merged data to use in the data workspace
@@ -99,6 +99,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -121,9 +122,10 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 100m
         requests:
           memory: 32Mi
-          cpu: 50m
+          cpu: 100m
       volumeMounts:
         - name: access-token-secret-vol
           mountPath: "/etc/secrets"
@@ -133,13 +135,15 @@ spec:
         set -eu
 
         ACCESS_TOKEN="$(cat /etc/secrets/token)"
+        EMAIL="$(cat /etc/secrets/email)"
 
         ISSUE_TRACKERS='{
             "Jira": {
                 "api": "rest/api/2/issue",
                 "servers": [
                     "issues.redhat.com",
-                    "jira.atlassian.com"
+                    "jira.atlassian.com",
+                    "redhat.atlassian.net"
                 ]
             },
             "bugzilla": {
@@ -160,19 +164,19 @@ spec:
         for ((i = 0; i < NUM_ISSUES; i++)); do
             issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
             server=$(jq -r '.source' <<< "$issue")
-            if [ "$server" != "issues.redhat.com" ] ; then
+            if [ "$server" = "issues.redhat.com" ] ; then
+                server=redhat.atlassian.net
+            fi
+            if [ "$server" != "redhat.atlassian.net" ] ; then
                 echo "This task currently only supports closing issues on issues.redhat.com"
-                echo "Skipping issue $issue as it is on $server"
+                echo "and redhat.atlassian.net. Skipping issue $issue as it is on $server"
                 continue
             fi
 
-            CURL_ARGS=(
-              -H "Authorization: Bearer $ACCESS_TOKEN"
-              --retry 3
-            )
+            CURL_ARGS=(-u "${EMAIL}:${ACCESS_TOKEN}")
 
             API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$ISSUE_TRACKERS")
-            API_URL="https://$(jq -r '.source' <<< "$issue")/${API}/$(jq -r '.id' <<< "$issue")"
+            API_URL="https://${server}/${API}/$(jq -r '.id' <<< "$issue")"
 
             if [ "$(curl-with-retry "${CURL_ARGS[@]}" "${API_URL}" | jq -r '.fields.status.name')" == "Closed" ] ; then
                 echo "Issue $issue is already in Closed state. Skipping it."
@@ -209,6 +213,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/close-advisory-issues/tests/mocks.sh
+++ b/tasks/managed/close-advisory-issues/tests/mocks.sh
@@ -6,28 +6,28 @@ function curl-with-retry() {
   echo Mock curl called with: $* >&2
   echo $* >> "$(params.dataDir)/mock_curl.txt"
 
-  if [[ "$*" == *"Content-Type"*"https://issues.redhat.com/rest/api/2/issue/ISSUE-123/transitions" ]]
+  if [[ "$*" == *"-u team@domain.com:abcdefg"*"Content-Type"*"https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123/transitions" ]]
   then
     :
-  elif [[ "$*" == *"Content-Type"*"https://issues.redhat.com/rest/api/2/issue/FAIL-999/transitions" ]]
+  elif [[ "$*" == *"-u team@domain.com:abcdefg"*"Content-Type"*"https://redhat.atlassian.net/rest/api/2/issue/FAIL-999/transitions" ]]
   then
     return 1
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/FAIL-999/transitions" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/FAIL-999/transitions" ]]
   then
     echo '{"transitions":[{"id":"91","name":"Closed","description":""},{"id":"11","name":"New"}]}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/ISSUE-123/transitions" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/ISSUE-123/transitions" ]]
   then
     echo '{"transitions":[{"id":"91","name":"Closed","description":""},{"id":"11","name":"New"}]}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/NOCLOSE-555/transitions" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/NOCLOSE-555/transitions" ]]
   then
     echo '{"expand":"transitions","transitions":[]}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/CLOSED-987" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/CLOSED-987" ]]
   then
     echo '{"fields":{"status":{"name":"Closed","id":"99"}}}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/FAIL-999/comment" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/FAIL-999/comment" ]]
   then
     echo '{}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/NOCLOSE-555/comment" ]]
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/NOCLOSE-555/comment" ]]
   then
     echo '{}'
   else

--- a/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/close-advisory-issues/tests/pre-apply-task-hook.sh
@@ -7,4 +7,4 @@ yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-close-issue.yaml
@@ -63,7 +63,7 @@ spec:
                     "fixed": [
                       {
                         "id": "FAIL-999",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-cannot-get-transitions.yaml
@@ -64,7 +64,7 @@ spec:
                     "fixed": [
                       {
                         "id": "NOCLOSE-555",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-jira-conversion.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues-jira-conversion.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-close-advisory-issues-closed-issue
+  name: test-close-advisory-issues-jira-conversion
 spec:
   description: |
-    Test for close-advisory-issues where the issue is already closed. Curl should only be
-    called once for the issue
+    Test for close-advisory-issues where an issues.redhat.com issue is converted to
+    redhat.atlassian.net as this is the new server.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -61,12 +61,8 @@ spec:
                   "issues": {
                     "fixed": [
                       {
-                        "id": "CLOSED-987",
-                        "source": "redhat.atlassian.net"
-                      },
-                      {
-                        "id": "12345",
-                        "source": "bugzilla.redhat.com"
+                        "id": "ISSUE-123",
+                        "source": "issues.redhat.com"
                       }
                     ]
                   }
@@ -148,12 +144,11 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                  echo Error: curl was expected to be called 1 time. Actual calls:
+      
+              if grep -q "issues.redhat.com" "$(params.dataDir)/mock_curl.txt" ; then
+                  echo Error: issues.redhat.com should not be queried. Calls:
                   cat "$(params.dataDir)/mock_curl.txt"
                   exit 1
               fi
-
-              [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"CLOSED-987" ]]
       runAfter:
         - run-task

--- a/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/tests/test-close-advisory-issues.yaml
@@ -60,7 +60,7 @@ spec:
                     "fixed": [
                       {
                         "id": "ISSUE-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/embargo-check/README.md
+++ b/tasks/managed/embargo-check/README.md
@@ -1,7 +1,7 @@
 # embargo-check
 
 Tekton task to check if any issues or CVEs in the releaseNotes key of the data.json are embargoed. It checks the issues by server using curl and checks the CVEs via an InternalRequest. If any issue does not exist or any CVE is embargoed, the task will fail. The task will also fail if a Jira issue listed is for a component that does not exist in the releaseNotes.content.[images|artifacts] section or if said component does not list the CVE from the issue.
-Finally, the task will inject the `public` key to each issue listed for `issues.redhat.com`. This is a boolean value that is set based on the issues visibility.
+Finally, the task will inject the `public` key to each issue listed for `redhat.atlassian.net`. This is a boolean value that is set based on the issues visibility.
 
 ## Parameters
 

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -15,7 +15,7 @@ spec:
     for a component that does not exist in the releaseNotes.content.[images|artifacts] section
     or if said component does not list the CVE from the issue.
 
-    Finally, the task will inject the `public` key to each issue listed for `issues.redhat.com`.
+    Finally, the task will inject the `public` key to each issue listed for `redhat.atlassian.net`.
     This is a boolean value that is set based on the issues visibility.
   params:
     - name: dataPath
@@ -107,6 +107,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -129,6 +130,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 50m
         requests:
           memory: 64Mi
           cpu: 50m
@@ -139,6 +141,7 @@ spec:
         #!/usr/bin/env bash
 
         ACCESS_TOKEN="$(cat /etc/secrets/token)"
+        EMAIL="$(cat /etc/secrets/email)"
 
         set -x
 
@@ -147,7 +150,8 @@ spec:
                 "api": "rest/api/2/issue",
                 "servers": [
                     "issues.redhat.com",
-                    "jira.atlassian.com"
+                    "jira.atlassian.com",
+                    "redhat.atlassian.net"
                 ]
             },
             "bugzilla": {
@@ -165,8 +169,9 @@ spec:
         fi
 
         # It is expected for the custom field ids to remain stable, but to get them, you can do:
-        # curl -H "Authorization: Bearer $ACCESS_TOKEN" https://issues.redhat.com/rest/api/2/field
-        CVE_FIELD="customfield_12324749"
+        # curl -u "$email:$token" https://redhat.atlassian.net/rest/api/2/field and look for one with
+        # name "CVE ID"
+        CVE_FIELD="customfield_10667"
 
         RC=0
 
@@ -174,12 +179,15 @@ spec:
         for ((i = 0; i < NUM_ISSUES; i++)); do
             issue=$(jq -c --argjson i "$i" '.releaseNotes.issues.fixed[$i]' "${DATA_FILE}")
             server=$(jq -r '.source' <<< "$issue")
+            if [ "$server" = "issues.redhat.com" ] ; then
+                server=redhat.atlassian.net
+            fi
             API=$(jq -r '.[] | select(.servers[] | contains("'"$server"'")) | .api' <<< "$SUPPORTED_ISSUE_TRACKERS")
-            API_URL="https://$(jq -r '.source' <<< "$issue")/${API}/$(jq -r '.id' <<< "$issue")"
+            API_URL="https://${server}/${API}/$(jq -r '.id' <<< "$issue")"
             AUTH_ARGS=()
             set +x # We don't want to leak the ACCESS_TOKEN
-            if [ "$server" = "issues.redhat.com" ] ; then
-                AUTH_ARGS=(-H "Authorization: Bearer $ACCESS_TOKEN")
+            if [ "$server" = "redhat.atlassian.net" ] ; then
+                AUTH_ARGS=(-u "${EMAIL}:${ACCESS_TOKEN}")
             fi
             OUTPUT=$(curl-with-retry --retry 3 "${AUTH_ARGS[@]}" "${API_URL}")
             CURL_RC=$?
@@ -191,11 +199,13 @@ spec:
                 continue
             fi
 
-            # Public should be true if and only if the security field doesn't exist and the issue is accessible
-            # without authentication
+            # Public should be true if and only if the security field is null/missing and the issue is accessible
+            # without authentication. On Atlassian Cloud, the security field exists but is null for public issues.
+            # Also handle case where OUTPUT is empty (jq returns empty string).
             public=false
+            SECURITY_VALUE=$(jq '.fields.security' <<< "$OUTPUT")
 
-            if ! "$(jq '.fields | has("security")' <<< "$OUTPUT")" ; then
+            if [ -z "$SECURITY_VALUE" ] || [ "$SECURITY_VALUE" = "null" ]  ; then
                 echo "Checking if the issue is public - if not, curl will fail with error 401"
                 if curl-with-retry --retry 3 "${API_URL}" > /dev/null; then
                     public=true
@@ -206,8 +216,8 @@ spec:
             jq --argjson i "$i" --argjson public $public '.releaseNotes.issues.fixed[$i].public = $public' \
                 "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
 
-            # Perform additional checks only for issues on issues.redhat.com
-            if [ "$server" != "issues.redhat.com" ] ; then
+            # Perform additional checks only for issues on redhat.atlassian.net
+            if [ "$server" != "redhat.atlassian.net" ] ; then
                 continue
             fi
 
@@ -252,6 +262,7 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
+          cpu: 100m
         requests:
           memory: 512Mi
           cpu: 100m
@@ -317,6 +328,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -13,29 +13,37 @@ function curl-with-retry() {
   elif [[ "$*" == "--retry 3 https://bugzilla.redhat.com/rest/bug/12345" ]]
   then
     :
+  elif [[ "$*" == "--retry 3 https://issues.redhat.com/"* ]]
+  then
+    echo "No calls should be made to issues.redhat.com anymore"
+    echo "The server value should've been translated to redhat.atlassian.net"
+    exit 1
   elif [[ "$*" == "--retry 3 https://jira.atlassian.com/rest/api/2/issue/EMBARGOED-987" ]]
   then
     exit 1
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/MISSINGRH-123" ]]
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/MISSINGRH-123" ]]
   then
     exit 1
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/FEATURE-123" ]] # Not a Vulnerability
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/FEATURE-123" ]] # Not a Vulnerability
   then
     echo '{"fields":{"issuetype":{"name":"Feature"},"security":"a"}}'
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/VULN-123" ]] # Vulnerability
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/VULN-123" ]] # Vulnerability
   then
-    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_12324749":"CVE-123","customfield_12324752":"my-component","security":"a"}}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PUBLIC-1" ]] # Public: no security field, works without auth
+    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_10667":"CVE-123","customfield_12324752":"my-component","security":"a"}}'
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PUBLIC-1" ]] # Public: no security field, works without auth
   then
     echo '{"fields":{"foo":"bar"}}'
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PRIVATE-1" ]] # Private: no security field, works with auth but not without
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PUBLIC-SECNULL" ]] # Public: security field exists but is null (Atlassian Cloud behavior)
   then
-    if [[ "$*" == *"Authorization: Bearer"* ]] ; then
+    echo '{"fields":{"security":null}}'
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PRIVATE-1" ]] # Private: no security field, works with auth but not without
+  then
+    if [[ "$*" == *"-u "* ]] ; then
       :
     else
       return 1
     fi
-  elif [[ "$*" == *"https://issues.redhat.com/rest/api/2/issue/PRIVATE-2" ]] # Private: has security field
+  elif [[ "$*" == *"https://redhat.atlassian.net/rest/api/2/issue/PRIVATE-2" ]] # Private: has security field
   then
     echo '{"fields":{"security":"bar"}}'
   else

--- a/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/embargo-check/tests/pre-apply-task-hook.sh
@@ -8,4 +8,4 @@ yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/embargo-check/tests/test-embargo-check-jira-conversion.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-jira-conversion.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-close-advisory-issues-closed-issue
+  name: test-embargo-check-jira-conversion
 spec:
   description: |
-    Test for close-advisory-issues where the issue is already closed. Curl should only be
-    called once for the issue
+    Test for embargo-check that ensures issues provided as issues.redhat.com use
+    the redhat.atlassian.net endpoints instead
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -51,7 +51,7 @@ spec:
           - name: setup-values
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
@@ -61,12 +61,29 @@ spec:
                   "issues": {
                     "fixed": [
                       {
-                        "id": "CLOSED-987",
-                        "source": "redhat.atlassian.net"
+                        "id": "VULN-123",
+                        "source": "issues.redhat.com"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "images": [
+                      {
+                        "component": "my-other-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/other-repo"
                       },
                       {
-                        "id": "12345",
-                        "source": "bugzilla.redhat.com"
+                        "component": "my-component",
+                        "architecture": "x86_64",
+                        "containerImage": "registry.io/org/repo",
+                        "cves": {
+                          "fixed": {
+                            "CVE-123": {
+                              "packages": []
+                            }
+                          }
+                        }
                       }
                     ]
                   }
@@ -85,12 +102,12 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: close-advisory-issues
+        name: embargo-check
       params:
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
-        - name: advisoryUrl
-          value: https://access.redhat.com/errata/RHBA-2025:1111
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -110,7 +127,7 @@ spec:
     - name: check-result
       params:
         - name: sourceDataArtifact
-          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+          value: "$(tasks.run-task.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
       taskSpec:
@@ -148,12 +165,10 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                  echo Error: curl was expected to be called 1 time. Actual calls:
+              if grep -q "issues.redhat.com" "$(params.dataDir)/mock_curl.txt" ; then
+                  echo Error: issues.redhat.com should not be queried. Calls:
                   cat "$(params.dataDir)/mock_curl.txt"
                   exit 1
               fi
-
-              [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"CLOSED-987" ]]
       runAfter:
         - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: test-embargo-check-non-vuln-rh-issue
 spec:
-  description: Test for embargo-check with a issues.redhat.com issue that is not of type Vulnerability
+  description: Test for embargo-check with a redhat.atlassian.net issue that is not of type Vulnerability
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -64,7 +64,7 @@ spec:
                       },
                       {
                         "id": "FEATURE-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       }
                     ]
                   }

--- a/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     test/assert-task-failure: "run-task"
 spec:
-  description: Test for embargo-check where a issues.redhat.com issue cannot be found
+  description: Test for embargo-check where a redhat.atlassian.net issue cannot be found
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -62,7 +62,7 @@ spec:
                     "fixed": [
                       {
                         "id": "MISSINGRH-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -5,10 +5,11 @@ metadata:
   name: test-embargo-check-rh-issue-public-key-added
 spec:
   description: |
-    Test for embargo-check with 4 issues. Two are private and should have the key added with
-    false (one because it has a security field, one because it can only be seen with
-    authenticated curl). The other two are public because they can be seen without authentication.
-    One is a jira issue and one is a bugzilla bug. Ensure the public keys are all properly added.
+    Test for embargo-check with 5 issues. Two are private and should have the key added with
+    false (one because it has a security field with a value, one because it can only be seen with
+    authenticated curl). The other three are public: one has no security field, one has security
+    field with null value (Atlassian Cloud behavior), and one is a bugzilla bug.
+    Ensure the public keys are all properly added.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -64,15 +65,19 @@ spec:
                     "fixed": [
                       {
                         "id": "PUBLIC-1",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
+                      },
+                      {
+                        "id": "PUBLIC-SECNULL",
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "PRIVATE-1",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "PRIVATE-2",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",
@@ -175,6 +180,9 @@ spec:
               set -eux
 
               test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PUBLIC-1") | .public' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == true
+
+              test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PUBLIC-SECNULL") | .public' \
                 "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == true
 
               test "$(jq -r '.releaseNotes.issues.fixed[] | select(.id=="PRIVATE-1") | .public' \

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-embargo-check-rh-issue-artifact
 spec:
   description: |
-    Test for embargo-check where a issues.redhat.com issue lists CVE-123 as a CVE and that
+    Test for embargo-check where a redhat.atlassian.net issue lists CVE-123 as a CVE and that
     CVE is listed in one component of releaseNotes.content.artifacts.
   params:
     - name: ociStorage
@@ -62,7 +62,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -7,7 +7,7 @@ metadata:
     test/assert-task-failure: "run-task"
 spec:
   description: |
-    Test for embargo-check where a issues.redhat.com issue lists CVE-123 as a CVE, but the images
+    Test for embargo-check where a redhat.atlassian.net issue lists CVE-123 as a CVE, but the images
     section does not list CVE-123 for any component. The task should fail.
   params:
     - name: ociStorage
@@ -64,7 +64,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -5,7 +5,7 @@ metadata:
   name: test-embargo-check-rh-issue
 spec:
   description: |
-    Test for embargo-check where a issues.redhat.com issue lists CVE-123 as a CVE and that
+    Test for embargo-check where a redhat.atlassian.net issue lists CVE-123 as a CVE and that
     CVE is listed in one component of releaseNotes.content.images.
   params:
     - name: ociStorage
@@ -62,7 +62,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "12345",

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -113,6 +113,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -135,6 +136,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -145,6 +147,7 @@ spec:
         #!/usr/bin/env bash
         set -e
         ACCESS_TOKEN="$(cat /etc/secrets/token)"
+        EMAIL="$(cat /etc/secrets/email)"
 
         set -x
 
@@ -166,7 +169,7 @@ spec:
             RELEASE_CVES["$cve"]=1
         done
 
-        CVE_FIELD="customfield_12324749"
+        CVE_FIELD="customfield_10667"
         RC=0
 
         NUM_ISSUES=$(jq -cr '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
@@ -175,8 +178,13 @@ spec:
             server=$(jq -r '.source' <<< "$issue")
             issue_id=$(jq -r '.id' <<< "$issue")
 
-            # Currently only handle issues.redhat.com
-            if [ "$server" != "issues.redhat.com" ] ; then
+            if [ "$server" = "issues.redhat.com" ] ; then
+                echo "Using redhat.atlassian.net endpoints for issues.redhat.com issue"
+                server=redhat.atlassian.net
+            fi
+
+            # Currently only handle redhat.atlassian.net
+            if [ "$server" != "redhat.atlassian.net" ] ; then
                 echo "Skipping non-JIRA issue: $issue_id from $server"
                 continue
             fi
@@ -184,7 +192,7 @@ spec:
             API_URL="https://${server}/rest/api/2/issue/${issue_id}"
 
             set +x # Don't leak the ACCESS_TOKEN
-            OUTPUT=$(curl-with-retry --retry 3 -H "Authorization: Bearer $ACCESS_TOKEN" "${API_URL}" 2>/dev/null)
+            OUTPUT=$(curl-with-retry --retry 3 -u "${EMAIL}:$ACCESS_TOKEN" "${API_URL}" 2>/dev/null)
             CURL_RC=$?
             set -x
 
@@ -225,6 +233,7 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
+          cpu: '1'
         requests:
           memory: 64Mi
           cpu: '1'
@@ -267,6 +276,7 @@ spec:
         do
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
             name=$(jq -r '.name' <<< "$component")
+            canonical_name=$(jq -r '.canonicalName // empty' <<< "$component")
             image=$(jq -r '.containerImage' <<< "$component")
             if ! [[ "$image" =~ ^[^:]+@sha256:[0-9a-f]+$ ]] ; then
                 echo "Failed to extract sha256 tag from ${image}. Exiting with failure"
@@ -317,8 +327,16 @@ spec:
                     arch=$(jq -r .platform.architecture <<< "${arch_json}")
                     digest=$(jq -r .digest <<< "${arch_json}")
                     containerImage="${deliveryRepo}@${digest}"
+
+                    # Determine the name part of the PURL
+                    # If canonicalName is present, use it. Otherwise fallback to the last segment of the deliveryRepo
+                    purl_path="${deliveryRepo##*/}"
+                    if [[ -n "$canonical_name" ]]; then
+                        purl_path="${canonical_name}"
+                    fi
+
                     # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo
-                    purl="pkg:oci/${deliveryRepo##*/}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
+                    purl="pkg:oci/${purl_path}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
 
                     uniqueTag=""
 
@@ -368,6 +386,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -396,24 +415,23 @@ spec:
             exit 1
         fi
 
-        # generate_purl_rpm name version release arch sha256 repository_id [vendor]
+        # generate_purl_rpm name version release arch distro repository_id [vendor]
         # Example:
-        #   generate_purl_rpm "zlib-devel" "1.2.11" "40.el9" "x86_64" \
-        #     "9775022716a2b6dd51d151a40aa4a6bcb466edeb01b747f48072703e509be097" \
+        #   generate_purl_rpm "zlib-devel" "1.2.11" "40.el9" "x86_64" "rhel"\
         #     "ubi-9-for-x86_64-appstream-rpms" "redhat"
         generate_purl_rpm() {
           local name="$1"
           local version="$2"
           local release="$3"
           local arch="$4"
-          local sha256="$5"
+          local distro="$5"
           local repository_id="$6"
           local vendor="${7:-redhat}"
 
           # Assemble purl:
-          # pkg:rpm/<vendor>/<name>@<version>-<release>?arch=<arch>&checksum=sha256:<sha256>&repository_id=<repo>
-          printf 'pkg:rpm/%s/%s@%s-%s?arch=%s&checksum=sha256:%s&repository_id=%s\n' \
-            "$vendor" "$name" "$version" "$release" "$arch" "$sha256" "$repository_id"
+          # pkg:rpm/<vendor>/<name>@<version>-<release>?arch=<arch>&distro=<distro>&repository_id=<repo>
+          printf 'pkg:rpm/%s/%s@%s-%s?arch=%s&distro=%s&repository_id=%s\n' \
+            "$vendor" "$name" "$version" "$release" "$arch" "$distro" "$repository_id"
         }
 
         append_artifact_entry() {
@@ -541,8 +559,6 @@ spec:
                 exit 1
               fi
 
-              pulp_domain="$(jq -r '.pulp.domain // ""' "${DATA_FILE}")"
-
               RPM_FILES_LENGTH=$(jq --arg name "$name" \
                 '[.components[]? | select(.name == $name) | .rpmsToPublish[]?] | length' "${SNAPSHOT_FILE}")
               for ((k = 0; k < RPM_FILES_LENGTH; k++)); do
@@ -552,28 +568,29 @@ spec:
                 arch=$(jq -r '.arch' <<< "$rpmfile")
                 version=$(jq -r '.version' <<< "$rpmfile")
                 release=$(jq -r '.release' <<< "$rpmfile")
-                sha256=$(jq -r '.sha256' <<< "$rpmfile")
+                distro=$(jq -r '.distro' <<< "$rpmfile")
 
                 # Expand per-target repo to keep repository_id accurate (noarch may target multiple repos).
+                # targetRepos is an array of objects: [{repository_id, repository_name, distro}, ...]
                 TARGET_REPOS_LEN=$(jq '.targetRepos | length' <<< "$rpmfile")
                 if [ "${TARGET_REPOS_LEN}" -eq 0 ]; then
                   # If no targetRepos is present, fall back to a best-effort purl without repository_id.
-                  purl=$(generate_purl_rpm "$rpm_name" "$version" "$release" "$arch" "$sha256" "")
+                  purl=$(generate_purl_rpm "$rpm_name" "$version" "$release" "$arch" "$distro" "")
                   echo "purl: $purl"
                   append_artifact_entry "$name" "$arch" "$os" "$purl"
                 else
                   for ((r = 0; r < TARGET_REPOS_LEN; r++)); do
-                    repo=$(jq -r --argjson r "$r" '.targetRepos[$r]' <<< "$rpmfile")
-                    pulprepo="${repo}"
-                    if [ -n "${pulp_domain}" ]; then
-                      pulprepo="${pulp_domain}/${repo}"
-                    fi
+                    repo_obj=$(jq -c --argjson r "$r" '.targetRepos[$r]' <<< "$rpmfile")
+                    repo_id=$(jq -r '.repository_id' <<< "$repo_obj")
+                    repo_name=$(jq -r '.repository_name' <<< "$repo_obj")
+                    repo_distro=$(jq -r '.distro // empty' <<< "$repo_obj")
                     arch_for_entry="${arch}"
-                    if [ "${repo}" = "source" ]; then
+                    if [ "${repo_name}" = "source" ]; then
                       arch_for_entry="source"
                     fi
+                    # Use repo_id directly for PURL repository_id (no domain prefix)
                     purl=$(generate_purl_rpm \
-                      "$rpm_name" "$version" "$release" "$arch_for_entry" "$sha256" "$pulprepo")
+                      "$rpm_name" "$version" "$release" "$arch_for_entry" "$repo_distro" "$repo_id")
                     echo "purl: $purl"
                     append_artifact_entry "$name" "$arch_for_entry" "$os" "$purl"
                   done
@@ -587,6 +604,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -676,7 +694,13 @@ spec:
             # Ignore manifest files
             [[ "$filename" == *_manifest.json ]] && continue
             checksum="${CHECKSUM_MAP[$filename]}"
-            download_url="https://github.com/$owner_repo/releases/download/$GITHUB_RELEASE_VERSION/$filename"
+            # GitHub release tags typically use 'v' prefix (e.g., v1.7.2), but the version
+            # extracted from filenames may not include it. Ensure the download URL uses the tag format.
+            github_tag="$GITHUB_RELEASE_VERSION"
+            if [[ ! "$github_tag" =~ ^v ]]; then
+                github_tag="v$GITHUB_RELEASE_VERSION"
+            fi
+            download_url="https://github.com/$owner_repo/releases/download/$github_tag/$filename"
             purl="pkg:generic/$name@$GITHUB_RELEASE_VERSION?checksum=$checksum&download_url=$download_url"
             jsonString=$(jq -cn \
                 --arg component "$name" \
@@ -695,6 +719,7 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
+          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -747,6 +772,7 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
+          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/populate-release-notes/tests/mocks.sh
+++ b/tasks/managed/populate-release-notes/tests/mocks.sh
@@ -14,15 +14,15 @@ function curl-with-retry() {
   mkdir -p "$(params.dataDir)"
   echo $* >> "$(params.dataDir)/mock_curl.txt"
 
-  if [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/VULN-123" ]]; then
+  if [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/VULN-123" ]]; then
     # Mock a vulnerability issue with CVE-123
-    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_12324749":"CVE-123"}}'
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/FEATURE-456" ]]; then
+    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_10667":"CVE-123"}}'
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/FEATURE-456" ]]; then
     # Mock a non-vulnerability issue
     echo '{"fields":{"issuetype":{"name":"Feature"}}}'
-  elif [[ "$*" == *"Authorization: Bearer"*"https://issues.redhat.com/rest/api/2/issue/VULN-MISSING-456" ]]; then
+  elif [[ "$*" == *"-u "*"https://redhat.atlassian.net/rest/api/2/issue/VULN-MISSING-456" ]]; then
     # Mock a vulnerability issue with CVE that should be missing from content
-    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_12324749":"CVE-MISSING-456"}}'
+    echo '{"fields":{"issuetype":{"name":"Vulnerability"},"customfield_10667":"CVE-MISSING-456"}}'
   else
     echo Error: Unexpected curl call: $*
     exit 1

--- a/tasks/managed/populate-release-notes/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/populate-release-notes/tests/pre-apply-task-hook.sh
@@ -9,4 +9,4 @@ yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Create a dummy access token secret (and delete it first if it exists)
 kubectl delete secret konflux-advisory-jira-secret --ignore-not-found
-kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg
+kubectl create secret generic konflux-advisory-jira-secret --from-literal=token=abcdefg --from-literal=email=team@domain.com

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-server-converted.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-server-converted.yaml
@@ -2,11 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-close-advisory-issues-closed-issue
+  name: test-populate-release-notes-cve-server-converted
 spec:
   description: |
-    Test for close-advisory-issues where the issue is already closed. Curl should only be
-    called once for the issue
+    Run the populate-release-notes task with CVE from issues.redhat.com
+    Tests that redhat.atlassian.net is queried for the issue details instead of
+    issues.redhat.com
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -48,7 +49,7 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: setup-values
+          - name: setup
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env sh
@@ -58,19 +59,64 @@ spec:
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
                 "releaseNotes": {
+                  "product_id": [
+                    123
+                  ],
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHSA",
                   "issues": {
                     "fixed": [
                       {
-                        "id": "CLOSED-987",
+                        "id": "VULN-123",
                         "source": "redhat.atlassian.net"
-                      },
+                      }
+                    ]
+                  },
+                  "cves": [
+                    {
+                      "key": "CVE-123",
+                      "component": "comp",
+                      "packages": [
+                        "pkg1",
+                        "pkg2"
+                      ],
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    }
+                  ],
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://docs.example.com/some/example/release-notes"
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repositories": [
                       {
-                        "id": "12345",
-                        "source": "bugzilla.redhat.com"
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
                       }
                     ]
                   }
-                }
+                ]
               }
               EOF
           - name: create-trusted-artifact
@@ -85,12 +131,12 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: close-advisory-issues
+        name: populate-release-notes
       params:
         - name: dataPath
-          value: $(context.pipelineRun.uid)/data.json
-        - name: advisoryUrl
-          value: https://access.redhat.com/errata/RHBA-2025:1111
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -154,6 +200,10 @@ spec:
                   exit 1
               fi
 
-              [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"CLOSED-987" ]]
+              if grep -q "issues.redhat.com" "$(params.dataDir)/mock_curl.txt" ; then
+                  echo Error: issues.redhat.com should not be queried. Calls:
+                  cat "$(params.dataDir)/mock_curl.txt"
+                  exit 1
+              fi
       runAfter:
         - run-task

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail-empty-cves.yaml
@@ -72,7 +72,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       }
                     ]
                   },

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-fail.yaml
@@ -71,7 +71,7 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-MISSING-456",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       }
                     ]
                   },

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
@@ -69,11 +69,11 @@ spec:
                     "fixed": [
                       {
                         "id": "VULN-123",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "FEATURE-456",
-                        "source": "issues.redhat.com"
+                        "source": "redhat.atlassian.net"
                       },
                       {
                         "id": "BZ-789",

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cves-github.yaml
@@ -203,9 +203,9 @@ spec:
         - name: taskGitRevision
           value: "main"
         - name: github_release_version
-          value: "v1.0.0"
+          value: "1.0.0"
         - name: github_release_url
-          value: "https://github.com/some-org/some-repo/releases/tag/v1.0.0"
+          value: "https://github.com/some-org/some-repo"
         - name: binaries_dir
           value: "$(context.pipelineRun.uid)/releases"
       runAfter:
@@ -263,5 +263,15 @@ spec:
                 "$DATA_FILE")" == "CVE-123CVE-456"
               test "$(jq '.releaseNotes.content.artifacts[0].cves.fixed."CVE-123".packages | length' \
                 "$DATA_FILE")" == 2
+
+              # Verify the PURL download_url has 'v' prefix in the tag (even though github_release_version was "1.0.0")
+              # The download URL should be: https://github.com/some-org/some-repo/releases/download/v1.0.0/<filename>
+              PURL=$(jq -r '.releaseNotes.content.artifacts[0].purl' "$DATA_FILE")
+              echo "PURL: $PURL"
+              # Check that download_url contains /download/v1.0.0/ (with the v prefix)
+              [[ "$PURL" == *"download/v1.0.0/"* ]] || { echo "ERROR: download_url missing 'v' prefix"; exit 1; }
+              # Check that the version in the PURL itself is still 1.0.0 (without v prefix)
+              [[ "$PURL" == "pkg:generic/releng-test-product-binaries@1.0.0?"* ]] \
+                || { echo "ERROR: PURL version should be 1.0.0"; exit 1; }
       runAfter:
         - run-task

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rpms.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rpms.yaml
@@ -58,6 +58,20 @@ spec:
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
                 "mapping": {
+                  "rpm-repositories": [
+                    {
+                      "name": "hbird-x86_64",
+                      "arch": "x86_64",
+                      "distro": "hummingbird",
+                      "repository_id": "hbird-x86_64"
+                    },
+                    {
+                      "name": "hbird-source",
+                      "arch": "source",
+                      "distro": "hummingbird",
+                      "repository_id": "hbird-source"
+                    }
+                  ],
                   "components": [
                       {
                         "name": "hello--main",
@@ -107,8 +121,10 @@ spec:
                         "epoch": "0",
                         "version": "1.0",
                         "release": "1.fc38",
-                        "sha256": "1234567890",
-                        "targetRepos": ["hbird-x86_64"]
+                        "targetRepos": [
+                          {"repository_id": "hbird-x86_64-id", "repository_name": "x86_64",
+                           "distro": "hummingbird"}
+                        ]
                       },
                       {
                         "rpm": "hello-1.0-1.fc38.src.rpm",
@@ -117,8 +133,10 @@ spec:
                         "epoch": "0",
                         "version": "1.0",
                         "release": "1.fc38",
-                        "sha256": "0987654321",
-                        "targetRepos": ["hbird-source"]
+                        "targetRepos": [
+                          {"repository_id": "hbird-source-id", "repository_name": "source",
+                           "distro": "hummingbird"}
+                        ]
                       }
                     ]
                   }
@@ -214,8 +232,9 @@ spec:
               fi
 
               # Verify that the PURL is correct for the first artifact
+              # pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25
               PURL=$(jq -r '.releaseNotes.content.artifacts[0].purl' "$DATA_FILE")
-              EXPECTED_PURL="pkg:rpm/redhat/hello@1.0-1.fc38?arch=x86_64&checksum=sha256:1234567890&repository_id=hbird-x86_64"
+              EXPECTED_PURL="pkg:rpm/redhat/hello@1.0-1.fc38?arch=x86_64&distro=hummingbird&repository_id=hbird-x86_64-id"
 
               if [ "$PURL" != "$EXPECTED_PURL" ]; then
                 echo "Error: Expected PURL '$EXPECTED_PURL', got '$PURL'"


### PR DESCRIPTION
This commit updates the embargo-check, close-advisory-issues, and populate-release-notes managed tasks to support the new red hat jira server.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
