### PR TITLE
fix(RELEASE-2363): handle Helm OCI artifacts in rh-sign-image

### DIFF
--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -280,8 +280,12 @@ spec:
             MEDIATYPE="$(jq -r '.mediaType' <<< "$RAW_OUTPUT")"
             if [ "$MEDIATYPE" != "application/vnd.oci.image.manifest.v1+json" ] && \
                [ "$MEDIATYPE" != "application/vnd.docker.distribution.manifest.v2+json" ]; then
-              nested_digests=$(jq -r '[.manifests[].digest] | join(" ")' <<< "$RAW_OUTPUT")
-              manifest_digests="$manifest_digests $nested_digests"
+              if jq -e '.manifests' <<< "$RAW_OUTPUT" > /dev/null 2>&1; then
+                nested_digests=$(jq -r '[.manifests[].digest] | join(" ")' <<< "$RAW_OUTPUT")
+                manifest_digests="$manifest_digests $nested_digests"
+              else
+                echo "Single-manifest artifact (e.g. Helm chart), no nested digests to add"
+              fi
             fi
             echo "MANIFEST DIGESTS: ${manifest_digests}"
 

--- a/tasks/managed/rh-sign-image/tests/mocks.sh
+++ b/tasks/managed/rh-sign-image/tests/mocks.sh
@@ -262,12 +262,32 @@ function skopeo() {
                   }
               '
           else
-            if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image"*":sha256-"*".src"* ]]
+            if [[ "$*" == "inspect --retry-times 3 --no-tags --raw docker://registry.io/helm-chart"* ]]
             then
-              echo "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1"
+              echo '{
+                      "schemaVersion": 2,
+                      "config": {
+                        "mediaType": "application/vnd.cncf.helm.config.v1+json",
+                        "digest": "sha256:helmconfigabc123",
+                        "size": 141
+                      },
+                      "layers": [
+                        {
+                          "mediaType": "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+                          "digest": "sha256:helmlayerdef456",
+                          "size": 4567
+                        }
+                      ]
+                    }
+                '
             else
-              echo Error: Unexpected call
-              exit 1
+              if [[ "$*" == "inspect --no-tags --format {{.Digest}} docker://registry.io/image"*":sha256-"*".src"* ]]
+              then
+                echo "sha256:9e8f9c7bdce16d2e9ebf93b84d3f8df9821ab74f8c2bf73446e8828f936c9db1"
+              else
+                echo Error: Unexpected call
+                exit 1
+              fi
 	    fi
 	  fi
         fi

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-helm-chart.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-helm-chart.yaml
@@ -1,0 +1,270 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-helm-chart
+spec:
+  description: Test signing a Helm OCI chart (single-manifest artifact, no .manifests array)
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "helm-comp0",
+                    "source": {
+                      "git": {
+                        "revision": "deadbeef"
+                      }
+                    },
+                    "containerImage": "registry.io/helm-chart0@sha256:h000",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/myproduct----myrepo",
+                        "rh-registry-repo": "registry.redhat.io/myproduct/myrepo",
+                        "registry-access-repo": "registry.access.redhat.com/myproduct/myrepo",
+                        "tags": [
+                          "0.1.0"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": "false"
+                  }
+                },
+                "sign": {
+                  "configMapName": "signing-config-map"
+                }
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release_plan_admission.json" << EOF
+              {
+                "spec": {
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "https://localhost.git"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipelines/abc/abc.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "release-service-account"
+                  }
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/signRegistryAccess.txt" << EOF
+              myproduct/myrepo
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: rh-sign-image
+      params:
+        - name: requester
+          value: testuser-helm
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: releasePlanAdmissionPath
+          value: $(context.pipelineRun.uid)/release_plan_admission.json
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: signRegistryAccessPath
+          value: $(context.pipelineRun.uid)/signRegistryAccess.txt
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              internalRequests="$(kubectl get internalrequest -o json --sort-by=.metadata.creationTimestamp | jq -c)"
+              irsLength=$(jq ".items | length" <<< "${internalRequests}" )
+
+              # Helm chart: only the top-level digest is signed, no nested manifests, no source container
+              expectedReferences=()
+              expectedReferences+=("registry.redhat.io/myproduct/myrepo:0.1.0")
+              expectedReferences+=("registry.access.redhat.com/myproduct/myrepo:0.1.0")
+
+              expectedDigests=()
+              expectedDigests+=("sha256:h000")
+              expectedDigests+=("sha256:h000")
+
+              foundReferences=()
+              foundDigests=()
+              for((ir=0; ir<irsLength; ir++)); do
+                params=$(jq -r ".items[$ir].spec.params" <<< "${internalRequests}")
+                requestRefs=$(jq -r '.references' <<< "${params}")
+                manifestDigest=$(jq -r '.manifest_digests' <<< "${params}")
+                for ref in $requestRefs; do
+                  foundReferences+=("${ref}")
+                done
+                for digest in $manifestDigest; do
+                  foundDigests+=("${digest}")
+                done
+
+                if [ "$(jq -r '.config_map_name' <<< "${params}")" != "signing-config-map" ]; then
+                  echo "config_map_name does not match"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.requester' <<< "${params}")" != "testuser-helm" ]; then
+                  echo "requester does not match"
+                  exit 1
+                fi
+              done
+
+              differenceReferences=$(echo "${expectedReferences[@]}" "${foundReferences[@]}" | tr ' ' '\n' | \
+                sort | uniq -u)
+              differenceDigests=$(echo "${expectedDigests[@]}" "${foundDigests[@]}" | tr ' ' '\n' | sort | uniq -u)
+
+              if [ -n "${differenceReferences}" ] ; then
+                echo "error: references expected compared to found do not match"
+                echo ""
+                echo "${differenceReferences}"
+                exit 1
+              fi
+              if [ -n "${differenceDigests}" ] ; then
+                echo "error: digests expected compared to found do not match"
+                echo ""
+                echo "${differenceDigests}"
+                exit 1
+              fi
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
Prevents a failure that will occur when signing Helm OCI charts that have no .manifests array. The task now checks for the key before iterating, so single-manifest artifacts like Helm charts sign only the top-level digest instead of failing with a jq null iteration error.

Related PRs for RELEASE-2363

add Helm OCI chart release pipeline https://github.com/konflux-ci/release-service-catalog/pull/2099
add validate-helm-chart-snapshot https://github.com/konflux-ci/release-service-catalog/pull/2100
add processHelmCharts param to create-pyxis-image https://github.com/konflux-ci/release-service-catalog/pull/2101
handle Helm OCI artifacts in rh-sign-image https://github.com/konflux-ci/release-service-catalog/pull/2097


Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
