### PR TITLE
chore: interactive mode for testing release pipelines

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -90,6 +90,8 @@ Example:
 ### Command Line Options
 
 - **`--skip-cleanup`** or **`-sc`** - Skip cleanup operations after test completion (useful for debugging)
+- **`--no-cve`** or **`-nocve`** - Skip CVE simulation in commit messages and release verification
+- **`--interactive`** or **`-i`** - Enable interactive mode for iterative debugging (see [Interactive Mode](#interactive-mode))
 
 ### Examples
 
@@ -99,6 +101,9 @@ Example:
 
 # Run test with debugging (skip cleanup)
 ./run-test.sh fbc-release --skip-cleanup
+
+# Run test in interactive mode
+./run-test.sh push-rpms-to-pulp --interactive
 ```
 
 ## Debugging
@@ -110,6 +115,44 @@ When debugging test failures, use the `--skip-cleanup` option to preserve resour
 ```bash
 ./run-test.sh <test-suite-name> --skip-cleanup
 ```
+
+### Interactive Mode
+
+Interactive mode (`-i` or `--interactive`) provides an iterative development experience for debugging release pipeline failures. When a release fails, instead of immediately exiting, the test pauses and presents an interactive menu:
+
+```
+🛑 Interactive Mode - Test paused
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  [r] Retry    - Create new Release with same snapshot
+  [i] Info     - Show release context again
+  [s] Shell    - Drop into bash shell (exit to return)
+  [c] Cleanup  - Run cleanup and exit
+  [q] Quit     - Exit without cleanup (keep resources)
+```
+
+**Key Features:**
+
+- **Retry (`r`)**: Creates a new Release CR using the same snapshot. This is useful when you've fixed the underlying pipeline code and want to re-test without rebuilding RPMs or recreating the entire test environment.
+- **Info (`i`)**: Displays release context including the Release name, Snapshot, ReleasePlan, managed PipelineRun URL (clickable link to OpenShift console), and namespace information.
+- **Shell (`s`)**: Drops into an interactive bash shell with useful environment variables pre-set (`RELEASE_NAME`, `RELEASE_NAMESPACE`, `tenant_namespace`, `managed_namespace`). Type `exit` to return to the menu.
+- **Cleanup (`c`)**: Runs the normal cleanup process and exits.
+- **Quit (`q`)**: Exits immediately without cleanup, preserving all resources for later debugging.
+
+**Example Usage:**
+
+```bash
+# Run test in interactive mode for pipeline development
+./run-test.sh push-rpms-to-pulp -i
+
+# Combine with skip-cleanup for maximum flexibility
+./run-test.sh fbc-release --interactive --skip-cleanup
+```
+
+Interactive mode is particularly useful when:
+- Developing or debugging release pipeline tasks
+- Iterating on fixes without full test re-runs
+- Investigating failures that require manual inspection
 
 ### Manual Cleanup
 

--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -93,11 +93,11 @@ check_env_vars() {
 }
 
 # Function to parse script options
-# Modifies global variables: CLEANUP, NO_CVE
+# Modifies global variables: CLEANUP, NO_CVE, INTERACTIVE_MODE
 parse_options() {
     echo "Parsing script options..."
     local opts # Use local for getopt result storage
-    opts=$(getopt -l "skip-cleanup,no-cve" -o "sc,nocve" -a -- "$@")
+    opts=$(getopt -l "skip-cleanup,no-cve,interactive" -o "sc,nocve,i" -a -- "$@")
     if [ $? -ne 0 ]; then
         log_error "Failed to parse options."
     fi
@@ -113,6 +113,10 @@ parse_options() {
                 NO_CVE="true"
                 shift
                 ;;
+            -i|--interactive)
+                INTERACTIVE_MODE="true"
+                shift
+                ;;
             --)
                 shift
                 break
@@ -122,7 +126,7 @@ parse_options() {
                 ;;
         esac
     done
-    echo "Options parsed: CLEANUP=${CLEANUP}, NO_CVE=${NO_CVE}"
+    echo "Options parsed: CLEANUP=${CLEANUP}, NO_CVE=${NO_CVE}, INTERACTIVE_MODE=${INTERACTIVE_MODE:-false}"
 }
 
 # Function to get Build PipelineRun URL
@@ -551,21 +555,71 @@ wait_for_releases() {
     echo ""
     echo "✅ Found: $release_names"
 
+    export RELEASE_NAMESPACE=${tenant_namespace}
+    export RELEASE_NAMES="$release_names"
+
+    _wait_for_releases_internal
+}
+
+# Internal function to wait for releases with interactive retry support
+_wait_for_releases_internal() {
+    local release_failed=false
+    local failed_release=""
+
     RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
 
-    export RELEASE_NAMESPACE=${tenant_namespace}
-    for release in ${release_names};
-    do
+    for release in ${RELEASE_NAMES}; do
       export RELEASE_NAME=${release}
       "${SUITE_DIR}/../scripts/wait-for-release.sh" &
     done
 
-    # Wait for remaining processes to finish
+    # Wait for remaining processes to finish, tracking failures
+    set +e
     while (( ${RUNNING_JOBS@P} > 0 )); do
-        wait -n
+        if ! wait -n; then
+            release_failed=true
+            # Find which release failed by checking status
+            for rel in ${RELEASE_NAMES}; do
+                local status
+                status=$(kubectl get release "${rel}" -n "${RELEASE_NAMESPACE}" \
+                    -o jsonpath='{.status.conditions[?(@.type=="Released")].status}' 2>/dev/null || echo "")
+                if [ "$status" == "False" ]; then
+                    failed_release="${rel}"
+                    break
+                fi
+            done
+        fi
     done
+    set -e
 
-    export RELEASE_NAMES="$release_names"
+    if [ "$release_failed" == "true" ]; then
+        echo ""
+        echo "🔴 Release pipeline failed: ${failed_release:-unknown}"
+
+        if [ "${INTERACTIVE_MODE:-false}" == "true" ]; then
+            export RELEASE_NAME="${failed_release:-$(echo $RELEASE_NAMES | awk '{print $1}')}"
+            show_release_context "${RELEASE_NAME}" "${RELEASE_NAMESPACE}"
+
+            while true; do
+                local prompt_result
+                interactive_prompt "${RELEASE_NAME}" "${RELEASE_NAMESPACE}"
+                prompt_result=$?
+
+                if [ $prompt_result -eq 0 ]; then
+                    # Retry succeeded - update RELEASE_NAMES and re-verify
+                    echo "✅ Retry release completed"
+                    RELEASE_NAMES="${RETRY_RELEASE_NAME}"
+                    return 0
+                elif [ $prompt_result -eq 2 ]; then
+                    # User chose cleanup
+                    exit 1
+                fi
+                # Otherwise user chose quit without cleanup (handled in interactive_prompt)
+            done
+        else
+            exit 1
+        fi
+    fi
 }
 
 # Function to clean up old resources based on originating tool label
@@ -636,4 +690,248 @@ patch_component_source() {
 patch_component_source_before_merge() {
     echo "📝 Note: Test Suite may implement ${FUNCNAME[0]}" \
      "to patch the component source BEFORE MERGE in their test.sh file"
+}
+
+# --- Interactive Mode Functions ---
+# These functions support iterative development by pausing on failure
+# and allowing retries with the same snapshot.
+
+# Get Konflux UI URL for pipelineruns
+# Arguments: $1=namespace, $2=pipelinerun_name
+get_pipelinerun_console_url() {
+    local namespace="$1"
+    local pipelinerun_name="$2"
+    local application_name
+
+    # Get application name from pipelinerun labels
+    application_name=$(kubectl get pipelinerun/"${pipelinerun_name}" -n "${namespace}" \
+        -ojsonpath='{.metadata.labels.appstudio\.openshift\.io/application}' 2>/dev/null || true)
+
+    if [ -n "$application_name" ]; then
+        get_build_pipeline_run_url "${namespace}" "${application_name}" "${pipelinerun_name}"
+    else
+        echo "N/A (no application label found)"
+    fi
+}
+
+# Show context information for debugging
+# Arguments: $1=release_name, $2=release_namespace
+show_release_context() {
+    local release_name="${1:-$RELEASE_NAME}"
+    local release_namespace="${2:-$RELEASE_NAMESPACE}"
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "📋 Release Context"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    if [ -z "$release_name" ] || [ -z "$release_namespace" ]; then
+        echo "  ⚠️  Release name or namespace not available"
+        echo ""
+        return
+    fi
+
+    local release_json
+    release_json=$(kubectl get release/"${release_name}" -n "${release_namespace}" -ojson 2>/dev/null || echo "{}")
+
+    local snapshot_name release_plan_name managed_plr author
+    snapshot_name=$(jq -r '.spec.snapshot // "N/A"' <<< "$release_json")
+    release_plan_name=$(jq -r '.spec.releasePlan // "N/A"' <<< "$release_json")
+    managed_plr=$(jq -r '.status.managedProcessing.pipelineRun // "N/A"' <<< "$release_json")
+    author=$(jq -r '.metadata.labels["release.appstudio.openshift.io/author"] // .status.attribution.author // "N/A"' <<< "$release_json")
+
+    echo "  Release:        ${release_namespace}/${release_name}"
+    echo "  Snapshot:       ${snapshot_name}"
+    echo "  ReleasePlan:    ${release_plan_name}"
+    echo "  Author:         ${author}"
+    echo ""
+
+    if [ "$managed_plr" != "N/A" ] && [ "$managed_plr" != "null" ]; then
+        local managed_plr_name managed_plr_ns
+        managed_plr_name=$(basename "$managed_plr")
+        managed_plr_ns=$(echo "$managed_plr" | cut -d'/' -f1)
+        echo "  Managed PLR:    ${managed_plr_name}"
+        echo "  PLR URL:        $(get_pipelinerun_console_url "${managed_plr_ns}" "${managed_plr_name}")"
+    fi
+
+    echo ""
+    echo "  Tenant NS:      ${tenant_namespace:-N/A}"
+    echo "  Managed NS:     ${managed_namespace:-N/A}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+}
+
+# Create a new Release with the same snapshot
+# Arguments: $1=original_release_name, $2=release_namespace
+# Returns: new release name via RETRY_RELEASE_NAME global variable
+retry_release() {
+    local original_release_name="${1:-$RELEASE_NAME}"
+    local release_namespace="${2:-$RELEASE_NAMESPACE}"
+
+    if [ -z "$original_release_name" ] || [ -z "$release_namespace" ]; then
+        echo "🔴 Cannot retry: release name or namespace not set"
+        return 1
+    fi
+
+    local release_json
+    release_json=$(kubectl get release/"${original_release_name}" -n "${release_namespace}" -ojson 2>/dev/null)
+
+    if [ -z "$release_json" ]; then
+        echo "🔴 Cannot retry: could not fetch original release ${original_release_name}"
+        return 1
+    fi
+
+    local snapshot_name release_plan_name author
+    snapshot_name=$(jq -r '.spec.snapshot // ""' <<< "$release_json")
+    release_plan_name=$(jq -r '.spec.releasePlan // ""' <<< "$release_json")
+    author=$(jq -r '.metadata.labels["release.appstudio.openshift.io/author"] // .status.attribution.author // ""' <<< "$release_json")
+
+    if [ -z "$snapshot_name" ] || [ -z "$release_plan_name" ]; then
+        echo "🔴 Cannot retry: missing snapshot or releasePlan in original release"
+        return 1
+    fi
+
+    # Generate unique retry name
+    local retry_suffix retry_name
+    retry_suffix=$(date +%s | tail -c 9)
+    retry_name="retry-${retry_suffix}"
+
+    echo "🔄 Creating retry release: ${retry_name}"
+    echo "   Snapshot:    ${snapshot_name}"
+    echo "   ReleasePlan: ${release_plan_name}"
+
+    # Delete if exists (from previous retry attempt)
+    kubectl delete release "${retry_name}" -n "${release_namespace}" --ignore-not-found >/dev/null 2>&1 || true
+
+    local retry_yaml
+    retry_yaml="$(cat <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${retry_name}
+  namespace: ${release_namespace}
+  labels:
+    release.appstudio.openshift.io/automated: "false"
+    release.appstudio.openshift.io/author: "${author}"
+spec:
+  releasePlan: ${release_plan_name}
+  snapshot: ${snapshot_name}
+EOF
+)"
+
+    echo "${retry_yaml}" | kubectl create -f - >/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "🔴 Failed to create retry release"
+        return 1
+    fi
+
+    echo "✅ Retry release created: ${retry_name}"
+
+    # Export for use by caller
+    export RETRY_RELEASE_NAME="${retry_name}"
+
+    # Wait for the release
+    echo ""
+    echo "⏳ Waiting for retry release to complete..."
+    RELEASE_NAME="${retry_name}" RELEASE_NAMESPACE="${release_namespace}" \
+        "${SUITE_DIR}/../scripts/wait-for-release.sh"
+
+    return $?
+}
+
+# Interactive prompt for failure handling
+# Arguments: $1=release_name, $2=release_namespace
+# Returns: 0 if retry succeeded, 1 otherwise
+interactive_prompt() {
+    local release_name="${1:-$RELEASE_NAME}"
+    local release_namespace="${2:-$RELEASE_NAMESPACE}"
+
+    while true; do
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "🛑 Interactive Mode - Test paused"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo ""
+        echo "  [r] Retry    - Create new Release with same snapshot"
+        echo "  [i] Info     - Show release context again"
+        echo "  [s] Shell    - Drop into bash shell (exit to return)"
+        echo "  [c] Cleanup  - Run cleanup and exit"
+        echo "  [q] Quit     - Exit without cleanup (keep resources)"
+        echo ""
+        read -r -p "Select option: " choice
+
+        case "${choice}" in
+            r|R)
+                echo ""
+                if retry_release "${release_name}" "${release_namespace}"; then
+                    echo ""
+                    echo "✅ Retry release completed successfully!"
+                    # Update RELEASE_NAME for verification
+                    export RELEASE_NAME="${RETRY_RELEASE_NAME}"
+                    return 0
+                else
+                    echo ""
+                    echo "🔴 Retry release failed"
+                    show_release_context "${RETRY_RELEASE_NAME:-$release_name}" "${release_namespace}"
+                fi
+                ;;
+            i|I)
+                show_release_context "${release_name}" "${release_namespace}"
+                ;;
+            s|S)
+                echo ""
+                echo "Dropping into shell. Type 'exit' to return to menu."
+                echo "Useful variables: RELEASE_NAME, RELEASE_NAMESPACE, tenant_namespace, managed_namespace"
+                echo ""
+                bash --norc -i
+                ;;
+            c|C)
+                echo ""
+                echo "Running cleanup..."
+                return 2  # Signal to run cleanup
+                ;;
+            q|Q)
+                echo ""
+                echo "Exiting without cleanup. Resources preserved for debugging."
+                echo ""
+                echo "To manually cleanup later:"
+                echo "  kubectl delete release -l originating-tool=${originating_tool:-unknown} -n ${release_namespace}"
+                exit 0
+                ;;
+            *)
+                echo "Invalid option. Please choose r, i, s, c, or q."
+                ;;
+        esac
+    done
+}
+
+# Handle test failure with optional interactive mode
+# Arguments: $1=failure_message, $2=release_name (optional), $3=release_namespace (optional)
+# Environment: INTERACTIVE_MODE=true to enable interactive prompts
+handle_test_failure() {
+    local failure_message="$1"
+    local release_name="${2:-$RELEASE_NAME}"
+    local release_namespace="${3:-$RELEASE_NAMESPACE}"
+
+    echo ""
+    echo "🔴 ${failure_message}"
+
+    if [ "${INTERACTIVE_MODE:-false}" == "true" ]; then
+        show_release_context "${release_name}" "${release_namespace}"
+
+        local prompt_result
+        interactive_prompt "${release_name}" "${release_namespace}"
+        prompt_result=$?
+
+        if [ $prompt_result -eq 0 ]; then
+            # Retry succeeded, caller should re-run verification
+            return 0
+        elif [ $prompt_result -eq 2 ]; then
+            # User requested cleanup
+            return 1
+        fi
+    fi
+
+    return 1
 }

--- a/integration-tests/run-test.sh
+++ b/integration-tests/run-test.sh
@@ -31,6 +31,12 @@
 #   -nocve, --no-cve      : If set, the script will not simulate the addition of a CVE.
 #                           This affects commit messages and expected CVE data during
 #                           release verification. Defaults to including CVE data.
+#   -i, --interactive     : Enable interactive mode. On failure, pauses and offers:
+#                           [r] Retry with same snapshot (no RPM rebuild needed)
+#                           [i] Show release context info
+#                           [s] Drop into shell for debugging
+#                           [c] Cleanup and exit
+#                           [q] Quit without cleanup
 #
 # Environment Variables (Expected):
 #   The script sources suite-specific environment variables from
@@ -79,15 +85,41 @@
 
 set -eo pipefail
 
-suite=$1
-if [ -z "$suite" ] ; then
-  echo "🔴 error: missing parameter suite"
-  exit 1
-fi
-
 # --- Configuration & Global Variables ---
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 LIB_DIR="${SCRIPT_DIR}/lib"
+
+# Parse arguments - extract suite name (first non-option argument)
+suite=""
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    -sc|--skip-cleanup|-nocve|--no-cve|-i|--interactive)
+      args+=("$arg")
+      ;;
+    -*)
+      echo "🔴 error: unknown option: $arg"
+      echo "Usage: ./run-test.sh <suite_name> [options]"
+      echo "Options: -i/--interactive, -sc/--skip-cleanup, -nocve/--no-cve"
+      exit 1
+      ;;
+    *)
+      if [ -z "$suite" ]; then
+        suite="$arg"
+      else
+        echo "🔴 error: unexpected argument: $arg"
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$suite" ]; then
+  echo "🔴 error: missing parameter suite"
+  echo "Usage: ./run-test.sh <suite_name> [options]"
+  echo "Example: ./run-test.sh push-rpms-to-pulp -i"
+  exit 1
+fi
 
 SUITE_DIR="${SCRIPT_DIR}/${suite}" # e.g. "${SCRIPT_DIR}/fbc-release"
 
@@ -121,8 +153,8 @@ fi
 # Pass error code, line number, and command to the cleanup function
 trap 'cleanup_resources $? $LINENO "$BASH_COMMAND"' EXIT
 
-check_env_vars "$@" # Pass all args for consistency, though check_env_vars doesn't use them
-parse_options "$@" # Parses options and sets CLEANUP, NO_CVE
+check_env_vars "${args[@]}" # Pass all args for consistency, though check_env_vars doesn't use them
+parse_options "${args[@]}" # Parses options and sets CLEANUP, NO_CVE, INTERACTIVE_MODE
 
 decrypt_secrets "${SUITE_DIR}"
 create_github_repository


### PR DESCRIPTION
## Describe your changes

Add --interactive (-i) flag to run-test.sh that pauses on release pipeline failure and provides an interactive menu for debugging:

- Retry: Create new Release with same snapshot (no rebuild needed)
- Info: Show release context (Release, Snapshot, PLR URL, namespaces)
- Shell: Drop into bash with context variables for manual debugging
- Cleanup: Run cleanup and exit
- Quit: Exit without cleanup to preserve resources

**This enables faster iteration when developing/debugging release pipelines by reusing the existing snapshot and test infrastructure.**

Also includes:
- Improved argument parsing to allow options in any position
- Document --no-cve option that was previously undocumented


Made-with: Cursor

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
