### PR TITLE
chore: tune Qodo PR-Agent to reduce comment noise

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -33,6 +33,8 @@ extra_instructions = """
 commitable_code_suggestions = true
 # Limit inline suggestions to 3 per PR.
 num_code_suggestions_per_chunk = 3
+# Reuse a single comment rather than adding a new one on each push.
+persistent_comment = true
 extra_instructions = """
 - Before suggesting a change, verify whether the PR/task already includes it (or equivalent logic). If it already exists, do not suggest it.
 - Do not repeat previously rejected suggestions in subsequent updates of the same PR if the thread was resolved without action.


### PR DESCRIPTION
Reuse a single comment for /improve suggestions rather than adding
a new one on each push, reducing noise in PRs.


Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
