### PR TITLE
fix(RELEASE-2377): replace per-CVE loop with single bulk jq operation

### DIFF
--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -786,23 +786,21 @@ spec:
             exit 0
         fi
 
-        # Set type to RHSA as there are CVEs fixed
-        jq '.releaseNotes.type = "RHSA"' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
-
-        # Inject classification link into data.json references
-        jq '.releaseNotes.references += ["https://access.redhat.com/security/updates/classification/"]' \
-            "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
-
-        for ((i = 0; i < NUM_CVES; i++))
-        do
-            cve=$(jq -rs --argjson i "$i" 'map(keys[]) | .[$i]' <<< "${CVES}")
-            # Inject cve link into data.json references
-            jq --arg cve "$cve" '.releaseNotes.references += ["https://access.redhat.com/security/cve/\($cve)"]' \
-                "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
-        done
-
-        # Remove duplicate references
-        jq '.releaseNotes.references |= unique' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
+        # Set type to RHSA, add the classification URL, and add per-CVE reference
+        # URLs — all in one jq call. CVE IDs are re-derived from DATA_FILE via
+        # getpath rather than being passed through --argjson. Passing a large JSON
+        # array (~tens of KB at 1000+ CVEs) via --argjson puts it on the process
+        # argv and triggers "Argument list too long" in Tekton containers.
+        jq --arg ct "${CONTENT_TYPE}" '
+          (getpath($ct | ltrimstr(".") | split("."))
+           | [.[] | select(.cves.fixed) | .cves.fixed | keys[]]
+           | unique) as $cveIds |
+          .releaseNotes.type = "RHSA" |
+          .releaseNotes.references +=
+            ["https://access.redhat.com/security/updates/classification/"] +
+            ($cveIds | map("https://access.redhat.com/security/cve/\(.)")) |
+          .releaseNotes.references |= unique
+        ' "${DATA_FILE}" > /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-1100-cves.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-1100-cves.yaml
@@ -1,0 +1,214 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-1100-cves
+spec:
+  description: |
+    Acceptance-criterion test for RELEASE-2377: verify that populate-release-notes
+    completes successfully with 1100 CVEs and produces the correct number of reference
+    URLs. Before the fix, the populate-release-notes-type-and-references step rewrote
+    data.json once per CVE (1100 sequential jq + file write/rename cycles), exhausting
+    the pipeline timeout. The fix replaced that loop with a single jq call; this test
+    validates both correctness and that the 32Mi memory limit on the step is sufficient
+    at this scale.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Build data.json with 1100 CVEs (CVE-0001 through CVE-1100) in a single jq call.
+              # 4-digit zero-padding keeps lexicographic and numeric sort order identical,
+              # making the index-based assertions in check-result deterministic.
+              #
+              # Important: do NOT store the generated JSON in a shell variable and pass it via
+              # --argjson. The ~152KB CVE array exceeds the kernel ARG_MAX inside the Tekton
+              # container, causing "Argument list too long". Building everything inside one jq
+              # expression avoids large shell arguments entirely.
+              jq -n '{
+                "releaseNotes": {
+                  "cves": [range(1;1101) | {
+                    "component": "comp",
+                    "key": ("CVE-" + (("0000" + (. | tostring))[-4:])),
+                    "packages": [],
+                    "summary": "",
+                    "uploadDate": "01-01-1980",
+                    "url": ""
+                  }],
+                  "product_id": [123],
+                  "product_name": "Test Product",
+                  "product_version": "1.0",
+                  "cpe": "cpe:/a:example:product:el9",
+                  "type": "RHSA",
+                  "issues": {"fixed": []},
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution"
+                }
+              }' > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "1.0"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # CVEs are present, so type must be RHSA
+              test "$(jq -r '.releaseNotes.type' "$DATA")" == "RHSA"
+
+              # The mock returns 2 architectures (amd64 + s390x) for the single component,
+              # producing 2 content images each carrying the same 1100 CVEs. After dedup:
+              # 1100 unique CVE URLs + 1 classification URL = 1101 total.
+              test "$(jq '.releaseNotes.references | length' "$DATA")" == 1101
+
+              # No duplicates
+              test "$(jq '.releaseNotes.references | unique | length' "$DATA")" == 1101
+
+              # Boundary check: first and last CVE references are correct.
+              # 4-digit zero-padded IDs sort lexicographically in numeric order.
+              test "$(jq -r '.releaseNotes.references[0]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-0001"
+              test "$(jq -r '.releaseNotes.references[1099]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-1100"
+
+              # Classification URL is last (updates/... sorts after cve/...)
+              test "$(jq -r '.releaseNotes.references[1100]' "$DATA")" == \
+                "https://access.redhat.com/security/updates/classification/"
+      runAfter:
+        - run-task

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-bulk-cves.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-bulk-cves.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-bulk-cves
+spec:
+  description: |
+    Test populate-release-notes with 15 unique CVEs on a single component to verify
+    correctness of the bulk jq path in populate-release-notes-type-and-references.
+    Motivated by RELEASE-2377 where 1037 CVEs caused a timeout with the old per-CVE
+    loop; this test catches ordering, count, and deduplication bugs at meaningful scale
+    without being a full 1100-item performance test.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Build data.json with 15 CVEs (CVE-001 through CVE-015) in a single jq call.
+              # Zero-padded IDs ensure lexicographic sort order matches numeric order,
+              # making index-based assertions in check-result straightforward.
+              jq -n '{
+                "releaseNotes": {
+                  "cves": [range(1;16) | {
+                    "component": "comp",
+                    "key": ("CVE-" + (("000" + (. | tostring))[-3:])),
+                    "packages": [],
+                    "summary": "",
+                    "uploadDate": "01-01-1980",
+                    "url": ""
+                  }],
+                  "product_id": [123],
+                  "product_name": "Test Product",
+                  "product_version": "1.0",
+                  "cpe": "cpe:/a:example:product:el9",
+                  "type": "RHSA",
+                  "issues": {"fixed": []},
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution"
+                }
+              }' > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "1.0"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # CVEs are present, so type must be RHSA
+              test "$(jq -r '.releaseNotes.type' "$DATA")" == "RHSA"
+
+              # The mock returns 2 architectures (amd64 + s390x) for the single component,
+              # producing 2 content images each with the same 15 CVEs. After dedup:
+              # 15 CVE reference URLs + 1 classification URL = 16 total.
+              test "$(jq '.releaseNotes.references | length' "$DATA")" == 16
+
+              # No duplicates: unique count must equal total count
+              test "$(jq '.releaseNotes.references | unique | length' "$DATA")" == 16
+
+              # Zero-padded CVE IDs sort lexicographically as expected.
+              # CVE-001 through CVE-015 come before the classification URL
+              # (cve/... < updates/...).
+              test "$(jq -r '.releaseNotes.references[0]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-001"
+              test "$(jq -r '.releaseNotes.references[14]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-015"
+              test "$(jq -r '.releaseNotes.references[15]' "$DATA")" == \
+                "https://access.redhat.com/security/updates/classification/"
+      runAfter:
+        - run-task

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cross-image-cve-dedup.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-cross-image-cve-dedup.yaml
@@ -1,0 +1,244 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-cross-image-cve-dedup
+spec:
+  description: |
+    Test that CVE reference URLs are deduplicated correctly when the same CVE appears
+    in multiple content images (i.e. shared across components). CVE-123 is fixed in
+    both comp1 and comp2; it should appear only once in releaseNotes.references.
+    Exercises the map(keys[]) | unique path in populate-release-notes-type-and-references.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "cves": [
+                    {
+                      "component": "comp1",
+                      "packages": ["pkg-a"],
+                      "key": "CVE-123",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "comp1",
+                      "packages": ["pkg-b"],
+                      "key": "CVE-456",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "comp2",
+                      "packages": ["pkg-c"],
+                      "key": "CVE-123",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "comp2",
+                      "packages": ["pkg-d"],
+                      "key": "CVE-789",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    }
+                  ],
+                  "product_id": [
+                    123
+                  ],
+                  "product_name": "Test Product",
+                  "product_version": "1.0",
+                  "cpe": "cpe:/a:example:product:el9",
+                  "type": "RHSA",
+                  "issues": {
+                    "fixed": []
+                  },
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1@sha256:111111aaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product1----repo1",
+                        "rh-registry-repo": "registry.redhat.io/product1/repo1",
+                        "tags": [
+                          "1.0"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2@sha256:222222bbbbbb",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product2----repo2",
+                        "rh-registry-repo": "registry.redhat.io/product2/repo2",
+                        "tags": [
+                          "1.0"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # CVEs are present, so type must be RHSA
+              test "$(jq -r '.releaseNotes.type' "$DATA")" == "RHSA"
+
+              # CVE-123 appears in both comp1 and comp2 content images but must produce only one
+              # reference URL. CVE-456 (comp1 only) and CVE-789 (comp2 only) each add one URL.
+              # Plus the classification URL = 4 total. No duplicates.
+              test "$(jq '.releaseNotes.references | length' "$DATA")" == 4
+
+              # After unique, references are sorted alphabetically.
+              # cve/CVE-123 < cve/CVE-456 < cve/CVE-789 < updates/classification/
+              test "$(jq -r '.releaseNotes.references[0]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-123"
+              test "$(jq -r '.releaseNotes.references[1]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-456"
+              test "$(jq -r '.releaseNotes.references[2]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-789"
+              test "$(jq -r '.releaseNotes.references[3]' "$DATA")" == \
+                "https://access.redhat.com/security/updates/classification/"
+      runAfter:
+        - run-task

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-mixed-cve-images.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-mixed-cve-images.yaml
@@ -1,0 +1,239 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-mixed-cve-images
+spec:
+  description: |
+    Verify that when some components have CVEs and others do not, only the CVEs from
+    components that have them contribute to references, and the type is still set to
+    RHSA because at least one image has CVEs.
+
+    comp1 has CVE-123 and CVE-456. comp2 has no CVE entries in releaseNotes.cves.
+    Both appear in content.images (2 archs each = 4 image entries). The
+    populate-release-notes-type-and-references step must select only the 2 entries
+    that have cves.fixed and ignore the 2 comp2 entries that don't.
+
+    This covers the select(.cves.fixed) filter path in type-and-references and guards
+    against a regression where missing cves.fixed causes errors or spurious references.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "cves": [
+                    {
+                      "component": "comp1",
+                      "packages": ["pkg1"],
+                      "key": "CVE-123",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "comp1",
+                      "packages": ["pkg2"],
+                      "key": "CVE-456",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    }
+                  ],
+                  "product_id": [123],
+                  "product_name": "Test Product",
+                  "product_version": "1.0",
+                  "cpe": "cpe:/a:example:product:el9",
+                  "type": "RHBA",
+                  "issues": {"fixed": []},
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "registry.io/image1@sha256:111111aaaaaa",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product1----repo1",
+                        "rh-registry-repo": "registry.redhat.io/product1/repo1",
+                        "tags": ["1.0"]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "registry.io/image2@sha256:222222bbbbbb",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product2----repo2",
+                        "rh-registry-repo": "registry.redhat.io/product2/repo2",
+                        "tags": ["1.0"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # Sanity check: output must be valid JSON
+              jq empty "$DATA"
+
+              # comp1 has CVEs so type must be upgraded to RHSA even though comp2 doesn't
+              test "$(jq -r '.releaseNotes.type' "$DATA")" == "RHSA"
+
+              # The mock returns 2 archs per component, so 4 content.images entries total
+              test "$(jq '.releaseNotes.content.images | length' "$DATA")" == 4
+
+              # comp2 images must NOT have a cves field (no CVE entries for comp2)
+              comp2_cves=$(jq '[.releaseNotes.content.images[]
+                | select(.component == "comp2") | .cves]
+                | map(select(. != null)) | length' "$DATA")
+              test "$comp2_cves" == 0
+
+              # comp1 images must have cves.fixed with CVE-123 and CVE-456
+              comp1_cve_count=$(jq '[.releaseNotes.content.images[]
+                | select(.component == "comp1") | .cves.fixed | keys[]]
+                | unique | length' "$DATA")
+              test "$comp1_cve_count" == 2
+
+              # Only comp1 CVE URLs in references, plus classification. comp2 adds nothing.
+              # CVE-123 < CVE-456 < classification (cve < updates alphabetically)
+              test "$(jq '.releaseNotes.references | length' "$DATA")" == 3
+              test "$(jq -r '.releaseNotes.references[0]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-123"
+              test "$(jq -r '.releaseNotes.references[1]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-456"
+              test "$(jq -r '.releaseNotes.references[2]' "$DATA")" == \
+                "https://access.redhat.com/security/updates/classification/"
+      runAfter:
+        - run-task

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-references-no-cve-dup.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-references-no-cve-dup.yaml
@@ -1,0 +1,223 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-references-no-cve-dup
+spec:
+  description: |
+    Verify that a CVE reference URL already present in releaseNotes.references before
+    the task runs is not duplicated in the output. The classification URL is also
+    pre-populated and must appear exactly once.
+
+    This exercises the final `jq '.releaseNotes.references |= unique'` dedup in
+    populate-release-notes-type-and-references against pre-existing values, not just
+    against URLs generated within the same run. The rhsa-references test covers
+    pre-existing non-CVE URLs but not pre-existing CVE URLs.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "cves": [
+                    {
+                      "component": "comp",
+                      "packages": ["pkg1"],
+                      "key": "CVE-123",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    },
+                    {
+                      "component": "comp",
+                      "packages": ["pkg2"],
+                      "key": "CVE-456",
+                      "summary": "",
+                      "uploadDate": "01-01-1980",
+                      "url": ""
+                    }
+                  ],
+                  "product_id": [123],
+                  "product_name": "Test Product",
+                  "product_version": "1.0",
+                  "cpe": "cpe:/a:example:product:el9",
+                  "type": "RHSA",
+                  "issues": {"fixed": []},
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution",
+                  "references": [
+                    "https://access.redhat.com/security/cve/CVE-123",
+                    "https://access.redhat.com/security/updates/classification/",
+                    "https://docs.example.com/existing-page"
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": ["1.0"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # Sanity check: output must be valid JSON
+              jq empty "$DATA"
+
+              # CVE-123 URL was pre-populated in references AND is generated by the task.
+              # The classification URL was also pre-populated AND is added by the task.
+              # Both must appear exactly once after deduplication.
+              # CVE-456 is new (not pre-populated). The existing docs URL is preserved.
+              # Total: CVE-123, CVE-456, classification, docs = 4 references.
+              test "$(jq '.releaseNotes.references | length' "$DATA")" == 4
+
+              # Sorted alphabetically by unique:
+              # cve/CVE-123 < cve/CVE-456 < updates/classification < docs.example.com
+              test "$(jq -r '.releaseNotes.references[0]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-123"
+              test "$(jq -r '.releaseNotes.references[1]' "$DATA")" == \
+                "https://access.redhat.com/security/cve/CVE-456"
+              test "$(jq -r '.releaseNotes.references[2]' "$DATA")" == \
+                "https://access.redhat.com/security/updates/classification/"
+              test "$(jq -r '.releaseNotes.references[3]' "$DATA")" == \
+                "https://docs.example.com/existing-page"
+
+              # Explicit uniqueness check
+              test "$(jq '.releaseNotes.references | unique | length' "$DATA")" == 4
+      runAfter:
+        - run-task


### PR DESCRIPTION
## Describe your changes
The populate-release-notes-type-and-references step was rewriting data.json once per CVE in a loop. 
With large CVE lists (e.g. 1037 CVEs in RHODF 4.18) this took ~49 minutes and hit the 1-hour pipeline timeout. 
Replace the loop with a single jq call that builds and injects all CVE reference URLs at once.

Resource usage at scale : a new integration test (test-populate-release-notes-1100-cves) generates 1100 unique CVE entries and runs the full task. 
It verifies that:
- The task completes successfully within the pipeline timeout
- The populate-release-notes-type-and-references step (32 Mi memory limit) handles the load without OOMKill: at 1100 CVEs the data is ~500 KB, well within the limit
- The output contains exactly 1101 references (1100 CVE URLs + 1 classification URL) with no duplicates

The 32 Mi memory limit is sufficient because the fix replaced 1100 sequential jq + file-write cycles with a single jq call that streams all CVE keys in one pass; peak memory is proportional to data size (~500 KB), not to iteration count.

## Relevant Jira
[RELEASE-2377](https://redhat.atlassian.net/browse/RELEASE-2377)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


[RELEASE-2377]: https://redhat.atlassian.net/browse/RELEASE-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ