### PR TITLE
fix(RELEASE-2349): remove duplicate fixed releaseNotes issues

### DIFF
--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -162,6 +162,17 @@ spec:
             exit 0
         fi
 
+        # Drop duplicate issue references (same source + id); keeps first occurrence.
+        DEDUP_TMP="$(mktemp)"
+        BEFORE_LEN=$(jq -r '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
+        jq '.releaseNotes.issues.fixed |= unique_by([.source, .id])' \
+            "${DATA_FILE}" > "${DEDUP_TMP}"
+        mv "${DEDUP_TMP}" "${DATA_FILE}"
+        AFTER_LEN=$(jq -r '.releaseNotes.issues.fixed | length' "${DATA_FILE}")
+        if [ "${BEFORE_LEN}" -gt "${AFTER_LEN}" ]; then
+            echo "Deduplicated releaseNotes.issues.fixed: ${BEFORE_LEN} -> ${AFTER_LEN} entries"
+        fi
+
         declare -A RELEASE_CVES
         NUM_CVES=$(jq '.releaseNotes.cves | length' "${DATA_FILE}")
         for ((i = 0; i < NUM_CVES; i++)); do

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cve-validation-pass.yaml
@@ -72,6 +72,10 @@ spec:
                         "source": "redhat.atlassian.net"
                       },
                       {
+                        "id": "VULN-123",
+                        "source": "redhat.atlassian.net"
+                      },
+                      {
                         "id": "FEATURE-456",
                         "source": "redhat.atlassian.net"
                       },
@@ -207,8 +211,12 @@ spec:
                   exit 1
               fi
 
-              [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"VULN-123"* ]]
-              [[ $(tail -n 1 "$(params.dataDir)/mock_curl.txt") == *"FEATURE-456"* ]]
+              [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"FEATURE-456"* ]]
+              [[ $(tail -n 1 "$(params.dataDir)/mock_curl.txt") == *"VULN-123"* ]]
+
+              # Duplicate VULN-123 in issues.fixed should be removed before validation
+              test "$(jq '.releaseNotes.issues.fixed | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")" == 3
 
               # The CVEs should be present in the comp image section
               test "$(jq '.releaseNotes.content.images[0].cves.fixed | length' \


### PR DESCRIPTION
This commit updates the populate-release-notes task to remove duplicate issues. For example, if ISSUE-1 is listed twice in releaseNotes accidentally, it should be reduced down to one occurrence. It being there multiple times can cause issues with downstream consumers, and it is also just confusing.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
