### PR TITLE
fix(prepare-and-finalize-artifacts): fix oras mock arg parsing

### DIFF
--- a/tasks/managed/prepare-and-finalize-artifacts/tests/mocks.sh
+++ b/tasks/managed/prepare-and-finalize-artifacts/tests/mocks.sh
@@ -9,13 +9,34 @@ if [ "$COMMAND" = "pull" ]; then
 elif [ "$COMMAND" = "push" ]; then
     echo "Mock 'oras push' called. Validating arguments..."
     EXPECTED_TARGET="mock.registry/test-repo/my-artifact"
-    if [ "$6" != "$EXPECTED_TARGET" ]; then
-        echo "ERROR: Mock oras expected target '$EXPECTED_TARGET' (at \$6) but got '$6'"
+    EXPECTED_SOURCE_NAME="sourceDataArtifact"
+    shift # remove "push"
+    POSITIONAL_ARGS=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --registry-config|--ca-file|--annotation)
+                shift 2
+                ;;
+            --*=*)
+                shift
+                ;;
+            --*)
+                shift
+                ;;
+            *)
+                POSITIONAL_ARGS="$POSITIONAL_ARGS $1"
+                shift
+                ;;
+        esac
+    done
+    ACTUAL_TARGET=$(echo $POSITIONAL_ARGS | awk '{print $1}')
+    ACTUAL_SOURCE=$(echo $POSITIONAL_ARGS | awk '{print $2}')
+    if [ "$ACTUAL_TARGET" != "$EXPECTED_TARGET" ]; then
+        echo "ERROR: Mock oras expected target '$EXPECTED_TARGET' but got '$ACTUAL_TARGET'"
         exit 1
     fi
-    EXPECTED_SOURCE_NAME="sourceDataArtifact"
-    if [ "$7" != "$EXPECTED_SOURCE_NAME" ]; then
-        echo "ERROR: Mock oras expected source '$EXPECTED_SOURCE_NAME' (at \$7) but got '$7'"
+    if [ "$ACTUAL_SOURCE" != "$EXPECTED_SOURCE_NAME" ]; then
+        echo "ERROR: Mock oras expected source '$EXPECTED_SOURCE_NAME' but got '$ACTUAL_SOURCE'"
         exit 1
     fi
     echo "SUCCESS: Mock oras push validated."


### PR DESCRIPTION
- The mock oras script in \`mocks.sh\` used hardcoded argument positions (\$6/\$7) to validate push target and source
- Since RELEASE-2177 (commit 8cfcf88) updated the \`create-trusted-artifact\` StepAction image, \`oras push\` now includes \`--registry-config\` and \`--ca-file\` flags which shifted argument positions
- This was not caught earlier because CI only runs task tests for changed files under \`tasks/\`, and the StepAction update was under \`stepactions/\`
- Replaced hardcoded positions with argument scanning that handles any number of flags

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
