### PR TITLE
chore: add cursor rule for generating task and pipeline READMEs

### DIFF
--- a/.cursor/rules/readme-from-yaml.mdc
+++ b/.cursor/rules/readme-from-yaml.mdc
@@ -1,0 +1,24 @@
+---
+description: READMEs for tasks and pipelines are generated from YAML; do not edit them by hand.
+globs: "pipelines/**/README.md,tasks/**/README.md"
+alwaysApply: false
+---
+
+# Task and pipeline README generation
+
+README.md files under `tasks/` and `pipelines/` are **generated** from the corresponding Tekton YAML. Do not edit them manually.
+
+To update a task or pipeline README:
+
+1. Edit the **YAML file** (e.g. `simple-signing-pipeline.yaml`): update `spec.description` and/or `spec.params[].description` (and `default` where applicable).
+2. Regenerate the README by running:
+   ```bash
+   ./.github/scripts/readme_generator.sh <directory>
+   ```
+   Example:
+   ```bash
+   ./.github/scripts/readme_generator.sh pipelines/internal/simple-signing-pipeline/
+   ./.github/scripts/readme_generator.sh tasks/managed/rh-sign-image/
+   ```
+
+CI runs `.github/scripts/check_readme.sh` to ensure README.md matches the generator output; manual edits will cause the check to fail.


### PR DESCRIPTION
## Describe your changes

I had cursor generate this last time I hit this issue, but I forgot to add it to my commit. So adding it now.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
