### PR TITLE
feat(RELEASE-1265): add check-file-update, update rh-push-to-registry-redhat-io

### DIFF
--- a/pipelines/internal/check-file-updates/README.md
+++ b/pipelines/internal/check-file-updates/README.md
@@ -1,0 +1,16 @@
+# check-file-updates pipeline
+
+Internal pipeline to check whether fileUpdates changes are already complete for
+a given componentGroup and GitLab repository.
+
+This is intended to be triggered via InternalRequest from managed release tasks.
+
+## Parameters
+
+| Name                | Description                                                                           | Optional | Default value                                             |
+|---------------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| upstream_repo       | Git repository (GitLab) where fileUpdates merge requests are created                  | No       | -                                                         |
+| componentGroup      | Component group being released (used to identify Konflux fileUpdates MRs)             | No       | -                                                         |
+| file_updates_secret | Secret containing GitLab host/access token used by internal services                  | Yes      | file-updates-secret                                       |
+| taskGitUrl          | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision     | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |

--- a/pipelines/internal/check-file-updates/check-file-updates.yaml
+++ b/pipelines/internal/check-file-updates/check-file-updates.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: check-file-updates
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |-
+    Internal pipeline to check whether fileUpdates changes are already complete for
+    a given componentGroup and GitLab repository.
+
+    This is intended to be triggered via InternalRequest from managed release tasks.
+  params:
+    - name: upstream_repo
+      type: string
+      description: Git repository (GitLab) where fileUpdates merge requests are created
+    - name: componentGroup
+      type: string
+      description: Component group being released (used to identify Konflux fileUpdates MRs)
+    - name: file_updates_secret
+      type: string
+      description: Secret containing GitLab host/access token used by internal services
+      default: file-updates-secret
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  tasks:
+    - name: check-file-updates-task
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/check-file-updates-task/check-file-updates-task.yaml
+      params:
+        - name: upstream_repo
+          value: $(params.upstream_repo)
+        - name: componentGroup
+          value: $(params.componentGroup)
+        - name: file_updates_secret
+          value: $(params.file_updates_secret)
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+  results:
+    - name: result
+      value: $(tasks.check-file-updates-task.results.result)
+    - name: file_updates_complete
+      value: $(tasks.check-file-updates-task.results.file_updates_complete)
+    - name: merge_request_url
+      value: $(tasks.check-file-updates-task.results.merge_request_url)
+    - name: internalRequestPipelineRunName
+      value: $(tasks.check-file-updates-task.results.internalRequestPipelineRunName)
+    - name: internalRequestTaskRunName
+      value: $(tasks.check-file-updates-task.results.internalRequestTaskRunName)

--- a/pipelines/managed/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/README.md
@@ -2,6 +2,15 @@
 
 Tekton pipeline to release content to registry.redhat.io registry.
 
+This pipeline is idempotent: components that have already been fully released are
+automatically filtered out by verifying:
+- Pyxis metadata: image record must have non-empty rpm_manifest.rpms. A digest-only
+  or partial record does not count as released, so reruns will still push RPM data if needed.
+- fileUpdates completion (merged GitLab merge requests), checked via InternalRequest
+
+When all components are filtered, downstream release tasks are skipped (skip_release=true).
+This prevents redundant processing and allows safe re-runs of the same snapshot.
+
 ## Parameters
 
 | Name                            | Description                                                                                                                        | Optional | Default value                                             |

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -9,6 +9,15 @@ metadata:
 spec:
   description: |-
     Tekton pipeline to release content to registry.redhat.io registry.
+
+    This pipeline is idempotent: components that have already been fully released are
+    automatically filtered out by verifying:
+    - Pyxis metadata: image record must have non-empty rpm_manifest.rpms. A digest-only
+      or partial record does not count as released, so reruns will still push RPM data if needed.
+    - fileUpdates completion (merged GitLab merge requests), checked via InternalRequest
+
+    When all components are filtered, downstream release tasks are skipped (skip_release=true).
+    This prevents redundant processing and allows safe re-runs of the same snapshot.
   params:
     - name: release
       type: string
@@ -290,8 +299,51 @@ spec:
           value: "$(params.taskGitRevision)"
       runAfter:
         - reduce-snapshot
+    - name: filter-already-released-by-pyxis-and-file-updates
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/filter-already-released-by-pyxis-and-file-updates/filter-already-released-by-pyxis-and-file-updates.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: pyxisSecret
+          value: "$(tasks.collect-task-params.results.extractedValues[2])"
+        - name: pyxisServer
+          value: "$(tasks.collect-task-params.results.extractedValues[3])"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: orasOptions
+          value: "$(params.orasOptions)"
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      runAfter:
+        - apply-mapping
+        - reduce-snapshot
+        - collect-task-params
     - name: verify-conforma
       timeout: "4h00m0s"
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -318,11 +370,11 @@ spec:
         - name: WORKERS
           value: "$(tasks.collect-task-params.results.extractedValues[0])"
         - name: SOURCE_DATA_ARTIFACT
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: TRUSTED_ARTIFACTS_DEBUG
           value: "$(params.trustedArtifactsDebug)"
       runAfter:
-        - apply-mapping
+        - filter-already-released-by-pyxis-and-file-updates
         - collect-task-params
     - name: rh-sign-image-cosign
       timeout: "6h00m0s"
@@ -330,6 +382,9 @@ spec:
         - input: $(tasks.collect-task-params.results.extractedValues[1])
           operator: notin
           values: [""]
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -367,6 +422,9 @@ spec:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in
           values: ["true"]
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -386,7 +444,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -400,6 +458,10 @@ spec:
     - name: rh-sign-image
       timeout: "6h00m0s"
       retries: 3
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -444,12 +506,16 @@ spec:
           value: "$(params.taskGitRevision)"
       runAfter:
         - verify-conforma
-        - apply-mapping
+        - filter-already-released-by-pyxis-and-file-updates
         - publish-pyxis-repository
         - extract-requester-from-release
         - collect-task-params
     - name: create-pyxis-image
       retries: 5
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -487,6 +553,10 @@ spec:
         - collect-task-params
     - name: publish-pyxis-repository
       retries: 5
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -510,7 +580,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -522,8 +592,13 @@ spec:
       runAfter:
         - collect-task-params
         - apply-mapping
+        - filter-already-released-by-pyxis-and-file-updates
     - name: push-rpm-data-to-pyxis
       retries: 5
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       taskRef:
         resolver: "git"
         params:
@@ -553,9 +628,13 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - create-pyxis-image
+        - update-cr-status
         - collect-task-params
     - name: run-file-updates
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: fileUpdatesPath
           value: $(tasks.collect-data.results.data)
@@ -570,7 +649,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+          value: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -580,7 +659,7 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - push-rpm-data-to-pyxis
+        - publish-pyxis-repository
       taskRef:
         kind: Task
         params:
@@ -592,6 +671,10 @@ spec:
             value: tasks/managed/run-file-updates/run-file-updates.yaml
         resolver: git
     - name: update-cr-status
+      when:
+        - input: "$(tasks.filter-already-released-by-pyxis-and-file-updates.results.skip_release)"
+          operator: in
+          values: ["false"]
       params:
         - name: resource
           value: $(params.release)


### PR DESCRIPTION
## Describe your changes
- Add check-file-updates internal pipeline to check whether fileUpdates
  merge requests are complete for a given componentGroup and GitLab
  repository (triggered via InternalRequest)
- Update rh-push-to-registry-redhat-io to filter already-released
  components by verifying Pyxis metadata and fileUpdates completion,
  making the pipeline idempotent and safe to re-run

Tested with:
https://github.com/konflux-ci/release-service-catalog/pull/2046

## Relevant Jira
[RELEASE-1265](https://issues.redhat.com/browse/RELEASE-1265)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


[RELEASE-1265]: https://redhat.atlassian.net/browse/RELEASE-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ