### PR TITLE
fix(CALUNGA-214): use public key for Chains provenance verification

### DIFF
--- a/tasks/managed/extract-py-artifacts/README.md
+++ b/tasks/managed/extract-py-artifacts/README.md
@@ -1,6 +1,9 @@
 # extract-py-artifacts
 
 Extract Python packages from OCI artifacts for signing and upload.
+The fetch-chains-provenance step verifies and retrieves Tekton Chains SLSA provenance
+using cosign with the public key from k8s://openshift-pipelines/public-key.
+The pipeline service account must have get access to this secret
 
 ## Parameters
 

--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   description: |
     Extract Python packages from OCI artifacts for signing and upload.
+    The fetch-chains-provenance step verifies and retrieves Tekton Chains SLSA provenance
+    using cosign with the public key from k8s://openshift-pipelines/public-key.
+    The pipeline service account must have get access to this secret
   params:
     - name: SNAPSHOT_PATH
       type: string
@@ -176,7 +179,7 @@ spec:
             --type=slsaprovenance \
             --insecure-ignore-tlog=true \
             --insecure-ignore-sct=true \
-            --key k8s://tekton-chains/signing-secrets \
+            --key k8s://openshift-pipelines/public-key \
             "${IMAGE}" 2>"${COSIGN_STDERR}" | head -1 | jq . > "${PROVENANCE_FILE}"; then
             echo "  Saved Chains provenance to ${PROVENANCE_FILE}"
           else


### PR DESCRIPTION
The fetch-chains-provenance step was referencing the private signing key in k8s://tekton-chains/signing-secrets, which the release service account does not have access to. Since cosign verify-attestation only needs the public key, we switch to k8s://openshift-pipelines/public-key which is the same key used by EC verification.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
