### PR TITLE
test(RELEASE-2327): add image shasum and skopeo pull verification

### DIFF
--- a/integration-tests/push-to-external-registry-idempotent/test.sh
+++ b/integration-tests/push-to-external-registry-idempotent/test.sh
@@ -107,34 +107,13 @@ verify_single_release() {
     fi
 
     echo "Verifying image pullability with skopeo..."
-    local ORIGINAL_PULLSPEC="${image_url}"
-    local STRIPPED_PULLSPEC
-
-    if [[ "$ORIGINAL_PULLSPEC" == *":"* && "$ORIGINAL_PULLSPEC" != *"@"* ]]; then
-        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%:*}"
-        echo "Stripped tag from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
-    elif [[ "$ORIGINAL_PULLSPEC" == *"@"* ]]; then
-        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%@*}"
-        echo "Stripped digest from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
-    else
-        STRIPPED_PULLSPEC="$ORIGINAL_PULLSPEC"
-        echo "No tag or digest found, using original as is: $STRIPPED_PULLSPEC"
-    fi
-
-    local COMPLETE_PULLSPEC="${STRIPPED_PULLSPEC}@${image_shasum}"
-    echo "New complete pullspec: $COMPLETE_PULLSPEC"
-
-    DOCKER_CONFIG="$(mktemp -d)"
-    export DOCKER_CONFIG
-
-    yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
-        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" | base64 -d > "${DOCKER_CONFIG}/config.json"
-
-    if skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
-        echo "✅️ Image '$COMPLETE_PULLSPEC' can be pulled using skopeo."
-    else
-        echo "🔴 Failed to pull or inspect image '$COMPLETE_PULLSPEC'."
-        skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}"
+    set +e
+    "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
+        "${image_url}" "${image_shasum}" \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+    skopeo_return_code=$?
+    set -e
+    if [ "${skopeo_return_code}" -ne 0 ]; then
         failures=$((failures+1))
     fi
 

--- a/integration-tests/push-to-external-registry/test.sh
+++ b/integration-tests/push-to-external-registry/test.sh
@@ -44,39 +44,13 @@ verify_release_contents() {
     fi
 
     echo "Verifying image pullability with skopeo..."
-    # --- Step 1: Strip the tag or digest from the original pullspec ---
-    ORIGINAL_PULLSPEC="${image_url}"
-    # Check if the pullspec contains a tag (:) or a digest (@)
-    if [[ "$ORIGINAL_PULLSPEC" == *":"* && "$ORIGINAL_PULLSPEC" != *"@"* ]]; then
-        # Contains a tag, strip it
-        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%:*}"
-        echo "Stripped tag from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
-    elif [[ "$ORIGINAL_PULLSPEC" == *"@"* ]]; then
-        # Contains a digest, strip it
-        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%@*}"
-        echo "Stripped digest from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
-    else
-        # No tag or digest found, use the original as is
-        STRIPPED_PULLSPEC="$ORIGINAL_PULLSPEC"
-        echo "No tag or digest found, using original as is: $STRIPPED_PULLSPEC"
-    fi
-
-    # --- Step 2: Concatenate the new digest to create the complete pullspec ---
-    COMPLETE_PULLSPEC="${STRIPPED_PULLSPEC}@${image_shasum}"
-    echo "New complete pullspec: $COMPLETE_PULLSPEC"
-
-    DOCKER_CONFIG="$(mktemp -d)"
-    export DOCKER_CONFIG
-
-    yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
-        ${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml | base64 -d > ${DOCKER_CONFIG}/config.json
-
-    # --- Step 3: Verify the new complete pullspec using skopeo ---
-    if skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
-        echo "✅️ Image '$COMPLETE_PULLSPEC' can be pulled using skopeo."
-    else
-        echo "🔴 Failed to pull or inspect image '$COMPLETE_PULLSPEC'."
-        skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}"
+    set +e
+    "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
+        "${image_url}" "${image_shasum}" \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+    skopeo_return_code=$?
+    set -e
+    if [ "${skopeo_return_code}" -ne 0 ]; then
         failures=$((failures+1))
     fi
 

--- a/integration-tests/rh-push-to-registry-redhat-io/test.sh
+++ b/integration-tests/rh-push-to-registry-redhat-io/test.sh
@@ -67,39 +67,13 @@ verify_release_contents() {
     fi
 
     echo "Verifying image pullability with skopeo..."
-    # --- Step 1: Strip the tag or digest from the original pullspec ---
-    ORIGINAL_PULLSPEC="${image_url}"
-    # Check if the pullspec contains a tag (:) or a digest (@)
-    if [[ "$ORIGINAL_PULLSPEC" == *":"* && "$ORIGINAL_PULLSPEC" != *"@"* ]]; then
-        # Contains a tag, strip it
-        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%:*}"
-        echo "Stripped tag from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
-    elif [[ "$ORIGINAL_PULLSPEC" == *"@"* ]]; then
-        # Contains a digest, strip it
-        STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%@*}"
-        echo "Stripped digest from: $ORIGINAL_PULLSPEC -> $STRIPPED_PULLSPEC"
-    else
-        # No tag or digest found, use the original as is
-        STRIPPED_PULLSPEC="$ORIGINAL_PULLSPEC"
-        echo "No tag or digest found, using original as is: $STRIPPED_PULLSPEC"
-    fi
-
-    # --- Step 2: Concatenate the new digest to create the complete pullspec ---
-    COMPLETE_PULLSPEC="${STRIPPED_PULLSPEC}@${image_shasum}"
-    echo "New complete pullspec: $COMPLETE_PULLSPEC"
-
-    DOCKER_CONFIG="$(mktemp -d)"
-    export DOCKER_CONFIG
-
-    yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
-        ${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml | base64 -d > ${DOCKER_CONFIG}/config.json
-
-    # --- Step 3: Verify the new complete pullspec using skopeo ---
-    if skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
-        echo "✅️ Image '$COMPLETE_PULLSPEC' can be pulled using skopeo."
-    else
-        echo "🔴 Failed to pull or inspect image '$COMPLETE_PULLSPEC'."
-        skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}"
+    set +e
+    "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
+        "${image_url}" "${image_shasum}" \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+    skopeo_return_code=$?
+    set -e
+    if [ "${skopeo_return_code}" -ne 0 ]; then
         failures=$((failures+1))
     fi
 

--- a/integration-tests/rhtap-service-push/README.md
+++ b/integration-tests/rhtap-service-push/README.md
@@ -29,3 +29,12 @@ The RHTAP service push test follows this specific workflow:
 2. **Infra-Deployments Integration** - Integrates with infra-deployments repository
 3. **Service Push Pipeline Execution** - Executes the RHTAP service push pipeline
 4. **Deployment Verification** - Validates successful service deployment and updates
+
+### Release Verification Checks
+
+`verify_release_contents()` asserts the following for each Release:
+
+- **`image_url`** - non-empty; the published image URL is present in the Release status
+- **`image_shasum`** - non-empty; the image digest is recorded in the Release status
+- **Skopeo inspect** - `skopeo inspect` succeeds on the digest pullspec (`<registry>/<repo>@<shasum>`), confirming the image is actually pullable from the target registry
+- **Infra-deployments PR** - a pull request touching `components/release/development/kustomization.yaml` exists in `hacbs-release/infra-deployments` for the released git revision

--- a/integration-tests/rhtap-service-push/test.sh
+++ b/integration-tests/rhtap-service-push/test.sh
@@ -36,9 +36,10 @@ verify_release_contents() {
       echo "Revision: ${revision}"
 
       local failures=0
-      local image_url
+      local image_url image_shasum
 
       image_url=$(jq -r '.status.artifacts.images[0].urls[0] // ""' <<< "${release_json}")
+      image_shasum=$(jq -r '.status.artifacts.images[0].shasum // ""' <<< "${release_json}")
 
       echo "Checking image_url..."
       if [ -n "${image_url}" ]; then
@@ -46,6 +47,29 @@ verify_release_contents() {
       else
         echo "🔴 image_url was empty!"
         failures=$((failures+1))
+      fi
+
+      echo "Checking image_shasum..."
+      if [ -n "${image_shasum}" ]; then
+        echo "✅️ image_shasum: ${image_shasum}"
+      else
+        echo "🔴 image_shasum was empty!"
+        failures=$((failures+1))
+      fi
+
+      echo "Verifying image pullability with skopeo..."
+      if [ -n "${image_url}" ] && [ -n "${image_shasum}" ]; then
+        set +e
+        "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
+          "${image_url}" "${image_shasum}" \
+          "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+        skopeo_return_code=$?
+        set -e
+        if [ "${skopeo_return_code}" -ne 0 ]; then
+          failures=$((failures+1))
+        fi
+      else
+        echo "⚠️  Skipping skopeo check: image_url or image_shasum is empty."
       fi
 
       set +e

--- a/integration-tests/scripts/skopeo-verify-image.sh
+++ b/integration-tests/scripts/skopeo-verify-image.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Verifies that an image is pullable from its target registry using skopeo.
+#
+# Usage: skopeo-verify-image.sh <image_url> <image_shasum> <managed_secrets_yaml>
+#
+# Arguments:
+#   image_url            - The published image URL (may include a tag or digest)
+#   image_shasum         - The image digest (e.g. sha256:abc123...)
+#   managed_secrets_yaml - Path to the decrypted managed-secrets.yaml file
+#
+# Exits with 0 on success, 1 on failure.
+
+set -euo pipefail
+
+image_url="${1:?image_url argument is required}"
+image_shasum="${2:?image_shasum argument is required}"
+managed_secrets_yaml="${3:?managed_secrets_yaml argument is required}"
+
+if [[ "${image_url}" == *"@"* ]]; then
+    STRIPPED_PULLSPEC="${image_url%@*}"
+    echo "Stripped digest from: ${image_url} -> ${STRIPPED_PULLSPEC}"
+elif [[ "${image_url}" == *":"* ]]; then
+    STRIPPED_PULLSPEC="${image_url%:*}"
+    echo "Stripped tag from: ${image_url} -> ${STRIPPED_PULLSPEC}"
+else
+    STRIPPED_PULLSPEC="${image_url}"
+    echo "No tag or digest found, using original as is: ${STRIPPED_PULLSPEC}"
+fi
+
+COMPLETE_PULLSPEC="${STRIPPED_PULLSPEC}@${image_shasum}"
+echo "New complete pullspec: ${COMPLETE_PULLSPEC}"
+
+DOCKER_CONFIG="$(mktemp -d)"
+export DOCKER_CONFIG
+
+yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
+    "${managed_secrets_yaml}" | base64 -d > "${DOCKER_CONFIG}/config.json"
+
+if skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
+    echo "✅️ Image '${COMPLETE_PULLSPEC}' can be pulled using skopeo."
+else
+    echo "🔴 Failed to pull or inspect image '${COMPLETE_PULLSPEC}'."
+    skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}"
+    exit 1
+fi


### PR DESCRIPTION
## Describe your changes
add image shasum and skopeo pull verification to the rhtap-service-push e2e test

**image_shasum extraction and check:**
- Reads .status.artifacts.images[0].shasum from the Release JSON, the same field used by push-to-external-registry.
- Fails the release check if the value is empty.

**skopeo inspect verification:**
- Only runs when both image_url and image_shasum are non-empty (avoids a redundant failure when the earlier checks already caught empty values).
- Strips any existing tag or digest from image_url to get a bare registry/repository path, then appends @${image_shasum} to build a canonical digest pullspec (e.g. quay.io/hacbs-release-tests/osd-addons/e2e-component-index@sha256:abc123...).
- Extracts the Docker credentials from the decrypted managed-secrets.yaml (same pattern used by push-to-external-registry) into a temp DOCKER_CONFIG dir so skopeo can authenticate.
- Runs skopeo inspect --tls-verify=true on the digest pullspec; on failure, re-runs without &>/dev/null to surface the full error in the test log.
- Counts as one failure toward the per-release failures counter, consistent with the existing pattern.

## Relevant Jira
[RELEASE-2327](https://redhat.atlassian.net/browse/RELEASE-2327)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


[RELEASE-2327]: https://redhat.atlassian.net/browse/RELEASE-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ