### PR TITLE
fix(HUM-808): src rpms should use arch=src in purls

### DIFF
--- a/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
@@ -33,7 +33,7 @@ spec:
         },
         {
           "name": "rpm-source",
-          "arch": "source",
+          "arch": "src",
           "repository_id": "rpm-source",
           "repository_name": "source",
           "distro": "testdistro"

--- a/integration-tests/push-rpms-to-pulp/test.sh
+++ b/integration-tests/push-rpms-to-pulp/test.sh
@@ -76,9 +76,9 @@ verify_release_contents() {
     advisory_url=$(jq -r '.status.artifacts.advisory.url // ""' <<< "${release_json}")
     advisory_internal_url=$(jq -r '.status.artifacts.advisory.internal_url // ""' <<< "${release_json}")
 
-    # first 2 arches are specified in the pipelinerun templates, the last one is source.
+    # first 2 arches are specified in the pipelinerun templates, the last one is src.
     # When the release includes noarch RPMs, fanout adds extra rpmfiles (one per default arch).
-    arches=("x86_64" "source")
+    arches=("x86_64" "src")
     echo "Checking RPM files count..."
     local rpmfiles=$(jq -c '.status.artifacts.rpmfiles // []' <<< "${release_json}")
     local rpmfiles_count=$(jq -r '. | length' <<< "${rpmfiles}")
@@ -103,10 +103,10 @@ verify_release_contents() {
     # When the release includes noarch RPMs, assert they are published to all default arch repos.
     if [ "${noarch_count}" -gt 0 ]; then
       echo "Checking noarch RPM fanout to default arch repos..."
-      # Get arches from the rpm-repositories mapping in the RPA (excluding source)
+      # Get arches from the rpm-repositories mapping in the RPA (excluding src)
       default_arches=$(kubectl get releaseplanadmission "${release_plan_admission_name}" \
         -n "${managed_namespace}" -ojson \
-        | jq -r '.spec.data.mapping["rpm-repositories"][]? | select(.arch != "source") | .arch' \
+        | jq -r '.spec.data.mapping["rpm-repositories"][]? | select(.arch != "src") | .arch' \
         | sort -u)
       for default_arch in ${default_arches}; do
         local noarch_for_arch
@@ -232,8 +232,8 @@ verify_release_contents() {
               failures=$((failures+1))
             fi
 
-            # Check for source RPM entry with .src suffix (e.g., "hello-2.12.1-xxx.src (source)")
-            if echo "${description}" | grep -q "hello-.*\.src (source)"; then
+            # Check for source RPM entry with .src suffix (e.g., "hello-2.12.1-xxx.src (source)" or "(src)")
+            if echo "${description}" | grep -qE "hello-.*\.src \((source|src)\)"; then
               echo "✅️ Found source RPM entry with .src suffix in description"
             else
               echo "🔴 Missing source RPM entry with .src suffix in description"

--- a/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/filter-already-released-advisory-rpms.yaml
@@ -469,9 +469,14 @@ spec:
 
             if [[ "${f}" == *.src.rpm ]]; then
               arch="src"
-              repo_info="$(get_repo_info_for_arch "source")"
-              [[ -z "${repo_info}" ]] && continue
-              target_repos_json="[${repo_info}]"
+              # Source RPMs use arch="src" in the mapping
+              repo_info="$(get_repo_info_for_arch "src")"
+              if [[ -n "${repo_info}" ]]; then
+                target_repos_json="[${repo_info}]"
+              else
+                echo "Warning: No repository mapping for source arch, skipping ${f}" >&2
+                continue
+              fi
             elif [[ "${f}" == *.noarch.rpm ]]; then
               [[ "$(jq 'length' <<< "${NOARCH_TARGET_REPOS_JSON}")" -eq 0 ]] && continue
               target_repos_json="${NOARCH_TARGET_REPOS_JSON}"

--- a/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-basic.yaml
+++ b/tasks/managed/filter-already-released-advisory-rpms/tests/test-filter-already-released-advisory-rpms-basic.yaml
@@ -83,8 +83,10 @@ spec:
                       "distro": "testdistro"
                     },
                     {
-                      "name": "rpm-source", "arch": "source",
-                      "repository_id": "rpm-source", "repository_name": "source",
+                      "name": "rpm-source",
+                      "arch": "src",
+                      "repository_id": "rpm-source",
+                      "repository_name": "source",
                       "distro": "testdistro"
                     }
                   ]

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rpms.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rpms.yaml
@@ -70,7 +70,7 @@ spec:
                     },
                     {
                       "name": "hbird-source",
-                      "arch": "source",
+                      "arch": "src",
                       "distro": "hummingbird",
                       "repository_id": "hbird-source"
                     }

--- a/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -1041,7 +1041,7 @@ spec:
 
             jq --arg pkg "${pkg}" \
                --arg rpmname "${_name}" \
-               --arg arch "source" \
+               --arg arch "src" \
                --arg pulprepo "${PULP_DOMAIN}/source" \
                --arg epoch "${epoch}" \
                --arg version "${version}" \

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-noarch-all-default-arches.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-noarch-all-default-arches.yaml
@@ -212,7 +212,7 @@ spec:
                 echo Error: expected 1 x86_64 rpmfile entry.
                 exit 1
               fi
-              if [ "$(echo "$results" | jq '[.rpmfiles[] | select(.arch == "source")] | length')" != "1" ]; then
+              if [ "$(echo "$results" | jq '[.rpmfiles[] | select(.arch == "src")] | length')" != "1" ]; then
                 echo Error: expected 1 source rpmfile entry.
                 exit 1
               fi

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-noarch-rpms.yaml
@@ -192,7 +192,7 @@ spec:
                 exit 1
               fi
               # count how source rpmfiles are in the results
-              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "source")) | length')" != 0 ]; then
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "src")) | length')" != 0 ]; then
                 echo Error: there should be 0 source rpmfiles in the results. Actual results:
                 echo "$results"
                 exit 1

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-only-x86-64-rpms.yaml
@@ -190,7 +190,7 @@ spec:
                 exit 1
               fi
               # count how source rpmfiles are in the results
-              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "source")) | length')" != 0 ]; then
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "src")) | length')" != 0 ]; then
                 echo Error: there should be 0 source rpmfiles in the results. Actual results:
                 echo "$results"
                 exit 1

--- a/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
+++ b/tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp.yaml
@@ -195,7 +195,7 @@ spec:
               fi
 
               # count how source rpmfiles are in the results
-              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "source")) | length')" != 1 ]; then
+              if [ "$(echo "$results" | jq '.rpmfiles | map(select(.arch == "src")) | length')" != 1 ]; then
                 echo Error: there should be 1 source rpmfile in the results. Actual results:
                 echo "$results"
                 exit 1


### PR DESCRIPTION
## Describe your changes
- According to [RH standards](https://redhatproductsecurity.github.io/security-data-guidelines/purl/#identifying-rpm-packages), the purl values for src rpms must specify arch=src
- ensure that we always now use arch=src in other labels in data files

## Relevant Jira
- HUM-808

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
