### PR TITLE
fix: adding mechanism to cleanup Release CRs

### DIFF
--- a/integration-tests/fbc-release/test.sh
+++ b/integration-tests/fbc-release/test.sh
@@ -852,7 +852,14 @@ verify_hotfix_tagging() {
 wait_for_release() {
     local release_name=$1
     echo "⏳ Waiting for release $release_name to complete..."
-    
+
+    # Add labels to the release CR for cleanup tracking
+    # - originating-tool: identifies which test suite created it (for cleanup)
+    # - test-run-uuid: unique ID from test.env (supports concurrent test runs)
+    kubectl patch release "${release_name}" -n "${tenant_namespace}" \
+      --type merge \
+      -p "{\"metadata\":{\"labels\":{\"originating-tool\":\"${originating_tool}\",\"test-run-uuid\":\"${uuid}\"}}}"
+
     export RELEASE_NAME=${release_name}
     export RELEASE_NAMESPACE=${tenant_namespace}
     "${SUITE_DIR}/../scripts/wait-for-release.sh"

--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -151,7 +151,7 @@ get_build_pipeline_run_url() { # args are ns, app, name
 
 # Function for cleaning up resources
 # Relies on global variables: CLEANUP, SUITE_DIR, component_repo_name, component_branch, tmpDir, advisory_yaml_dir
-# Optional variables: component2_repo_name (for multi-component tests)
+# Optional variables: component2_repo_name (for multi-component tests), uuid (from test.env), tenant_namespace
 cleanup_resources() {
   local err=${1:-0} # Default to 0 if no error code passed
   local line=${2:-"N/A"}
@@ -192,6 +192,18 @@ cleanup_resources() {
         rm -rf "${tmpDir}"
     else
         echo "tmpDir not set or not a directory, skipping k8s resource cleanup." | tee -a "${cleanup_log_file}"
+    fi
+
+    # Clean up Release CRs created by this specific test run
+    # Use uuid (from test.env) to support concurrent test execution
+    if [ -n "$uuid" ] && [ -n "$tenant_namespace" ]; then
+        echo "Deleting Release CRs with test-run-uuid=${uuid} in namespace ${tenant_namespace}..." | tee -a "${cleanup_log_file}"
+        kubectl delete release -n "${tenant_namespace}" \
+            -l test-run-uuid="${uuid}" \
+            --ignore-not-found >> "${cleanup_log_file}" 2>&1 || \
+            echo "Warning: Failed to delete some Release CRs" | tee -a "${cleanup_log_file}"
+    else
+        echo "Skipping Release CR cleanup: uuid or tenant_namespace not set" | tee -a "${cleanup_log_file}"
     fi
 
     if [ -n "$advisory_yaml_dir" ] && [ -d "$advisory_yaml_dir" ]; then
@@ -620,6 +632,13 @@ wait_for_releases() {
     export RELEASE_NAMESPACE=${tenant_namespace}
     for release in ${release_names};
     do
+      # Add labels to the release CR for cleanup tracking
+      # - originating-tool: identifies which test suite created it (for periodic cleanup)
+      # - test-run-uuid: unique ID from test.env (supports concurrent test runs)
+      kubectl patch release "${release}" -n "${tenant_namespace}" \
+        --type merge \
+        -p "{\"metadata\":{\"labels\":{\"originating-tool\":\"${originating_tool}\",\"test-run-uuid\":\"${uuid}\"}}}"
+
       export RELEASE_NAME=${release}
       "${SUITE_DIR}/../scripts/wait-for-release.sh" &
     done
@@ -655,7 +674,7 @@ cleanup_old_resources() {
 
     echo "🔍 Searching for resources with originating-tool=${originating_tool}"
 
-    local kinds="enterprisecontractpolicy rp rpa rolebinding sa clusterrole secret application component imagerepository"
+    local kinds="enterprisecontractpolicy rp rpa rolebinding sa clusterrole secret application component imagerepository release"
     for kind in $kinds; do
         local namespaces="dev-release-team-tenant managed-release-team-tenant"
         for namespace in $namespaces; do

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -363,4 +363,12 @@ spec:
                 echo "Deleting resources..."
                 kubectl delete -f "$tmpDir/tenant-resources.yaml" --ignore-not-found || true
                 kubectl delete -f "$tmpDir/managed-resources.yaml" --ignore-not-found || true
+
+                # Delete Release CRs created by this test run using uuid label
+                if [ -n "$uuid" ] && [ -n "$tenant_namespace" ]; then
+                  echo "Deleting Release CRs with test-run-uuid=${uuid} in namespace ${tenant_namespace}..."
+                  kubectl delete release -n "${tenant_namespace}" \
+                    -l test-run-uuid="${uuid}" \
+                    --ignore-not-found || echo "Warning: Failed to delete some Release CRs"
+                fi
               done

--- a/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
@@ -365,3 +365,11 @@ spec:
               echo "Deleting resources..."
               kubectl delete -f "$tmpDir/tenant-resources.yaml" --ignore-not-found
               kubectl delete -f "$tmpDir/managed-resources.yaml" --ignore-not-found
+
+              # Delete Release CRs created by this test run using uuid label
+              if [ -n "$uuid" ] && [ -n "$tenant_namespace" ]; then
+                echo "Deleting Release CRs with test-run-uuid=${uuid} in namespace ${tenant_namespace}..."
+                kubectl delete release -n "${tenant_namespace}" \
+                  -l test-run-uuid="${uuid}" \
+                  --ignore-not-found || echo "Warning: Failed to delete some Release CRs"
+              fi

--- a/integration-tests/rh-advisories-large-snapshot/test.sh
+++ b/integration-tests/rh-advisories-large-snapshot/test.sh
@@ -557,11 +557,20 @@ wait_for_releases() {
     : "${large_snapshot_name:?large_snapshot_name must be set}"
     : "${tenant_namespace:?tenant_namespace must be set}"
 
+    local release_name="${large_snapshot_name}-release"
+
+    # Add labels to the release CR for cleanup tracking
+    # - originating-tool: identifies which test suite created it (for cleanup)
+    # - test-run-uuid: unique ID from test.env (supports concurrent test runs)
+    kubectl patch release "${release_name}" -n "${tenant_namespace}" \
+      --type merge \
+      -p "{\"metadata\":{\"labels\":{\"originating-tool\":\"${originating_tool}\",\"test-run-uuid\":\"${uuid}\"}}}"
+
     echo "Waiting for release to start processing..." >&2
     wait_for_release_to_start || log_error "Failed to wait for release to start"
 
     # Export variables expected by verify_release_contents
-    export RELEASE_NAME="${large_snapshot_name}-release"
+    export RELEASE_NAME="${release_name}"
     export RELEASE_NAMESPACE="${tenant_namespace}"
     export RELEASE_NAMES="${RELEASE_NAME}"
 }


### PR DESCRIPTION
## Describe your changes
Since appliction CR don't have the ownership of  Release CR any more, the Release CRs can't be deleted when application CR is deleted. It need to be deleted explicitly.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
