### PR TITLE
fix(RELEASE-2230): repository_url in purl

### DIFF
--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -343,8 +343,8 @@ spec:
                         purl_path="${canonical_name}"
                     fi
 
-                    # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo
-                    purl="pkg:oci/${purl_path}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo%/*}"
+                    # purl should be pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo/bar
+                    purl="pkg:oci/${purl_path}@${digest/:/%3A}?arch=${arch}&repository_url=${deliveryRepo}"
 
                     uniqueTag=""
 
@@ -363,9 +363,9 @@ spec:
                     fi
 
                     # for values derived from org.opencontainers.image.created, the purl will become
-                    # pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo&tag=1742843776
+                    # pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo/bar&tag=1742843776
                     # OR if the label is not present and a unique tag is found, purl will look like:
-                    # pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo&tag=0.1-12345678
+                    # pkg:oci/bar@sha256%3Aabcde?arch=amd64&repository_url=registry.redhat.io/foo/bar&tag=0.1-12345678
                     if [[ -n $uniqueTag ]] ; then
                         purl="${purl}&tag=${uniqueTag}"
                     fi

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-images.yaml
@@ -206,7 +206,7 @@ spec:
               test "$(jq -r '.architecture' <<< "$image1arch1")" == "amd64"
               test "$(jq -r '.containerImage' <<< "$image1arch1")" == "registry.redhat.io/product/repo@sha256:abcdefg"
               test "$(jq -r '.purl' <<< "$image1arch1")" == \
-                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product/repo&tag=9.4.0-1723436855"
               test "$(jq -r '.repository' <<< "$image1arch1")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$image1arch1")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
 
@@ -216,7 +216,7 @@ spec:
               test "$(jq -r '.architecture' <<< "$image1arch2")" == "s390x"
               test "$(jq -r '.containerImage' <<< "$image1arch2")" == "registry.redhat.io/product/repo@sha256:deadbeef"
               test "$(jq -r '.purl' <<< "$image1arch2")" == \
-               "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
+               "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product/repo&tag=9.4.0-1723436855"
               test "$(jq -r '.repository' <<< "$image1arch2")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$image1arch2")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
 
@@ -227,7 +227,7 @@ spec:
               test "$(jq -r '.containerImage' <<< "$image2arch1")" == \
                 "registry.stage.redhat.io/product2/repo2@sha256:abcdefg"
               test "$(jq -r '.purl' <<< "$image2arch1")" == \
-                "pkg:oci/repo2@sha256%3Aabcdefg?arch=amd64&repository_url=registry.stage.redhat.io/product2"
+                "pkg:oci/repo2@sha256%3Aabcdefg?arch=amd64&repository_url=registry.stage.redhat.io/product2/repo2"
               test "$(jq -r '.repository' <<< "$image2arch1")" == "registry.stage.redhat.io/product2/repo2"
               test "$(jq -rc '.tags' <<< "$image2arch1")" == '["foo","bar"]'
 
@@ -238,7 +238,7 @@ spec:
               test "$(jq -r '.containerImage' <<< "$image2arch2")" == \
                 "registry.stage.redhat.io/product2/repo2@sha256:deadbeef"
               test "$(jq -r '.purl' <<< "$image2arch2")" == \
-                "pkg:oci/repo2@sha256%3Adeadbeef?arch=s390x&repository_url=registry.stage.redhat.io/product2"
+                "pkg:oci/repo2@sha256%3Adeadbeef?arch=s390x&repository_url=registry.stage.redhat.io/product2/repo2"
               test "$(jq -r '.repository' <<< "$image2arch2")" == "registry.stage.redhat.io/product2/repo2"
               test "$(jq -rc '.tags' <<< "$image2arch2")" == '["foo","bar"]'
       runAfter:

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-repositories.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-multiple-repositories.yaml
@@ -201,7 +201,7 @@ spec:
               test "$(jq -r '.containerImage' <<< "$image1repo1arch1")" == \
                 "registry.redhat.io/product/repo@sha256:abcdefg"
               test "$(jq -r '.purl' <<< "$image1repo1arch1")" == \
-                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product/repo&tag=9.4.0-1723436855"
               test "$(jq -r '.repository' <<< "$image1repo1arch1")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$image1repo1arch1")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
 
@@ -212,7 +212,7 @@ spec:
               test "$(jq -r '.containerImage' <<< "$image1repo1arch2")" == \
                 "registry.redhat.io/product/repo@sha256:deadbeef"
               test "$(jq -r '.purl' <<< "$image1repo1arch2")" == \
-               "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product&tag=9.4.0-1723436855"
+               "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product/repo&tag=9.4.0-1723436855"
               test "$(jq -r '.repository' <<< "$image1repo1arch2")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$image1repo1arch2")" == '["9.4-1723436855","9.4.0-1723436855","foo","bar"]'
 
@@ -223,7 +223,7 @@ spec:
               test "$(jq -r '.containerImage' <<< "$image1repo2arch1")" == \
                 "registry.redhat.io/product/repo2@sha256:abcdefg"
               test "$(jq -r '.purl' <<< "$image1repo2arch1")" == \
-                "pkg:oci/repo2@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
+                "pkg:oci/repo2@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product/repo2"
               test "$(jq -r '.repository' <<< "$image1repo2arch1")" == "registry.redhat.io/product/repo2"
               test "$(jq -rc '.tags' <<< "$image1repo2arch1")" == '["foo","bar"]'
 
@@ -234,7 +234,7 @@ spec:
               test "$(jq -r '.containerImage' <<< "$image1repo2arch2")" == \
                 "registry.redhat.io/product/repo2@sha256:deadbeef"
               test "$(jq -r '.purl' <<< "$image1repo2arch2")" == \
-               "pkg:oci/repo2@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
+               "pkg:oci/repo2@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product/repo2"
               test "$(jq -r '.repository' <<< "$image1repo2arch2")" == "registry.redhat.io/product/repo2"
               test "$(jq -rc '.tags' <<< "$image1repo2arch2")" == '["foo","bar"]'
       runAfter:

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-single-image.yaml
@@ -189,7 +189,7 @@ spec:
               test "$(jq -r '.architecture' <<< "$imagearch1")" == "amd64"
               test "$(jq -r '.containerImage' <<< "$imagearch1")" == "registry.redhat.io/product/repo@sha256:abcdefg"
               test "$(jq -r '.purl' <<< "$imagearch1")" == \
-                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product/repo"
               test "$(jq -r '.repository' <<< "$imagearch1")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$imagearch1")" == '["foo","bar"]'
               test "$(jq -rc '.component' <<< "$imagearch1")" == "comp"
@@ -199,7 +199,7 @@ spec:
               test "$(jq -r '.architecture' <<< "$imagearch2")" == "s390x"
               test "$(jq -r '.containerImage' <<< "$imagearch2")" == "registry.redhat.io/product/repo@sha256:deadbeef"
               test "$(jq -r '.purl' <<< "$imagearch2")" == \
-                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product"
+                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product/repo"
               test "$(jq -r '.repository' <<< "$imagearch2")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$imagearch2")" == '["foo","bar"]'
               test "$(jq -rc '.component' <<< "$imagearch2")" == "comp"

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-unique-tag-from-label.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-unique-tag-from-label.yaml
@@ -197,7 +197,7 @@ spec:
               test "$(jq -r '.architecture' <<< "$imagearch1")" == "amd64"
               test "$(jq -r '.containerImage' <<< "$imagearch1")" == "registry.redhat.io/product/repo@sha256:abcdefg"
               test "$(jq -r '.purl' <<< "$imagearch1")" == \
-                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product&tag=1744596866"
+                "pkg:oci/repo@sha256%3Aabcdefg?arch=amd64&repository_url=registry.redhat.io/product/repo&tag=1744596866"
               test "$(jq -r '.repository' <<< "$imagearch1")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$imagearch1")" == '["foo","bar"]'
               test "$(jq -rc '.component' <<< "$imagearch1")" == "comp"
@@ -207,7 +207,7 @@ spec:
               test "$(jq -r '.architecture' <<< "$imagearch2")" == "s390x"
               test "$(jq -r '.containerImage' <<< "$imagearch2")" == "registry.redhat.io/product/repo@sha256:deadbeef"
               test "$(jq -r '.purl' <<< "$imagearch2")" == \
-                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product&tag=1744596866"
+                "pkg:oci/repo@sha256%3Adeadbeef?arch=s390x&repository_url=registry.redhat.io/product/repo&tag=1744596866"
               test "$(jq -r '.repository' <<< "$imagearch2")" == "registry.redhat.io/product/repo"
               test "$(jq -rc '.tags' <<< "$imagearch2")" == '["foo","bar"]'
               test "$(jq -rc '.component' <<< "$imagearch2")" == "comp"


### PR DESCRIPTION
## Describe your changes

The repository_url qualifier of the purl is generated in populate-release-notes. It was intentionally stripping bar from registry.redhat.com/foo/bar, but apparently that's wrong and the full repository url should be included.

## Relevant Jira

RELEASE-2230

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
