### PR TITLE
feat(KONFLUX-12368): add test for incrementer with timestamp tags

### DIFF
--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -46,6 +46,12 @@ function skopeo() {
       return
   fi
 
+  # mixed timestamp and incrementer tags: timestamps ignored, increments from 135
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-timestamp-mixed ]]; then
+      echo '{"Tags": ["1.2.1", "1.2.1-26", "1.2.1-67", "1.2.1-135", "1.2.1-1737653481", "1.2.1-1740048934", "1.2.1-1745398585"]}'
+      return
+  fi
+  
   # 7 digit tags: ignored by {1,6} regex, incrementer starts at 1
   if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-leadingzero ]]; then
       echo '{"Tags": ["v0.7.0-0760387", "v0.7.0-0760386"]}'

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -135,6 +135,17 @@ spec:
                           ]
                         }
                       ]
+                    },
+                    {
+                      "name": "comp6-timestamp-mixed",
+                      "repositories": [
+                        {
+                          "url": "repo-timestamp-mixed",
+                          "tags": [
+                            "1.2.1-{{ incrementer }}"
+                          ]
+                        }
+                      ]
                     }
                   ],
                   "defaults": {
@@ -184,6 +195,16 @@ spec:
                   {
                     "name": "comp5-octal",
                     "containerImage": "registry.io/image5@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp6-timestamp-mixed",
+                    "containerImage": "registry.io/image6@sha256:123456",
                     "source": {
                       "git": {
                         "revision": "testrevision",
@@ -326,3 +347,9 @@ spec:
                 jq -c '.components[] | select(.name=="comp5-octal").repositories[0].tags' \
                 < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
               )" == '["defaultTag","v1.0.0-9"]'
+
+              echo Test that comp6 incrementer ignores timestamp tags and increments from 135
+              test "$(
+                jq -c '.components[] | select(.name=="comp6-timestamp-mixed").repositories[0].tags' \
+                < "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              )" == '["1.2.1-136","defaultTag"]'


### PR DESCRIPTION
## Describe your changes
The fix in 7af1a6b1 for KONFLUX-11897 already handles this bug. This commit adds a test with mixed timestamp and incrementer tags to check it increments from 135.
## Relevant Jira
Jira: https://redhat.atlassian.net/browse/KONFLUX-12368
Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1773147069613089thread_ts=1772185840.853629&cid=C04PZ7H0VA8
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
