### PR TITLE
feat(CALUNGA-215): Upgrade wheel attestations to be SLSA L3 compliant

### DIFF
--- a/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
+++ b/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
@@ -153,6 +153,7 @@ spec:
         set -x
 
         FILES_DIR=$(params.dataDir)/$(params.filesDir)
+        PROVENANCE_DIR="${FILES_DIR}/chains-provenance"
 
         # Get release timestamp
         RELEASE_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -166,6 +167,23 @@ spec:
             exit 1
         fi
 
+        # Load the first Chains provenance predicate. All wheels in a
+        # release come from the same build pipeline, so one is sufficient.
+        CHAINS_PREDICATE=""
+        if [ -d "${PROVENANCE_DIR}" ]; then
+            shopt -s nullglob
+            for prov_file in "${PROVENANCE_DIR}"/sha256:*.json; do
+                CHAINS_PREDICATE=$(jq '.predicate' "${prov_file}")
+                echo "Loaded Chains provenance from ${prov_file}"
+                break
+            done
+            shopt -u nullglob
+        fi
+
+        if [ -z "${CHAINS_PREDICATE}" ]; then
+            echo "WARNING: No Chains provenance found, falling back to minimal predicate"
+        fi
+
         # Function to run cosign with retries
         run_cosign() {
             local attempt=0
@@ -176,7 +194,6 @@ spec:
                     return 0
                 fi
                 sleep $backoff2
-                # Fibonacci backoff
                 local old_backoff1=$backoff1
                 backoff1=$backoff2
                 backoff2=$((old_backoff1 + backoff2))
@@ -224,44 +241,67 @@ spec:
 
           # Create SLSA provenance predicate
           PREDICATE_FILE="/tmp/${WHEEL}.predicate.json"
-          cat > "${PREDICATE_FILE}" <<EOF
-        {
-          "_type": "https://in-toto.io/Statement/v0.1",
-          "predicateType": "https://slsa.dev/provenance/v0.2",
-          "subject": [
-            {
-              "name": "${WHEEL}",
-              "digest": {
-                "sha256": "${WHEEL_SHA256}"
-              }
-            }
-          ],
-          "predicate": {
-            "builder": {
-              "id": "https://konflux-ci.dev/calunga"
-            },
-            "buildType": "https://konflux-ci.dev/PythonWheelBuild@v1",
-            "metadata": {
-              "buildFinishedOn": "${RELEASE_TIME}",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
+
+          if [ -n "${CHAINS_PREDICATE}" ]; then
+            jq -n \
+              --arg release_time "${RELEASE_TIME}" \
+              --argjson chains_predicate "${CHAINS_PREDICATE}" \
+            '{
+              buildDefinition: (
+                if $chains_predicate.buildDefinition then
+                  $chains_predicate.buildDefinition
+                else {
+                  buildType: ($chains_predicate.buildType // "https://konflux-ci.dev/PythonWheelBuild@v1"),
+                  externalParameters: ($chains_predicate.invocation.parameters // {}),
+                  internalParameters: ($chains_predicate.invocation.environment // {}),
+                  resolvedDependencies: ($chains_predicate.materials // [])
+                }
+                end
+              ),
+              runDetails: (
+                if $chains_predicate.runDetails then
+                  $chains_predicate.runDetails
+                else {
+                  builder: {
+                    id: ($chains_predicate.builder.id // "https://konflux-ci.dev/calunga")
+                  },
+                  metadata: {
+                    invocationId: ($chains_predicate.metadata.buildInvocationId // null),
+                    startedOn: ($chains_predicate.metadata.buildStartedOn // null),
+                    finishedOn: ($chains_predicate.metadata.buildFinishedOn // $release_time)
+                  }
+                }
+                end
+              )
+            }' > "${PREDICATE_FILE}"
+          else
+            # Fallback: minimal v1 predicate when Chains provenance is unavailable
+            jq -n \
+              --arg release_time "${RELEASE_TIME}" \
+            '{
+              buildDefinition: {
+                buildType: "https://konflux-ci.dev/PythonWheelBuild@v1",
+                externalParameters: {},
+                resolvedDependencies: []
               },
-              "reproducible": true
-            }
-          }
-        }
-        EOF
+              runDetails: {
+                builder: {
+                  id: "https://konflux-ci.dev/calunga"
+                },
+                metadata: {
+                  finishedOn: $release_time
+                }
+              }
+            }' > "${PREDICATE_FILE}"
+          fi
 
           ATT_FILE="${WHEEL}.attestation"
           DSSE_FILE="/tmp/${WHEEL}.dsse.json"
 
-          # Sign the attestation with cosign using AWS KMS key
           echo "Signing attestation with cosign (AWS KMS)"
           if run_cosign attest-blob "${WHEEL}" \
             --predicate="${PREDICATE_FILE}" \
-            --type=https://slsa.dev/provenance/v0.2 \
+            --type=https://slsa.dev/provenance/v1 \
             --key "$SIGN_KEY" \
             --yes \
             "${REKOR_ARGS[@]}" \
@@ -289,6 +329,9 @@ spec:
           ATT_COUNT=$((ATT_COUNT + 1))
           rm -f "${PREDICATE_FILE}"
         done
+
+        # Clean up the chains-provenance directory so it's not uploaded to Pulp
+        rm -rf "${PROVENANCE_DIR}"
 
         echo ""
         echo "=========================================="

--- a/tasks/managed/rh-sign-python-wheels/tests/mocks.sh
+++ b/tasks/managed/rh-sign-python-wheels/tests/mocks.sh
@@ -10,26 +10,31 @@ function cosign() {
   if [[ "$1" == "attest-blob" ]]; then
     # Extract the output file from arguments
     output_file=""
+    predicate_file=""
     for arg in "$@"; do
       if [[ "$arg" == --output-file=* ]]; then
         output_file="${arg#--output-file=}"
+      elif [[ "$arg" == --predicate=* ]]; then
+        predicate_file="${arg#--predicate=}"
       fi
     done
 
     if [[ -n "$output_file" ]]; then
-      # Create a mock DSSE envelope
-      cat > "$output_file" << 'DSSE_EOF'
-{
-  "payloadType": "application/vnd.in-toto+json",
-  "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSJ9",
-  "signatures": [
-    {
-      "keyid": "",
-      "sig": "MEUCIQC5mock5signature5here"
-    }
-  ]
-}
-DSSE_EOF
+      # Build a statement from the predicate, matching real cosign behavior
+      PREDICATE_CONTENT=$(cat "$predicate_file" 2>/dev/null || echo '{}')
+      STATEMENT=$(jq -n -c \
+        --arg type "https://in-toto.io/Statement/v1" \
+        --argjson predicate "$PREDICATE_CONTENT" \
+        '{_type: $type, predicate: $predicate}')
+      ENCODED=$(echo -n "$STATEMENT" | base64 -w 0)
+
+      jq -n \
+        --arg payload "$ENCODED" \
+        '{
+          payloadType: "application/vnd.in-toto+json",
+          payload: $payload,
+          signatures: [{keyid: "", sig: "MEUCIQC5mock5signature5here"}]
+        }' > "$output_file"
     fi
     return 0
   fi

--- a/tasks/managed/rh-sign-python-wheels/tests/test-rh-sign-python-wheels.yaml
+++ b/tasks/managed/rh-sign-python-wheels/tests/test-rh-sign-python-wheels.yaml
@@ -53,10 +53,49 @@ spec:
               set -eux
 
               mkdir -p "$(params.dataDir)/files"
+              mkdir -p "$(params.dataDir)/files/chains-provenance"
 
               # Create mock wheel and sdist files
               echo "mock wheel content" > "$(params.dataDir)/files/my_package-1.0.0-py3-none-any.whl"
               echo "mock sdist content" > "$(params.dataDir)/files/my_package-1.0.0.tar.gz"
+
+              # Create mock Chains provenance (SLSA v1 format)
+              cat > "$(params.dataDir)/files/chains-provenance/sha256:abc123.json" << 'PROVEOF'
+              {
+                "predicateType": "https://slsa.dev/provenance/v1",
+                "predicate": {
+                  "buildDefinition": {
+                    "buildType": "https://tekton.dev/chains/v2/slsa",
+                    "externalParameters": {
+                      "runSpec": {
+                        "pipelineRef": {"name": "build-python-wheels-oci-ta"},
+                        "params": [{"name": "PACKAGES", "value": ["my_package==1.0.0"]}]
+                      }
+                    },
+                    "internalParameters": {
+                      "tekton-pipelines-feature-flags": {"EnableStepActions": "true"}
+                    },
+                    "resolvedDependencies": [
+                      {
+                        "uri": "git+https://github.com/calungaproject/index.git",
+                        "digest": {"sha1": "abc123def456"},
+                        "name": "pipelineTask"
+                      }
+                    ]
+                  },
+                  "runDetails": {
+                    "builder": {
+                      "id": "https://konflux-ci.dev/chains/v2"
+                    },
+                    "metadata": {
+                      "invocationId": "calunga-tenant/build-run-12345",
+                      "startedOn": "2026-02-19T21:40:00Z",
+                      "finishedOn": "2026-02-19T21:51:09Z"
+                    }
+                  }
+                }
+              }
+              PROVEOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -162,7 +201,37 @@ spec:
                   echo "ERROR: Attestation file ${att_file} does not have envelope field"
                   exit 1
                 fi
+
+                # Decode the DSSE payload and verify SLSA v1 predicate structure
+                STATEMENT=$(jq -r '.envelope.statement' "${att_file}" | base64 -d 2>/dev/null || true)
+                if [ -n "${STATEMENT}" ]; then
+                  echo "  Checking SLSA v1 predicate structure..."
+                  if ! echo "${STATEMENT}" | jq -e '.predicate | has("buildDefinition")' > /dev/null 2>&1; then
+                    echo "ERROR: Predicate missing buildDefinition"
+                    exit 1
+                  fi
+                  if ! echo "${STATEMENT}" | jq -e '.predicate | has("runDetails")' > /dev/null 2>&1; then
+                    echo "ERROR: Predicate missing runDetails"
+                    exit 1
+                  fi
+                  if ! echo "${STATEMENT}" | jq -e '.predicate.runDetails | has("builder")' > /dev/null 2>&1; then
+                    echo "ERROR: Predicate missing runDetails.builder"
+                    exit 1
+                  fi
+                  BD='.predicate.buildDefinition'
+                  if ! echo "${STATEMENT}" | jq -e "$BD | has(\"buildType\")" > /dev/null 2>&1; then
+                    echo "ERROR: Predicate missing buildDefinition.buildType"
+                    exit 1
+                  fi
+                  echo "  SLSA v1 predicate structure OK"
+                fi
               done
+
+              # Verify chains-provenance directory was cleaned up
+              if [ -d "${FILES_DIR}/chains-provenance" ]; then
+                echo "ERROR: chains-provenance directory should have been removed"
+                exit 1
+              fi
 
               echo "All checks passed!"
       runAfter:


### PR DESCRIPTION
Rewrite the attest-blob step in rh-sign-python-wheels to reuse the Tekton Chains SLSA provenance. The Chains provenance already contains the required buildDefinition and runDetails fields with real build metadata. This will fall back to a minimal v1 predicate if no Chains provenance is available.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
