### PR TITLE
feat(RELEASE-2363): add validate-helm-chart-snapshot task

### DIFF
--- a/tasks/managed/validate-helm-chart-snapshot/README.md
+++ b/tasks/managed/validate-helm-chart-snapshot/README.md
@@ -1,0 +1,23 @@
+# validate-helm-chart-snapshot
+
+Validates that each component in the mapped snapshot is a Helm OCI artifact and that release tags and
+destination repository names match chart metadata from the OCI manifest (annotations). Compares
+org.opencontainers.image.version to each repository tag using Helm's OCI convention (first underscore in a
+tag corresponds to SemVer build-metadata plus). Compares org.opencontainers.image.title to the basename of
+each mapped repository URL (path after converting ---- to /).
+
+## Parameters
+
+| Name                    | Description                                                                                                                | Optional | Default value        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
+| snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                   |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                   |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions are stored                                 | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                    |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca           |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt        |

--- a/tasks/managed/validate-helm-chart-snapshot/tests/mocks.sh
+++ b/tasks/managed/validate-helm-chart-snapshot/tests/mocks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Mock skopeo for integration tests (prepended by pre-apply-task-hook.sh).
+skopeo() {
+  if [[ "${1:-}" == "inspect" ]]; then
+    local image_ref="${*##*docker://}"
+    if [[ "$image_ref" == *"/myimage@"* ]]; then
+      cat <<'MOCKJSON'
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "size": 200
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "size": 5000
+    }
+  ]
+}
+MOCKJSON
+    else
+      cat <<'MOCKJSON'
+{
+  "schemaVersion": 2,
+  "config": {
+    "mediaType": "application/vnd.cncf.helm.config.v1+json",
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "size": 100
+  },
+  "layers": [],
+  "annotations": {
+    "org.opencontainers.image.title": "mychart",
+    "org.opencontainers.image.version": "1.0.0+buildmeta"
+  }
+}
+MOCKJSON
+    fi
+    return 0
+  fi
+  echo "unexpected skopeo invocation: $*" >&2
+  exit 1
+}

--- a/tasks/managed/validate-helm-chart-snapshot/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/validate-helm-chart-snapshot/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+yq -i '.spec.steps[1].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[1].script' "$TASK_PATH"

--- a/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-fail-not-helm.yaml
+++ b/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-fail-not-helm.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-helm-chart-snapshot-fail-not-helm
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run validate-helm-chart-snapshot with a regular container image (not a Helm chart).
+    The task should fail because config.mediaType is application/vnd.oci.image.config.v1+json
+    instead of application/vnd.cncf.helm.config.v1+json.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: ""
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: add-snapshot
+            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mapped.json" << 'EOF'
+              {
+                "application": "container-app",
+                "components": [
+                  {
+                    "name": "myimage",
+                    "containerImage": "quay.io/tenant/myimage@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/acme----myimage",
+                        "tags": ["1.0.0"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: validate-helm-chart-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-fail-tag-mismatch.yaml
+++ b/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-fail-tag-mismatch.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-helm-chart-snapshot-fail-tag-mismatch
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run validate-helm-chart-snapshot with a tag that does not match the chart version
+    (tag "0.2.0" vs chart version "1.0.0+buildmeta"). The task should fail.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: ""
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: add-snapshot
+            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mapped.json" << 'EOF'
+              {
+                "application": "helm-app",
+                "components": [
+                  {
+                    "name": "mychart",
+                    "containerImage": "quay.io/tenant/mychart@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/acme----mychart",
+                        "tags": ["0.2.0"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: validate-helm-chart-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-fail-title-mismatch.yaml
+++ b/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-fail-title-mismatch.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-helm-chart-snapshot-fail-title-mismatch
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run validate-helm-chart-snapshot with a repository whose basename does not match
+    the chart title from OCI annotations (repo basename "wrong-name" vs chart title
+    "mychart"). The task should fail.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: ""
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: add-snapshot
+            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mapped.json" << 'EOF'
+              {
+                "application": "helm-app",
+                "components": [
+                  {
+                    "name": "mychart",
+                    "containerImage": "quay.io/tenant/mychart@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/acme----wrong-name",
+                        "tags": ["1.0.0_buildmeta"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: validate-helm-chart-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-success.yaml
+++ b/tasks/managed/validate-helm-chart-snapshot/tests/test-validate-helm-chart-snapshot-success.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-validate-helm-chart-snapshot-success
+spec:
+  description: |
+    Run validate-helm-chart-snapshot with a mapped Helm snapshot; skopeo is mocked.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: ""
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: "/var/workdir/release"
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: add-snapshot
+            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mapped.json" << 'EOF'
+              {
+                "application": "helm-app",
+                "components": [
+                  {
+                    "name": "mychart",
+                    "containerImage": "quay.io/tenant/mychart@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/acme----mychart",
+                        "tags": ["1.0.0_buildmeta"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: validate-helm-chart-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/validate-helm-chart-snapshot/validate-helm-chart-snapshot.yaml
+++ b/tasks/managed/validate-helm-chart-snapshot/validate-helm-chart-snapshot.yaml
@@ -1,0 +1,200 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: validate-helm-chart-snapshot
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Validates that each component in the mapped snapshot is a Helm OCI artifact and that release tags and
+    destination repository names match chart metadata from the OCI manifest (annotations). Compares
+    org.opencontainers.image.version to each repository tag using Helm's OCI convention (first underscore in a
+    tag corresponds to SemVer build-metadata plus). Compares org.opencontainers.image.title to the basename of
+    each mapped repository URL (path after converting ---- to /).
+  params:
+    - name: snapshotPath
+      description: Path to the JSON string of the mapped Snapshot spec in the data workspace
+      type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/release
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+    securityContext:
+      runAsUser: 1001
+  steps:
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+          cpu: 30m
+        requests:
+          memory: 64Mi
+          cpu: 30m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: validate-helm-chart-snapshot
+      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 500m
+        requests:
+          memory: 256Mi
+          cpu: 500m
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        if [ ! -f "${SNAPSHOT_FILE}" ]; then
+          echo "No snapshot file at ${SNAPSHOT_FILE}" >&2
+          exit 1
+        fi
+
+        # Map OCI tag to SemVer: registry tags cannot contain '+'; Helm uses first '_' as build-metadata separator.
+        oci_tag_to_version() {
+          local t="$1"
+          if [[ "$t" == *_* ]]; then
+            echo "${t/_/+}"
+          else
+            echo "$t"
+          fi
+        }
+
+        # Basename of delivery repo path (after ---- to /), last segment.
+        delivery_repo_basename() {
+          local url="$1"
+          local path
+          path="${url#*/}"
+          path="${path//----/\/}"
+          echo "${path##*/}"
+        }
+
+        num_components=$(jq '.components | length' "${SNAPSHOT_FILE}")
+        for ((i = 0; i < num_components; i++)); do
+          component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_FILE}")
+          name=$(jq -r '.name' <<< "$component")
+          container_image=$(jq -r '.containerImage' <<< "$component")
+
+          raw=$(skopeo inspect --retry-times 3 --raw "docker://${container_image}")
+          config_mt=$(jq -r '.config.mediaType // empty' <<< "$raw")
+          if [[ "$config_mt" != "application/vnd.cncf.helm.config.v1+json" ]]; then
+            echo "Error: component (${name}) is not a Helm OCI artifact (mediaType: ${config_mt})" >&2
+            exit 1
+          fi
+
+          title=$(jq -r '.annotations["org.opencontainers.image.title"] // empty' <<< "$raw")
+          version=$(jq -r '.annotations["org.opencontainers.image.version"] // empty' <<< "$raw")
+          if [[ -z "$title" || -z "$version" ]]; then
+            echo "Error: component (${name}) Helm manifest missing org.opencontainers.image.title" \
+              "(${title}) or org.opencontainers.image.version (${version}) annotations" >&2
+            exit 1
+          fi
+
+          num_repos=$(jq '.repositories | length' <<< "$component")
+          if [[ "$num_repos" -eq 0 ]]; then
+            echo "Error: component (${name}) has no repositories" >&2
+            exit 1
+          fi
+          for ((j = 0; j < num_repos; j++)); do
+            repo=$(jq -c --argjson j "$j" '.repositories[$j]' <<< "$component")
+            url=$(jq -r '.url' <<< "$repo")
+            url="${url%:*}"
+
+            expected_basename=$(delivery_repo_basename "$url")
+            if [[ "$title" != "$expected_basename" ]]; then
+              echo "Error: component (${name}) chart title (${title}) does not match delivery" \
+                "repository basename (${expected_basename})" >&2
+              exit 1
+            fi
+
+            num_tags=$(jq '.tags | length' <<< "$repo")
+            if [[ "$num_tags" -eq 0 ]]; then
+              echo "Error: component (${name}) repository (${url}) has no tags" >&2
+              exit 1
+            fi
+            for ((k = 0; k < num_tags; k++)); do
+              tag=$(jq -r --argjson k "$k" '.tags[$k]' <<< "$repo")
+              mapped=$(oci_tag_to_version "$tag")
+              if [[ "$mapped" != "$version" ]]; then
+                echo "Error: component (${name}) tag (${tag}) normalized to (${mapped}) does not match" \
+                  "chart version (${version})" >&2
+                exit 1
+              fi
+            done
+          done
+          echo "Validated Helm OCI artifact for component (${name}) chart (${title}) version (${version})"
+        done


### PR DESCRIPTION
New task that validates mapped snapshots contain valid Helm OCI artifacts. Checks chart title matches delivery repository basename and release tags match org.opencontainers.image.version using Helm's underscore-to-plus normalization convention.

Related PRs for RELEASE-2363

add Helm OCI chart release pipeline https://github.com/konflux-ci/release-service-catalog/pull/2099
add validate-helm-chart-snapshot https://github.com/konflux-ci/release-service-catalog/pull/2100
add processHelmCharts param to create-pyxis-image https://github.com/konflux-ci/release-service-catalog/pull/2101
handle Helm OCI artifacts in rh-sign-image https://github.com/konflux-ci/release-service-catalog/pull/2097

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
