### PR TITLE
feat(CALUNGA-214): Fetch Chains provenance during artifact extraction

### DIFF
--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -145,6 +145,55 @@ spec:
         echo "Extracted files:"
         ls -la "${FILES_DIR}"
 
+    - name: fetch-chains-provenance
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        PROVENANCE_DIR="${FILES_DIR}/chains-provenance"
+        DOCKER_CONFIG="$(mktemp -d)"
+        export DOCKER_CONFIG
+        mkdir -p "${PROVENANCE_DIR}"
+
+        while read -r IMAGE; do
+          echo "Fetching Chains provenance for ${IMAGE}"
+
+          select-oci-auth "${IMAGE}" > "${DOCKER_CONFIG}/config.json"
+
+          # Use the image digest as the filename so downstream can
+          # match provenance to the image that produced it.
+          DIGEST="${IMAGE##*@}"
+          PROVENANCE_FILE="${PROVENANCE_DIR}/${DIGEST}.json"
+
+          # Chains uses AWS KMS for signing, not public Sigstore/Rekor,
+          # so transparency log and SCT verification are skipped.
+          COSIGN_STDERR="/tmp/cosign-stderr-${DIGEST}.log"
+          if cosign verify-attestation \
+            --type=slsaprovenance \
+            --insecure-ignore-tlog=true \
+            --insecure-ignore-sct=true \
+            --key k8s://tekton-chains/signing-secrets \
+            "${IMAGE}" 2>"${COSIGN_STDERR}" | head -1 | jq . > "${PROVENANCE_FILE}"; then
+            echo "  Saved Chains provenance to ${PROVENANCE_FILE}"
+          else
+            echo "ERROR: Failed to fetch Chains provenance for ${IMAGE}"
+            cat "${COSIGN_STDERR}"
+            exit 1
+          fi
+          rm -f "${COSIGN_STDERR}"
+        done < "${IMAGES_TXT}"
+
+        echo "Chains provenance files:"
+        ls -la "${PROVENANCE_DIR}"
+
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/extract-py-artifacts/tests/mocks.sh
+++ b/tasks/managed/extract-py-artifacts/tests/mocks.sh
@@ -43,3 +43,15 @@ function oras() {
   return 0
 }
 
+function cosign() {
+  echo "Mock cosign called with: $*" >&2
+
+  if [[ "$1" == "verify-attestation" ]]; then
+    # Output on a single line, matching real cosign verify-attestation behavior
+    echo '{"predicateType":"https://slsa.dev/provenance/v1","predicate":{"buildDefinition":{"buildType":"https://tekton.dev/chains/v2/slsa","externalParameters":{"runSpec":{"pipelineRef":{"name":"build-python-wheels-oci-ta"},"params":[{"name":"PACKAGES","value":["test_package==1.0.0"]}]}},"internalParameters":{},"resolvedDependencies":[{"uri":"git+https://github.com/calungaproject/index.git","digest":{"sha1":"abc123def456"}}]},"runDetails":{"builder":{"id":"https://konflux-ci.dev/chains/v2"},"metadata":{"invocationId":"calunga-tenant/build-run-mock","startedOn":"2026-02-19T21:40:00Z","finishedOn":"2026-02-19T21:51:09Z"}}}}'
+    return 0
+  fi
+
+  return 0
+}
+

--- a/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
@@ -6,7 +6,8 @@
 #   [1] use-trusted-artifact (StepAction ref - no mock needed)
 #   [2] get-image-urls (script - inject mocks)
 #   [3] extract-artifacts (script - inject mocks)
-#   [4] create-trusted-artifact (StepAction ref - no mock needed)
+#   [4] fetch-chains-provenance (script - inject mocks)
+#   [5] create-trusted-artifact (StepAction ref - no mock needed)
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -15,3 +16,6 @@ yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 
 # Inject mocks into the extract-artifacts step (step index 3)
 yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
+
+# Inject mocks into the fetch-chains-provenance step (step index 4)
+yq -i '.spec.steps[4].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[4].script' "$TASK_PATH"

--- a/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
@@ -162,8 +162,30 @@ spec:
                 exit 1
               fi
 
+              # Check that Chains provenance was fetched
+              PROV_DIR="${FILES_DIR}/chains-provenance"
+              if [ ! -d "${PROV_DIR}" ]; then
+                echo "ERROR: chains-provenance directory not found"
+                exit 1
+              fi
+              PROV_COUNT=$(find "${PROV_DIR}" -name '*.json' | wc -l)
+              if [ "${PROV_COUNT}" -eq 0 ]; then
+                echo "ERROR: No Chains provenance files found"
+                ls -la "${PROV_DIR}"
+                exit 1
+              fi
+              # Verify each provenance contains a valid SLSA predicate
+              for prov_file in "${PROV_DIR}"/*.json; do
+                if ! jq -e '.predicate.buildDefinition' "${prov_file}" > /dev/null; then
+                  echo "ERROR: ${prov_file} missing buildDefinition"
+                  exit 1
+                fi
+              done
+
               echo "Files extracted:"
               ls -la "${FILES_DIR}"
+              echo "Chains provenance:"
+              ls -la "${FILES_DIR}/chains-provenance"
 
               echo "All checks passed!"
       runAfter:


### PR DESCRIPTION
Add a fetch-chains-provenance step to the extract-py-artifacts task that retrieves the Tekton Chains SLSA provenance for each OCI artifact from the registry using cosign verify-attestation. The provenance is saved alongside the extracted wheels so it can be used by the signing task to produce SLSA L3 compliant attestations.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
