### PR TITLE
chore: add retry to e2e test Conforma task

### DIFF
--- a/pipelines/managed/e2e/e2e.yaml
+++ b/pipelines/managed/e2e/e2e.yaml
@@ -98,6 +98,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
     - name: verify-conforma
+      retries: 2
       timeout: "4h00m0s"
       taskRef:
         resolver: "git"


### PR DESCRIPTION
The e2e tests sometimes fail due to failing release pipeline that fails on the transient issues with the Conform task. Adding a retry to mitigate that.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
