### PR TITLE
fix: add retry logic to GitHub repo creation verification

### DIFF
--- a/integration-tests/scripts/copy-branch-to-repo-git.sh
+++ b/integration-tests/scripts/copy-branch-to-repo-git.sh
@@ -103,21 +103,40 @@ if [ -z "${DEST_REPO_CHECK}" ]; then
     exit 1
   fi
   
-  # Verify the repository was created successfully
+  # Verify the repository was created successfully with retry logic
+  # GitHub API may take a moment to propagate the newly created repository
   echo "Re-verifying destination repository ${dest_repo}..."
-  DEST_REPO_RECHECK_RESPONSE=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${dest_repo} 2> /dev/null)
-  if [ -n "${DEBUG}" ]; then
-    echo "🐛 Destination repo recheck API response: ${DEST_REPO_RECHECK_RESPONSE}"
-  fi
-  DEST_REPO_CHECK=$(echo "${DEST_REPO_RECHECK_RESPONSE}" | jq -r '.full_name // ""')
-  if [ -z "${DEST_REPO_CHECK}" ]; then
-    echo "🔴 error: destination repository ${dest_repo} still not accessible after creation"
+  max_attempts=5
+  attempt=1
+  verification_success=false
+
+  while [ $attempt -le $max_attempts ]; do
+    DEST_REPO_RECHECK_RESPONSE=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${dest_repo} 2> /dev/null)
     if [ -n "${DEBUG}" ]; then
-      echo "🐛 Recheck response: ${DEST_REPO_RECHECK_RESPONSE}"
+      echo "🐛 Destination repo recheck API response: ${DEST_REPO_RECHECK_RESPONSE}"
+    fi
+    DEST_REPO_CHECK=$(echo "${DEST_REPO_RECHECK_RESPONSE}" | jq -r '.full_name // ""')
+    if [ -n "${DEST_REPO_CHECK}" ]; then
+      verification_success=true
+      break
+    fi
+
+    echo "⚠️  Repository not yet available (attempt ${attempt}/${max_attempts})"
+    if [ $attempt -lt $max_attempts ]; then
+      echo "Waiting 3 seconds before retry..."
+      sleep 3
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  if [ "$verification_success" = false ]; then
+    echo "🔴 error: destination repository ${dest_repo} still not accessible after ${max_attempts} attempts"
+    if [ -n "${DEBUG}" ]; then
+      echo "🐛 Last response: ${DEST_REPO_RECHECK_RESPONSE}"
     fi
     exit 1
   fi
-  
+
   echo "✅ Repository ${dest_repo} created successfully"
 fi
 

--- a/integration-tests/scripts/create-github-repo.sh
+++ b/integration-tests/scripts/create-github-repo.sh
@@ -94,15 +94,33 @@ if [ -z "${CREATED_REPO}" ]; then
   exit 1
 fi
 
-# Verify the repository was created successfully
+# Verify the repository was created successfully with retry logic
+# GitHub API may take a moment to propagate the newly created repository
 echo "Verifying repository creation..."
-VERIFY_REPO=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${full_repo_name} 2> /dev/null | jq -r '.full_name // ""')
-if [ "${VERIFY_REPO}" = "${full_repo_name}" ]; then
-  echo "✅ Repository ${full_repo_name} created successfully!"
-  echo "   - URL: https://github.com/${full_repo_name}"
-  echo "   - Clone URL: https://github.com/${full_repo_name}.git"
-  echo "   - SSH URL: git@github.com:${full_repo_name}.git"
-else
-  echo "🔴 error: repository creation verification failed"
+max_attempts=5
+attempt=1
+verification_success=false
+
+while [ $attempt -le $max_attempts ]; do
+  VERIFY_REPO=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${full_repo_name} 2> /dev/null | jq -r '.full_name // ""')
+  if [ "${VERIFY_REPO}" = "${full_repo_name}" ]; then
+    echo "✅ Repository ${full_repo_name} created successfully!"
+    echo "   - URL: https://github.com/${full_repo_name}"
+    echo "   - Clone URL: https://github.com/${full_repo_name}.git"
+    echo "   - SSH URL: git@github.com:${full_repo_name}.git"
+    verification_success=true
+    break
+  fi
+
+  echo "⚠️  Repository not yet available (attempt ${attempt}/${max_attempts})"
+  if [ $attempt -lt $max_attempts ]; then
+    echo "Waiting 3 seconds before retry..."
+    sleep 3
+  fi
+  attempt=$((attempt + 1))
+done
+
+if [ "$verification_success" = false ]; then
+  echo "🔴 error: repository creation verification failed after ${max_attempts} attempts"
   exit 1
 fi


### PR DESCRIPTION
GitHub API may take a moment to propagate a newly created repository, causing intermittent verification failures in e2e tests. This adds retry logic (5 attempts, 3s delay) to repo creation verification in create-github-repo.sh and copy-branch-to-repo-git.sh, matching the existing pattern used in create-branch-from-base.sh

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
