### PR TITLE
fix(KFLUXSPRT-7391): remove duplicate jiraSecretName param

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -284,8 +284,6 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
-        - name: jiraSecretName
-          value: "$(tasks.collect-task-params.results.extractedValues[1])"
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
## Describe your changes
Commit 3214549 added a duplicate jiraSecretName parameter to the populate-release-notes task causing Tekton's validation to reject the pipeline with: parameter names must be unique.

## Relevant Jira
Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1774250372973619
Jira: https://redhat.atlassian.net/browse/KFLUXSPRT-7391
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
