### PR TITLE
fix(RELEASE-2380): add cloudMarketplaces system to check-data-keys schema

### DIFF
--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -297,7 +297,7 @@ spec:
         - name: systems
           value: |
             [
-              {"systemName": "mapping", "dynamic": false},
+              {"systemName": "cloudMarketplaces", "dynamic": false},
               {"systemName": "releaseNotes", "dynamic": false}
             ]
         - name: ociStorage

--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -33,7 +33,8 @@
               "conforma",
               "intention",
               "atlas",
-              "pulp"
+              "pulp",
+              "cloudMarketplaces"
             ]
           },
           "dynamic": {
@@ -1936,6 +1937,106 @@
                       ]
                     }
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "cloudMarketplaces"
+                },
+                "dynamic": {
+                  "not": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "mapping": {
+            "type": "object",
+            "required": [
+              "components",
+              "cloudMarketplacesSecret"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "mapping"
+        ],
+        "properties": {
+          "systems": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "systemName": {
+                  "const": "cloudMarketplaces"
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "mapping": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "required": [
+                    "name",
+                    "contentType",
+                    "staged",
+                    "starmap"
+                  ],
+                  "properties": {
+                    "staged": {
+                      "type": "object",
+                      "required": [
+                        "destination",
+                        "version",
+                        "files"
+                      ],
+                      "properties": {
+                        "files": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "required": [
+                              "filename",
+                              "source"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "starmap": {
+                      "type": "array",
+                      "minItems": 1
+                    }
+                  }
                 }
               }
             }

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-cloud-marketplaces.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-cloud-marketplaces.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-data-keys-cloud-marketplaces
+spec:
+  description: |
+    Run the check-data-keys task with cloudMarketplaces and releaseNotes system keys present.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "bootc-cuda-aws-disk-image-3-3",
+                      "contentType": "disk-image",
+                      "staged": {
+                        "destination": "rhelai-3_DOT_3-for-rhel-9-x86_64-isos",
+                        "version": "3.3",
+                        "files": [
+                          {
+                            "filename": "rhel-ai-cuda-aws-3.3-x86_64.raw.gz",
+                            "source": "disk.raw.gz"
+                          }
+                        ]
+                      },
+                      "starmap": [
+                        {
+                          "cloud": "aws",
+                          "name": "rhel-ai-nvidia-aws",
+                          "workflow": "stratosphere"
+                        }
+                      ]
+                    }
+                  ],
+                  "cloudMarketplacesSecret": "aws-stratosphere-secret"
+                },
+                "releaseNotes": {
+                  "product_id": [932],
+                  "product_name": "Red Hat Enterprise Linux AI",
+                  "product_version": "3.3",
+                  "product_stream": "rhel-ai-3.3",
+                  "cpe": "cpe:/a:redhat:enterprise_linux_ai:3.3::el9",
+                  "content": {
+                    "artifacts": [
+                      {
+                        "architecture": "x86_64",
+                        "os": "linux",
+                        "purl": "pkg:generic/bootc-cuda-aws-disk-image-3-3@3.3",
+                        "component": "bootc-cuda-aws-disk-image-3-3"
+                      }
+                    ]
+                  },
+                  "synopsis": "Red Hat Enterprise Linux AI 3.3",
+                  "topic": "Red Hat Enterprise Linux AI 3.3 is now available.",
+                  "description": "Red Hat Enterprise Linux AI 3.3 release.",
+                  "solution": "Before applying this update, ensure all errata have been applied."
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: check-data-keys
+      params:
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: systems
+          value: |
+            [
+              {"systemName": "cloudMarketplaces", "dynamic": false},
+              {"systemName": "releaseNotes", "dynamic": false}
+            ]
+        - name: schema
+          value: "https://get-local-schema.com"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cloud-marketplaces-key.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-missing-cloud-marketplaces-key.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-data-keys-fail-missing-cloud-marketplaces-key
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the check-data-keys task with cloudMarketplaces system declared
+    but missing required fields (staged, starmap) in the mapping component.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "bootc-cuda-aws-disk-image-3-3"
+                    }
+                  ]
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: check-data-keys
+      params:
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: systems
+          value: |
+            [
+              {"systemName": "cloudMarketplaces", "dynamic": false}
+            ]
+        - name: schema
+          value: "https://get-local-schema.com"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-partial-cloud-marketplaces.yaml
+++ b/tasks/managed/check-data-keys/tests/test-check-data-keys-fail-partial-cloud-marketplaces.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-check-data-keys-fail-partial-cloud-marketplaces
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the check-data-keys task with cloudMarketplaces system declared
+    and staged present but missing files and starmap as an empty array.
+    Verify the task fails with the expected error message.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "bootc-cuda-aws-disk-image-3-3",
+                      "staged": {
+                        "destination": "rhelai-3_DOT_3-for-rhel-9-x86_64-isos",
+                        "version": "3.3"
+                      },
+                      "starmap": []
+                    }
+                  ],
+                  "cloudMarketplacesSecret": "aws-stratosphere-secret"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: check-data-keys
+      params:
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: systems
+          value: |
+            [
+              {"systemName": "cloudMarketplaces", "dynamic": false}
+            ]
+        - name: schema
+          value: "https://get-local-schema.com"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup


### PR DESCRIPTION
## Summary
- Add "cloudMarketplaces" to the systemName enum in dataKeys.json
- Add if/then validation: when cloudMarketplaces system is declared,
  require mapping with components and cloudMarketplacesSecret
- Add if/then validation: each component must have name, staged, starmap
- Fix push-disk-images-to-marketplaces pipeline to use cloudMarketplaces
  system instead of incorrect mapping system, and keep releaseNotes
  system for advisory creation
- Add passing and failing tests for cloudMarketplaces validation

The marketplace pipeline was using the mapping system in check-data-keys but it requires fields not applicable to marketplace disk image releases (repository, repositories). Replaced mapping with cloudMarketplaces which validates the correct marketplace specific keys (contentType, staged, starmap and cloudMarketplacesSecret). Kept releaseNotes since the pipeline creates advisories that need cpe, product_stream and other releaseNotes fields.

Assisted-by: Claude
Co-Authored-By: Sean Conroy <sconroy@redhat.com>
Signed-off-by: Jakub Rusz <jrusz@redhat.com>

**Failed pipeline run:** [managed-shlxg](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/rhelai-bootc-3-3/pipelineruns/managed-shlxg)

**Jira:** [RELEASE-2380](https://redhat.atlassian.net/browse/RELEASE-2380)

## Test plan

- [ ] `test-check-data-keys-cloud-marketplaces` passes with valid marketplace data
- [ ] `test-check-data-keys-fail-missing-cloud-marketplaces-key` fails when required keys missing
- [ ] `check-jsonschema --check-metaschema schema/dataKeys.json` validates
- [ ] Existing check-data-keys tests still pass (no regression)


[RELEASE-2380]: https://redhat.atlassian.net/browse/RELEASE-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ