### PR TITLE
fix(RELEASE-2295): handle IR failure in publish-index-image

### DIFF
--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -122,7 +122,4 @@ spec:
         "${TARGET_AUTH_ARGS[@]}" \
         "docker://$(params.targetIndex)" && \
         echo -n "Index Image Published successfully" || \
-        echo -n "Failed publishing Index Image" ) | tee "$(results.requestMessage.path)"
-
-        # Ensure the script exits with the correct status
-        grep "success" "$(results.requestMessage.path)" >/dev/null
+        echo -n "Error: Failed publishing Index Image" ) | tee "$(results.requestMessage.path)"

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail.yaml
@@ -3,12 +3,10 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: test-publish-index-image-fail
-  annotations:
-    test/assert-task-failure: "run-task"
 spec:
   description: |
-    Run the publish-index-image task with a failing sourceIndex. The grep at the end of the task sets the task
-    status to that of the skopeo command, and here the mock will make the skopeo command fail due to the sourceIndex
+    Run the publish-index-image task with a failing sourceIndex. The task should succeed but set
+    requestMessage to an error string, since the internal task always propagates results.
   tasks:
     - name: run-task
       taskRef:
@@ -20,3 +18,24 @@ spec:
           value: "quay.io/target"
         - name: publishingCredentials
           value: "publish-index-image-secret"
+    - name: check-result
+      runAfter:
+        - run-task
+      params:
+        - name: requestMessage
+          value: $(tasks.run-task.results.requestMessage)
+      taskSpec:
+        params:
+          - name: requestMessage
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              if [[ "$(params.requestMessage)" != "Error: Failed publishing Index Image" ]]; then
+                echo Error: requestMessage should indicate failure
+                exit 1
+              fi

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -168,6 +168,8 @@ spec:
           pipelineTimeout=$(date -u -d @"${pipelineTimeoutSeconds}" +"%Hh%Mm%Ss")
           taskTimeout=$(date -u -d @"${requestTimeout}" +"%Hh%Mm%Ss")
 
+          IR_RESULT_FILE=$(mktemp)
+
           for((x=0; x<${#publishingImages[@]}; x++ )); do
               echo "=== Creating internal request to publish image:"
               echo ""
@@ -184,8 +186,23 @@ spec:
                   -t "$(params.requestTimeout)" \
                   --pipeline-timeout "${pipelineTimeout}" \
                   --task-timeout "$taskTimeout" \
-                  -l ${pipelinerun_label}="$(params.pipelineRunUid)"
-              echo "=== done"
+                  -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
+                  | tee "$IR_RESULT_FILE" || \
+                  (grep "^\[" "$IR_RESULT_FILE" | jq . && exit 1)
+
+              internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_RESULT_FILE")
+              echo "done (${internalRequest})"
+
+              results=$(kubectl get internalrequest "${internalRequest}" -o=jsonpath='{.status.results}')
+              requestMessage=$(echo "${results}" | jq -r '.requestMessage // ""')
+
+              if echo "${requestMessage}" | grep -qi "error"; then
+                echo "ERROR: Publish to ${publishingImages[$x]} failed"
+                echo "requestMessage: ${requestMessage}"
+                exit 1
+              fi
+              echo "=== published successfully (${publishingImages[$x]})"
+
               echo ""
               echo ""
           done

--- a/tasks/managed/publish-index-image/tests/mocks.sh
+++ b/tasks/managed/publish-index-image/tests/mocks.sh
@@ -13,3 +13,12 @@ function internal-request() {
   echo "Sync flag set to true. Waiting for the InternalRequest to be completed."
   sleep 2
 }
+
+function kubectl() {
+  if [[ "$*" == *"get internalrequest"*"jsonpath"*"status.results"* ]]
+  then
+    echo '{"requestMessage":"Index Image Published successfully"}'
+  else
+    /usr/bin/kubectl $*
+  fi
+}


### PR DESCRIPTION
## Describe your changes

The managed task was not reading requestMessage from the IR, so
soft failures (e.g. OCP version mismatch from #2005) would go
unnoticed. This ensures the managed task detects and fails on
error results instead of assuming success.

Changes:
- Internal task: remove grep "success" exit check so the IR always
  propagates results; prefix failure message with "Error:"
- Managed task: read .status.results.requestMessage from the IR
  and fail if it contains "error"
- Update fail test to expect success with error message

## Relevant Jira

RELEASE-2295

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
