### PR TITLE
fix: removed duplicate param jiraSecretName

### DIFF
--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -277,8 +277,6 @@ spec:
           value: "$(params.taskGitUrl)"
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
-        - name: jiraSecretName
-          value: "$(tasks.collect-task-params.results.extractedValues[2])"
       taskRef:
         resolver: "git"
         params:


### PR DESCRIPTION
push-disk-images-to-marketplaces.yaml has duplicate param jiraSecretName which needs to be removed

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
