### PR TITLE
fix: run idempotent test as well

### DIFF
--- a/integration-tests/scripts/find_release_pipelines_from_pr.sh
+++ b/integration-tests/scripts/find_release_pipelines_from_pr.sh
@@ -213,10 +213,10 @@ _find_and_process_pipelines() {
     done
   done
 
-  # Self-hosted Quay test uses the same pipeline, so trigger it alongside
-  if [[ " ${SELECTED_TESTCASES[*]} " =~ " push-to-external-registry " ]] && \
-     [[ ! " ${SELECTED_TESTCASES[*]} " =~ " push-to-external-registry-self-hosted-quay " ]]; then
+  # push-to-external-registry has extra test suites defined for it
+  if [[ " ${SELECTED_TESTCASES[*]} " =~ " push-to-external-registry " ]]; then
     SELECTED_TESTCASES+=("push-to-external-registry-self-hosted-quay")
+    SELECTED_TESTCASES+=("push-to-external-registry-idempotent")
   fi
   if (( ${#SELECTED_TESTCASES[@]} > 0 )); then
     echo -n "${SELECTED_TESTCASES[*]}"


### PR DESCRIPTION
The push-to-external-registry-idempotent test was always being skipped, since no pipeline has that name. This commit updates the helper script so that whenever a change is found in a push-to-external-registry task is found, the idempotent variant is run too.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
