### PR TITLE
feat(RELEASE-2209): add support for utils e2e testing

### DIFF
--- a/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
@@ -180,14 +180,11 @@ spec:
               echo "PR_GIT_REVISION: $(params.PR_GIT_REVISION)"
               if [ -n "${PR_NUMBER}" ]; then
                 echo "PR_NUMBER: ${PR_NUMBER}"
+              elif [ -n "${BRANCH_NAME}" ]; then
+                echo "This is not a PR, but a merge queue branch"
+                echo "BRANCH_NAME: ${BRANCH_NAME}"
               else
-                if [ -n "${BRANCH_NAME}" ]; then
-                  echo "This is not a PR, but a merge queue branch"
-                  echo "BRANCH_NAME: ${BRANCH_NAME}"
-                else
-                  echo "No PR_NUMBER or BRANCH_NAME environment variables found"
-                  exit 1
-                fi
+                echo "No PR_NUMBER or BRANCH_NAME; using SNAPSHOT git URL and revision (e.g. utils-e2e temp fork)"
               fi
 
               VAULT_PASSWORD_FILE=$(mktemp)
@@ -210,9 +207,17 @@ spec:
               if [ -n "${PR_NUMBER}" ]; then
                 AFFECTED_PIPELINES=$("/home/e2e/tests/scripts/find_release_pipelines_from_pr.sh" \
                   --repo "konflux-ci/release-service-catalog" --pull_request_number "${PR_NUMBER}")
-              else
+              elif [ -n "${BRANCH_NAME}" ]; then
                 AFFECTED_PIPELINES=$("/home/e2e/tests/scripts/find_release_pipelines_from_pr.sh" \
                   --repo "konflux-ci/release-service-catalog" --branch "${BRANCH_NAME}")
+              else
+                # utils-e2e: PR_GIT_URL is https://github.com/OWNER/REPO from clone-push
+                # PR_GIT_REVISION is the patched branch.
+                CATALOG_REPO_SLUG="$(params.PR_GIT_URL)"
+                CATALOG_REPO_SLUG="${CATALOG_REPO_SLUG#https://github.com/}"
+                CATALOG_REPO_SLUG="${CATALOG_REPO_SLUG%.git}"
+                AFFECTED_PIPELINES=$("/home/e2e/tests/scripts/find_release_pipelines_from_pr.sh" \
+                  --repo "${CATALOG_REPO_SLUG}" --branch "$(params.PR_GIT_REVISION)")
               fi
 
               # if PIPELINE_USED is set, use it, otherwise use PIPELINE_TEST_SUITE
@@ -226,11 +231,18 @@ spec:
               # check if PIPELINE is found as an affected pipeline
               if string_has_word "${PIPELINE}" "${AFFECTED_PIPELINES}" || \
                 [[ "${AFFECTED_PIPELINES}" == "release-pipelines" ]]; then
-                echo "This Test Suite is affected by changes in PR ${PR_NUMBER}"
-  
+                if [ -n "${PR_NUMBER}" ]; then
+                  echo "This Test Suite is affected by changes in PR ${PR_NUMBER}"
+                else
+                  echo "This Test Suite is in the affected set for this catalog revision (${AFFECTED_PIPELINES})"
+                fi
                 "/home/e2e/tests/run-test.sh" "$(params.PIPELINE_TEST_SUITE)"
               else
-                echo "This Test Suite is not affected by changes in PR ${PR_NUMBER}"
+                if [ -n "${PR_NUMBER}" ]; then
+                  echo "This Test Suite is not affected by changes in PR ${PR_NUMBER}"
+                else
+                  echo "This Test Suite is not in the affected set (${AFFECTED_PIPELINES})"
+                fi
                 exit 99
               fi
 

--- a/integration-tests/scripts/find_release_pipelines_from_pr.sh
+++ b/integration-tests/scripts/find_release_pipelines_from_pr.sh
@@ -48,9 +48,13 @@ _find_and_process_pipelines() {
   # Find all tasks and pipelines and save them to arrays
   find_changed_tekton_tasks_pipelines
 
+  _emit_integration_testcase_string
+  cleanup_workspace
+}
+
+_emit_integration_testcase_string() {
   if [ "$SELECT_ALL_TESTCASES" = true ]; then
     echo -n "release-pipelines"
-    cleanup_workspace
     return 0
   fi
 
@@ -115,7 +119,7 @@ _find_and_process_pipelines() {
     done <<< $TEKTON_COLLECTOR_PIPELINES
   fi
 
-  declare -a TEMP_MANAGED_PIPELINENAMES
+  declare -a TEMP_MANAGED_PIPELINENAMES=()
 
   # Map internal and collector pipelines to managed pipelines
   for pipeline_name in "${FOUND_INTERNAL_PIPELINENAMES[@]} ${FOUND_COLLECTOR_PIPELINENAMES[@]}"; do
@@ -202,7 +206,7 @@ _find_and_process_pipelines() {
   "rhtap-service-push" "rh-push-to-registry-redhat-io" "rh-push-to-external-registry" "push-to-addons-registry" \
   "push-rpms-to-pulp")
 
-  SELECTED_TESTCASES=()
+  declare -a SELECTED_TESTCASES=()
 
   for pplname in "${FOUND_PIPELINENAMES[@]}"; do
     for tc in "${ALL_TESTCASES[@]}"; do
@@ -216,8 +220,6 @@ _find_and_process_pipelines() {
   else
     echo -n "no-test-case"
   fi
-
-  cleanup_workspace
 }
 
 setup_workspace() {
@@ -263,6 +265,65 @@ clone_and_checkout_branch() {
   fi
 }
 
+# Classify one repo-relative path (git diff line or stdin line) into the TEKTON_* / INTEGRATION_SUITES
+# globals. Trims whitespace and strips a leading ./. Expects cwd = catalog repo root.
+# Returns 1 if the caller should stop processing further paths (SELECT_ALL_TESTCASES); 0 otherwise.
+_accumulate_one_catalog_changed_path() {
+  local file=$1
+  file="${file#"${file%%[![:space:]]*}"}"
+  file="${file%"${file##*[![:space:]]}"}"
+  [ -z "$file" ] && return 0
+  file="${file#./}"
+
+  # match the files under stepactions
+  if echo "$file" | grep -q "^stepactions/"; then
+    SELECT_ALL_TESTCASES=true
+    return 1
+  elif [[ "$file" =~ ^schema/dataKeys.json$ ]] && [ -f "$file" ]; then
+    SELECT_ALL_TESTCASES=true
+    return 1
+  elif echo "$file" | grep -q "^integration-tests/"; then
+    # Check if the file is in lib/, scripts/, or is run-test.sh - these should trigger all test suites
+    if echo "$file" | grep -q -E "^integration-tests/(lib|scripts)/|^integration-tests/run-test\.sh$"; then
+      SELECT_ALL_TESTCASES=true
+      return 1
+    else
+      local filename
+      filename=$(basename "$file")
+      if [[ ! $filename =~ \.md$ ]]; then
+        local -a parts
+        IFS='/' read -ra parts <<< "$file"
+        INTEGRATION_SUITES+=("${parts[1]}")
+      fi
+    fi
+  elif [[ "$file" =~ ^tasks/internal/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
+    if grep -q -E 'kind: *Task' "$file"; then
+      TEKTON_INTERNAL_TASKS+=("$file")
+    fi
+  elif [[ "$file" =~ ^tasks/collectors/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
+    if grep -q -E 'kind: *Task' "$file"; then
+      TEKTON_COLLECTOR_TASKS+=("$file")
+    fi
+  elif [[ "$file" =~ ^tasks/managed/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
+    if grep -q -E 'kind: *Task' "$file"; then
+      TEKTON_MANAGED_TASKS+=("$file")
+    fi
+  elif [[ "$file" =~ ^pipelines/managed/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
+    if grep -q -E 'kind: *Pipeline' "$file"; then
+      TEKTON_MANAGED_PIPELINES+=("$file")
+    fi
+  elif [[ "$file" =~ ^pipelines/internal/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
+    if grep -q -E 'kind: *Pipeline' "$file"; then
+      TEKTON_INTERNAL_PIPELINES+=("$file")
+    fi
+  elif [[ "$file" =~ ^pipelines/run-collectors/run-collectors.yaml$ ]] && [ -f "$file" ]; then
+    if grep -q -E 'kind: *Pipeline' "$file"; then
+      TEKTON_COLLECTOR_PIPELINES+=("$file")
+    fi
+  fi
+  return 0
+}
+
 find_changed_tekton_tasks_pipelines() {
   local FILES
   FILES=$(git diff --name-only origin/development...HEAD)
@@ -273,51 +334,43 @@ find_changed_tekton_tasks_pipelines() {
   fi
 
   while IFS= read -r file; do
-    # match the files under stepactions
-    if echo "$file" | grep -q "^stepactions/"; then
-      SELECT_ALL_TESTCASES=true
-      break
-    elif [[ "$file" =~ ^schema/dataKeys.json$ ]] && [ -f "$file" ]; then
-      SELECT_ALL_TESTCASES=true
-      break
-    elif echo "$file" | grep -q "^integration-tests/"; then
-      # Check if the file is in lib/, scripts/, or is run-test.sh - these should trigger all test suites
-      if echo "$file" | grep -q -E "^integration-tests/(lib|scripts)/|^integration-tests/run-test\.sh$"; then
-        SELECT_ALL_TESTCASES=true
-        break
-      else
-        filename=$(basename "$file")
-        if [[ ! $filename =~ \.md$ ]]; then
-          IFS='/' read -ra parts <<< "$file"
-          INTEGRATION_SUITES+=("${parts[1]}")
-        fi
-      fi
-    elif [[ "$file" =~ ^tasks/internal/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
-      if grep -q -E 'kind: *Task' "$file"; then
-        TEKTON_INTERNAL_TASKS+=("$file")
-      fi
-    elif [[ "$file" =~ ^tasks/collectors/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
-      if grep -q -E 'kind: *Task' "$file"; then
-        TEKTON_COLLECTOR_TASKS+=("$file")
-      fi
-    elif [[ "$file" =~ ^tasks/managed/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
-      if grep -q -E 'kind: *Task' "$file"; then
-        TEKTON_MANAGED_TASKS+=("$file")
-      fi
-    elif [[ "$file" =~ ^pipelines/managed/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
-      if grep -q -E 'kind: *Pipeline' "$file"; then
-        TEKTON_MANAGED_PIPELINES+=("$file")
-      fi
-    elif [[ "$file" =~ ^pipelines/internal/[^/]+/[^/]+\.ya?ml$ ]] && [ -f "$file" ]; then
-      if grep -q -E 'kind: *Pipeline' "$file"; then
-        TEKTON_INTERNAL_PIPELINES+=("$file")
-      fi
-    elif [[ "$file" =~ ^pipelines/run-collectors/run-collectors.yaml$ ]] && [ -f "$file" ]; then
-      if grep -q -E 'kind: *Pipeline' "$file"; then
-        TEKTON_COLLECTOR_PIPELINES+=("$file")
-      fi
-    fi
+    _accumulate_one_catalog_changed_path "$file" || break
   done <<< "$FILES"
+}
+
+# Paths come from stdin (one repo-relative path per line). Expects cwd = catalog repo root.
+find_changed_tekton_tasks_pipelines_from_stdin() {
+  local file
+  while IFS= read -r file; do
+    _accumulate_one_catalog_changed_path "$file" || break
+  done
+}
+
+# Internal: read catalog Task/pipeline paths on stdin (one per line). Prints testcase tokens in the
+# same format as the PR/branch workflow (via _emit_integration_testcase_string): space-separated,
+# or no-test-case. First argument: catalog root. Source this file, then call (or use from tooling).
+_catalog_stdin_task_paths_to_testcase_tokens() {
+  local CATALOG_ROOT=$1
+  if [ -z "${CATALOG_ROOT}" ] || [ ! -d "${CATALOG_ROOT}" ]; then
+    echo "_catalog_stdin_task_paths_to_testcase_tokens: catalog root not found: ${CATALOG_ROOT:-}" >&2
+    return 1
+  fi
+  (
+    cd "${CATALOG_ROOT}" || exit 1
+    declare -a FOUND_PIPELINENAMES=()
+    declare -a FOUND_INTERNAL_PIPELINENAMES=()
+    declare -a FOUND_COLLECTOR_PIPELINENAMES=()
+    declare -a TEKTON_INTERNAL_TASKS=()
+    declare -a TEKTON_COLLECTOR_TASKS=()
+    declare -a TEKTON_MANAGED_TASKS=()
+    declare -a TEKTON_MANAGED_PIPELINES=()
+    declare -a TEKTON_INTERNAL_PIPELINES=()
+    declare -a TEKTON_COLLECTOR_PIPELINES=()
+    declare -a INTEGRATION_SUITES=()
+    declare SELECT_ALL_TESTCASES=false
+    find_changed_tekton_tasks_pipelines_from_stdin
+    _emit_integration_testcase_string
+  )
 }
 
 find_pipelines_using_task() {
@@ -470,5 +523,7 @@ main() {
   fi
 }
 
-# Execute main function with all arguments
-main "$@"
+# Run CLI only when this file is executed; when sourced, library functions are loaded and main is skipped.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
This commit adds additional helper functions to
find_release_pipelines_from_pr.sh to help enable running the catalog e2e test suites from the utils repo.

It also modifies the e2e-tests-staging-pipeline file to support release-service-catalog forks, as that is how the utils e2e will be executed.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
