### PR TITLE
revert(RELEASE-2035): revert cpu limits on task steps

### DIFF
--- a/.github/scripts/tkn_check_compute_resources.sh
+++ b/.github/scripts/tkn_check_compute_resources.sh
@@ -44,22 +44,19 @@ for file in ${CHANGED_FILES}; do
       fail=1
     fi
 
-    # Ensure limits.cpu equals requests.cpu
-    limits_cpu=$(yq '.cpu' <<< "$limits")
-    requests_cpu=$(yq '.cpu' <<< "$requests")
-    if [[ "$limits_cpu" == "null" || "$requests_cpu" == "null" || "$limits_cpu" != "$requests_cpu" ]]; then
-      echo "ERROR: $file step $step_name (index $i) limits.cpu and requests.cpu must be defined and equal"
-      fail=1
-    fi
-
     # Check no other keys exist in computeResources (order-agnostic)
     if ! yq -e 'keys | contains(["limits","requests"]) and length == 2' <<< "$compute_resources" > /dev/null 2>&1; then
       echo "ERROR: $file step $step_name (index $i) computeResources has extra or missing keys"
       fail=1
     else
-      # Check that limits has exactly cpu and memory, requests only has cpu and memory (order-agnostic)
-      if ! yq -e 'keys | contains(["cpu","memory"]) and length == 2' <<< "$limits" > /dev/null 2>&1; then
-        echo "ERROR: $file step $step_name (index $i) computeResources.limits must have exactly cpu and memory"
+      # Check that limits has memory (and optionally cpu), requests has cpu and memory (order-agnostic)
+      if ! yq -e 'has("memory")' <<< "$limits" > /dev/null 2>&1; then
+        echo "ERROR: $file step $step_name (index $i) computeResources.limits must have memory defined"
+        fail=1
+      fi
+      limits_keys_ok=$(yq -e 'keys | all_c(. == "memory" or . == "cpu")' <<< "$limits" 2>/dev/null)
+      if [[ "$limits_keys_ok" != "true" ]]; then
+        echo "ERROR: $file step $step_name (index $i) computeResources.limits has unexpected keys (only memory and cpu allowed)"
         fail=1
       fi
       if ! yq -e 'keys | contains(["cpu","memory"]) and length == 2' <<< "$requests" > /dev/null 2>&1; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,17 +114,13 @@ All steps in the [managed](tasks/managed) and [internal](tasks/internal) tasks h
 If you are contributing a new managed or internal task (or adding a step to an existing one), you must provide appropriate `computeResources`. If you do not do this, your PR will fail
 the linting check due to the check defined in [this script](.github/scripts/tkn_check_compute_resources.sh).
 
-When setting `computeResources`, you should set:
-- `limits.memory` and `requests.memory` to the same value
-- `limits.cpu` and `requests.cpu` to the same value
-
-Here is an example:
+When setting `computeResources`, you should set the `limits.memory` and `requests.memory` to the same value. No `limits.cpu` should be defined, but a `requests.cpu` should be.
+Here is an example
 ```yaml
 - name: my-new-step
   computeResources:
     limits:
       memory: 256Mi
-      cpu: 250m
     requests:
       memory: 256Mi
       cpu: 250m

--- a/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
+++ b/tasks/internal/check-embargoed-cves-task/check-embargoed-cves-task.yaml
@@ -56,7 +56,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m

--- a/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
+++ b/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
@@ -77,7 +77,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 200m
         requests:
           memory: 512Mi
           cpu: 200m

--- a/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
+++ b/tasks/internal/collect-blob-signing-params/collect-blob-signing-params.yaml
@@ -40,7 +40,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 25m
         requests:
           memory: 64Mi
           cpu: 25m

--- a/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
+++ b/tasks/internal/collect-simple-signing-params/collect-simple-signing-params.yaml
@@ -62,7 +62,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 25m
         requests:
           memory: 64Mi
           cpu: 25m

--- a/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
+++ b/tasks/internal/create-advisory-oci-artifact-task/create-advisory-oci-artifact-task.yaml
@@ -66,7 +66,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -90,10 +90,9 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: '1'
         requests:
           memory: 256Mi
-          cpu: '1'
+          cpu: '1'  # 1 is the max allowed by at least the staging cluster
       volumeMounts:
         - name: advisory-secret
           mountPath: /mnt/advisory_secret

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -70,7 +70,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: '1'
         requests:
           memory: 256Mi
           cpu: '1'

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -61,7 +61,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: '1'
         requests:
           memory: 128Mi
           cpu: '1'  # 1 is the max allowed by at least the staging cluster

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -84,7 +84,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -68,7 +68,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 400m
         requests:
           memory: 64Mi
           cpu: 400m

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -90,7 +90,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 450m
         requests:
           memory: 512Mi
           cpu: 450m

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -185,7 +185,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -407,7 +406,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -607,7 +605,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -785,7 +782,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -949,7 +945,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -1161,7 +1156,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 500m
         requests:
           memory: 512Mi
           cpu: 500m
@@ -1350,7 +1344,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -1687,7 +1680,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m

--- a/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
+++ b/tasks/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
@@ -66,7 +66,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 100m
         requests:
           memory: 512Mi
           cpu: 100m

--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -110,7 +110,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -152,7 +151,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -177,7 +175,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -253,7 +250,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -286,7 +282,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -369,7 +364,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -433,7 +427,6 @@ spec:
       computeResources:
         limits:
           memory: 56Mi
-          cpu: 25m
         requests:
           memory: 56Mi
           cpu: 25m

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -102,7 +102,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: '1'
         requests:
           memory: 512Mi
           cpu: '1'
@@ -428,7 +427,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 250m
         requests:
           memory: 256Mi
           cpu: 250m

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -140,7 +140,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -165,7 +164,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 200m
         requests:
           memory: 512Mi  # was exiting with code 137 when set to 256Mi
           cpu: 200m
@@ -688,7 +686,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -133,7 +133,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -158,7 +157,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: '1'
         requests:
           memory: 64Mi
           cpu: '1'
@@ -676,7 +674,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
+++ b/tasks/managed/base64-encode-checksum/base64-encode-checksum.yaml
@@ -90,7 +90,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -114,7 +113,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -108,7 +108,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -133,7 +132,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 10m
         requests:
           memory: 64Mi  # was exiting with code 137 when set to 32Mi
           cpu: 10m
@@ -166,7 +164,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/check-labels/check-labels.yaml
+++ b/tasks/managed/check-labels/check-labels.yaml
@@ -76,7 +76,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -99,7 +98,6 @@ spec:
       computeResources:
         limits:
           memory: 100Mi
-          cpu: 10m
         requests:
           memory: 100Mi
           cpu: 10m
@@ -196,7 +194,6 @@ spec:
       computeResources:
         limits:
           memory: 100Mi
-          cpu: 300m
         requests:
           memory: 100Mi
           cpu: 300m

--- a/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+++ b/tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
@@ -42,7 +42,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 200m
         requests:
           memory: 128Mi
           cpu: 200m

--- a/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
+++ b/tasks/managed/cleanup-workspace/cleanup-workspace.yaml
@@ -52,7 +52,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 60m
         requests:
           memory: 64Mi
           cpu: 60m

--- a/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
+++ b/tasks/managed/close-advisory-issues/close-advisory-issues.yaml
@@ -103,7 +103,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -126,7 +125,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 100m
         requests:
           memory: 32Mi
           cpu: 100m
@@ -217,7 +215,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-charon-params/collect-charon-params.yaml
+++ b/tasks/managed/collect-charon-params/collect-charon-params.yaml
@@ -109,7 +109,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -132,7 +131,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -184,7 +182,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -157,7 +157,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 50m
         requests:
           memory: 64Mi
           cpu: 50m
@@ -320,7 +319,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -370,7 +368,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-gh-params/collect-gh-params.yaml
+++ b/tasks/managed/collect-gh-params/collect-gh-params.yaml
@@ -102,7 +102,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -126,7 +125,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -93,7 +93,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -117,7 +116,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -185,7 +183,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
+++ b/tasks/managed/collect-registry-token-secret/collect-registry-token-secret.yaml
@@ -92,7 +92,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -118,7 +117,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
+++ b/tasks/managed/collect-slack-notification-params/collect-slack-notification-params.yaml
@@ -109,7 +109,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m
@@ -132,7 +131,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -283,7 +281,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/collect-task-params/collect-task-params.yaml
+++ b/tasks/managed/collect-task-params/collect-task-params.yaml
@@ -105,7 +105,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -130,7 +129,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/collect-tpa-params/collect-tpa-params.yaml
+++ b/tasks/managed/collect-tpa-params/collect-tpa-params.yaml
@@ -127,7 +127,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -151,7 +150,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -139,7 +139,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -162,7 +161,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -387,7 +385,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 650m
         requests:
           memory: 512Mi
           cpu: 650m
@@ -556,7 +553,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -110,7 +110,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -133,7 +132,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -178,7 +176,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -136,7 +136,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -159,7 +158,6 @@ spec:
       computeResources:
         limits:
           memory: 3Gi
-          cpu: '1'
         requests:
           memory: 3Gi
           cpu: '1'
@@ -542,7 +540,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -111,7 +111,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -134,7 +133,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 50m
         requests:
           memory: 64Mi
           cpu: 50m
@@ -266,7 +264,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 100m
         requests:
           memory: 512Mi
           cpu: 100m
@@ -332,7 +329,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
+++ b/tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
@@ -104,7 +104,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -127,7 +126,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -198,7 +196,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -96,7 +96,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -120,7 +119,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m
@@ -150,7 +148,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
+++ b/tasks/managed/extract-oot-kmods/extract-oot-kmods.yaml
@@ -98,7 +98,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -121,7 +120,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -156,7 +154,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 500m
         requests:
           memory: 1Gi
           cpu: 500m
@@ -376,7 +373,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -76,7 +76,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -88,7 +87,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 10m
         requests:
           memory: 64Mi
           cpu: 10m
@@ -111,7 +109,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 10m
         requests:
           memory: 64Mi
           cpu: 10m
@@ -126,7 +123,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -149,7 +145,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -127,7 +127,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -150,7 +149,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 650m
         requests:
           memory: 512Mi
           cpu: 650m
@@ -389,7 +387,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
@@ -146,7 +146,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -169,7 +168,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -692,7 +690,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
+++ b/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
@@ -108,7 +108,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -133,7 +132,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -307,7 +305,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
+++ b/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
@@ -84,7 +84,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -107,7 +106,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -128,7 +126,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -609,7 +606,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/get-ocp-version/get-ocp-version.yaml
+++ b/tasks/managed/get-ocp-version/get-ocp-version.yaml
@@ -91,7 +91,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -116,7 +115,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -203,7 +201,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -103,7 +103,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -128,7 +127,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -208,7 +206,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -112,7 +112,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -135,7 +134,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 450m
         requests:
           memory: 1Gi
           cpu: 450m
@@ -293,7 +291,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -113,7 +113,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -136,7 +135,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -244,7 +242,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: '1'
         requests:
           memory: 64Mi
           cpu: '1'
@@ -397,7 +394,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -645,7 +641,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -760,7 +755,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m
@@ -813,7 +807,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
+++ b/tasks/managed/prepare-and-finalize-artifacts/prepare-and-finalize-artifacts.yaml
@@ -75,7 +75,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -99,7 +98,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -134,7 +132,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
+++ b/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
@@ -125,7 +125,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -148,7 +147,6 @@ spec:
       computeResources:
         limits:
           memory: 3Gi
-          cpu: '1'
         requests:
           memory: 3Gi
           cpu: '1'

--- a/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
@@ -99,7 +99,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -124,7 +123,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -413,7 +411,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/prepare-validation/prepare-validation.yaml
+++ b/tasks/managed/prepare-validation/prepare-validation.yaml
@@ -50,7 +50,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
+++ b/tasks/managed/promote-koji-draft-build/promote-koji-draft-build.yaml
@@ -105,7 +105,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -129,7 +128,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 250m
         requests:
           memory: 256Mi
           cpu: 250m
@@ -244,7 +242,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -106,7 +106,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -130,7 +129,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 200m
         requests:
           memory: 512Mi
           cpu: 200m
@@ -196,7 +194,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -136,7 +136,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -159,7 +158,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 450m
         requests:
           memory: 32Mi
           cpu: 450m
@@ -317,7 +315,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
+++ b/tasks/managed/publish-to-mrrc/publish-to-mrrc.yaml
@@ -124,7 +124,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -147,7 +146,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -182,7 +180,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -254,7 +251,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -319,7 +315,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -361,7 +356,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -420,7 +414,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -114,7 +114,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -137,7 +136,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 650m
         requests:
           memory: 512Mi
           cpu: 650m
@@ -268,7 +266,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
+++ b/tasks/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
@@ -110,7 +110,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -134,7 +133,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -167,7 +165,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 250m
         requests:
           memory: 256Mi
           cpu: 250m
@@ -218,7 +215,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -97,7 +97,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -120,7 +119,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 650m
         requests:
           memory: 512Mi
           cpu: 650m
@@ -211,7 +209,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -65,7 +65,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -88,7 +87,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -117,7 +115,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -64,7 +64,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -87,7 +86,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -116,7 +114,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: '1'
         requests:
           memory: 1Gi
           cpu: '1'

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -65,7 +65,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -88,7 +87,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -117,7 +115,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m

--- a/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
+++ b/tasks/managed/push-rpm-data-to-pyxis/push-rpm-data-to-pyxis.yaml
@@ -108,7 +108,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -131,7 +130,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: '1'
         requests:
           memory: 1Gi
           cpu: '1'
@@ -324,7 +322,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: '1'
         requests:
           memory: 1Gi
           cpu: '1'
@@ -470,7 +467,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -105,7 +105,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -129,7 +128,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 325m
         requests:
           memory: 256Mi
           cpu: 325m
@@ -326,7 +324,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -150,7 +150,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -173,7 +172,6 @@ spec:
       computeResources:
         limits:
           memory: 3Gi
-          cpu: 1
         requests:
           memory: 3Gi
           cpu: 1
@@ -1098,7 +1096,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -110,7 +110,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -135,10 +134,9 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: '2'
         requests:
           memory: 1Gi
-          cpu: '2'
+          cpu: "2"
       script: |
         #!/usr/bin/env bash
         set -eux
@@ -534,7 +532,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+++ b/tasks/managed/reduce-snapshot/reduce-snapshot.yaml
@@ -110,7 +110,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -142,7 +141,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 10m
         requests:
           memory: 128Mi
           cpu: 10m
@@ -191,7 +189,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 10m
         requests:
           memory: 128Mi
           cpu: 10m
@@ -201,7 +198,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -119,7 +119,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -142,10 +141,9 @@ spec:
       computeResources:
         limits:
           memory: 2.5Gi
-          cpu: '2'
         requests:
           memory: 2.5Gi
-          cpu: '2'
+          cpu: "2"
       volumeMounts:
         - name: secret-vol
           mountPath: "/etc/secrets"
@@ -435,7 +433,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -133,7 +133,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -157,10 +156,9 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
-          cpu: '2'
         requests:
           memory: 4Gi
-          cpu: '2'
+          cpu: "2"
       volumeMounts:
         - name: pyxis-secret-vol
           mountPath: "/etc/secrets"
@@ -654,7 +652,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
+++ b/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
@@ -104,7 +104,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -127,10 +126,9 @@ spec:
       computeResources:
         limits:
           memory: 2.5Gi
-          cpu: '2'
         requests:
           memory: 2.5Gi
-          cpu: '2'
+          cpu: "2"
       volumeMounts:
         - name: secret-vol
           mountPath: "/etc/secrets"
@@ -306,7 +304,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -113,7 +113,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -136,7 +135,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 650m
         requests:
           memory: 512Mi
           cpu: 650m
@@ -236,7 +234,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/send-slack-notification/send-slack-notification.yaml
+++ b/tasks/managed/send-slack-notification/send-slack-notification.yaml
@@ -102,7 +102,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m
@@ -125,7 +124,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -192,7 +190,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
+++ b/tasks/managed/set-advisory-severity/set-advisory-severity.yaml
@@ -97,7 +97,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -120,7 +119,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -209,7 +207,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -125,7 +125,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -149,7 +148,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 100m
         requests:
           memory: 512Mi
           cpu: 100m
@@ -223,7 +221,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -140,7 +140,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -163,7 +162,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 250m
         requests:
           memory: 1Gi
           cpu: 250m
@@ -367,7 +365,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -117,7 +117,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -140,7 +139,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 250m
         requests:
           memory: 512Mi
           cpu: 250m
@@ -655,7 +653,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m
@@ -700,7 +697,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/update-cr-status/update-cr-status.yaml
+++ b/tasks/managed/update-cr-status/update-cr-status.yaml
@@ -101,7 +101,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 20m
         requests:
           memory: 128Mi
           cpu: 20m
@@ -124,7 +123,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 50m
         requests:
           memory: 128Mi
           cpu: 50m

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -116,7 +116,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 20m
         requests:
           memory: 32Mi
           cpu: 20m
@@ -139,7 +138,6 @@ spec:
       computeResources:
         limits:
           memory: 256Mi
-          cpu: 150m
         requests:
           memory: 256Mi
           cpu: 150m
@@ -157,7 +155,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -203,7 +200,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 100m
         requests:
           memory: 128Mi
           cpu: 100m
@@ -220,7 +216,6 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 350m
         requests:
           memory: 512Mi
           cpu: 350m
@@ -487,7 +482,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/update-package-collection/update-package-collection.yaml
+++ b/tasks/managed/update-package-collection/update-package-collection.yaml
@@ -113,7 +113,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -136,7 +135,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: '1'
         requests:
           memory: 1Gi
           cpu: "1"
@@ -692,7 +690,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -97,7 +97,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -120,7 +119,6 @@ spec:
       computeResources:
         limits:
           memory: 1Gi
-          cpu: 500m
         requests:
           memory: 1Gi
           cpu: 500m
@@ -200,7 +198,6 @@ spec:
       computeResources:
         limits:
           memory: 128Mi
-          cpu: 250m
         requests:
           memory: 128Mi
           cpu: 250m

--- a/tasks/managed/validate-single-component/validate-single-component.yaml
+++ b/tasks/managed/validate-single-component/validate-single-component.yaml
@@ -89,7 +89,6 @@ spec:
       computeResources:
         limits:
           memory: 64Mi
-          cpu: 30m
         requests:
           memory: 64Mi
           cpu: 30m
@@ -112,7 +111,6 @@ spec:
       computeResources:
         limits:
           memory: 32Mi
-          cpu: 10m
         requests:
           memory: 32Mi
           cpu: 10m

--- a/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
+++ b/tasks/managed/verify-access-to-resources/verify-access-to-resources.yaml
@@ -66,7 +66,6 @@ spec:
       computeResources:
         limits:
           memory: 100Mi
-          cpu: 10m
         requests:
           memory: 100Mi
           cpu: 10m


### PR DESCRIPTION
## Describe your changes
Reverts the following 5 commits that set limits.cpu = requests.cpu on all task steps:

941a69aa feat(RELEASE-2035): add cpu limits to managed tasks
2814c6ea feat(RELEASE-2035): add cpu limits to heavy managed tasks
7b31aa0b feat(RELEASE-2035): add cpu limits to internal tasks
f7c94307 feat(RELEASE-2035): add missing cpu limits to remaining tasks
8bea7834 feat(RELEASE-2251): increase compress-artifacts step resources

The CPU limits caused significant performance degradation due to CFS throttling on bursty steps (e.g. verify-access-to-resources went from ~12s to ~3min). The original Prometheus irate metric used for sizing captured average CPU rate but not burst/spike patterns, resulting in under-provisioned limits.

Will set up proper performance monitoring before re-attempting.## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
