### PR TITLE
fix(RELEASE-2379): redesign fbc pyxis images filter query

### DIFF
--- a/FBC-IDEMPOTENCY.md
+++ b/FBC-IDEMPOTENCY.md
@@ -1,0 +1,266 @@
+# FBC Release Idempotency — Solution Design
+
+This document explains the problem that motivated the `filter-published-fbc-images`
+redesign, why the original approach was fundamentally broken, what was changed, and
+how the current solution works.
+
+---
+
+## Background
+
+The Konflux FBC (File-Based Catalog) release pipeline publishes OLM operator catalog
+fragments to Red Hat's index images using IIB (Index Image Builder). A "fragment" is
+a container image that carries a partial OLM catalog tree — a set of operator package
+definitions that get merged into a versioned index image (e.g. the v4.14 or v4.16
+OpenShift catalog).
+
+When a release pipeline runs for a snapshot that was already successfully released,
+re-running the pipeline without any guard would:
+
+- Submit redundant IIB build requests for fragments that are already in the index.
+- Re-sign index images that have not changed.
+- Potentially create duplicate advisory entries.
+- Consume unnecessary compute and pipeline quota.
+
+The `filter-published-fbc-images` task is the guard. It sits at the start of the
+pipeline and removes from the snapshot any FBC fragments that are already present
+in the published index, so that downstream tasks only process what is genuinely new.
+
+---
+
+## Why the Original Approach Failed
+
+### What it did
+
+The original implementation queried Red Hat's **Pyxis** image metadata service.
+For each unique target index in the snapshot (one per OCP version), it issued an
+HTTP request to the Pyxis `/v1/images` endpoint, filtering by the registry, repository,
+and tag of the index image. The expectation was that Pyxis would return a
+`ContainerImage` record that included the digests of the FBC fragment images that
+had been contributed to that index.
+
+### The fundamental data gap
+
+The assumption was incorrect. The Pyxis `ContainerImage` schema stores metadata
+about an index image as a whole — its digest, registry location, labels — but it does
+**not** store which FBC fragment images were merged into it. The `related_images`
+and `bundles` fields in the Pyxis schema are OLM concepts tied to the traditional
+operator-certification pipeline (CSV-based bundles). They are not populated by the
+FBC contribution workflow.
+
+In practice:
+
+- Pyxis would return an HTTP 200 response with a valid `ContainerImage` record.
+- The record would contain no `related_images` or `bundles` fields.
+- Fragment digest extraction would yield an empty list.
+- The filter would conclude "no published fragments" and keep all components.
+- Every re-release would run the full IIB build regardless of whether the fragments
+  were already present.
+
+The filter appeared to work (it never crashed), but it was not performing any actual
+filtering. Idempotency was effectively disabled.
+
+### The query bug (separate from the data gap)
+
+In addition to the data gap, the original implementation also contained a query bug:
+it filtered Pyxis records by `docker_image_id`, which stores a config-layer digest
+rather than an image location. Pyxis records are indexed by registry + repository +
+tag, so queries by `docker_image_id` returned empty results even when the index image
+was present in Pyxis. This was discovered during investigation of
+[RELEASE-2379](https://redhat.atlassian.net/browse/RELEASE-2379) and was fixed
+(using `repositories.registry`, `repositories.repository`, `repositories.tags.name`),
+but correcting the query only revealed the deeper schema gap: even with the right
+query, Pyxis does not carry fragment-level data.
+
+### Why it "worked" in staging
+
+The Pyxis staging environment (`pyxis.stage.engineering.redhat.com`) had even less
+data than production. Preview index images built by IIB in staging were largely absent
+from the staging Pyxis instance, so the filter always returned empty results and kept
+all components — which matched expected staging behavior (always release). The
+absence of data masked the fundamental limitation.
+
+---
+
+## What Was Changed
+
+The implementation was redesigned to use **Kubernetes Release CRs** as the source of
+truth for previously published FBC fragments, completely replacing the Pyxis HTTP
+calls.
+
+The following changes were made across the codebase:
+
+**`tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml`**
+— Core task script rewritten. The Pyxis HTTP query logic, certificate handling, and
+`setup-pyxis-cert` step were removed. A new `releaseName` parameter was added (the
+namespaced name of the current Release CR). The filtering logic now queries the
+Kubernetes API for Release CRs in the tenant namespace instead of calling Pyxis.
+
+**`pipelines/managed/fbc-release/fbc-release.yaml`**
+— The `filter-published-fbc-images` task call was updated to remove `pyxisSecret`
+and pass `$(params.release)` as the new `releaseName` parameter.
+
+**`tasks/managed/filter-published-fbc-images/tests/mocks.sh`**
+— Test mocks were completely rewritten. The `curl` Pyxis mock was replaced with a
+`kubectl` Release CR mock. Eighteen unit tests were updated or rewritten to use
+the new parameter and mock approach.
+
+---
+
+## How the Current Solution Works
+
+### Data source: Release Custom Resources
+
+Every release managed by the Konflux Release Service creates a **Release CR** in the
+tenant namespace. When a release pipeline completes successfully, the Release controller
+writes the delivered artifacts into the Release CR's status:
+
+- `status.conditions[]` — includes a condition with `type: Released` and `status: True`
+  when the release fully succeeded.
+- `status.artifacts.components[].fbc_fragment` — the exact pullspec (including digest)
+  of the FBC fragment image that was contributed.
+- `status.artifacts.components[].target_index` — the index image the fragment was
+  contributed to (e.g. `quay.io/redhat/redhat----preview-operator-index:v4.14`).
+
+This data is written by the same `fbc-release` pipeline that the filter task is part
+of. It is authoritative: if the Release controller wrote `fbc_fragment = sha256:X`
+for a given target index, that fragment was genuinely delivered.
+
+### Step-by-step execution
+
+**1. OCP version extraction**
+
+For every component in the snapshot, the task inspects the fragment image using
+`skopeo inspect` and reads the `org.opencontainers.image.base.name` OCI annotation,
+which carries the base image reference including the OCP version tag (e.g. `v4.14`).
+This determines which index image the fragment targets. All OCP versions are validated
+and extracted before any filtering begins.
+
+**2. Target index resolution**
+
+The `fbc.targetIndex` field in the pipeline's data file may be a literal index image
+reference or a template containing `{{ OCP_VERSION }}`. The task substitutes the
+extracted OCP version for each component, producing one resolved target index per
+component. Components that resolve to the same target index are grouped together.
+
+**3. Application name lookup**
+
+The task reads the `releaseName` parameter (format: `namespace/name`), then queries
+the current Release CR to retrieve the `appstudio.openshift.io/application` label.
+This label is the application name that links all historical releases for the same
+product together.
+
+**4. Release CR query per target index**
+
+For each unique target index, the task lists all Release CRs in the tenant namespace
+that carry the same application label. From this list it extracts the fragment digest
+for every component whose `target_index` matches the current one, but only from
+releases that:
+
+- Are not the current in-flight release (excluded by name).
+- Have `status.conditions` with `type: Released` and `status: True` (completed
+  successfully).
+
+This produces a set of previously-published fragment digests for each target index.
+Fragments from failed or incomplete releases are excluded, which correctly handles
+partial-delivery scenarios where a prior pipeline crashed mid-run.
+
+**5. Filtering decision**
+
+For each snapshot component, the task extracts the digest from its `containerImage`
+reference and checks whether that digest appears in the published-fragments set for
+the component's resolved target index. If it does, the component is removed from the
+filtered snapshot. If it does not, the component is kept.
+
+**6. Output**
+
+The task writes a `filtered-snapshot.json` containing only the components that are
+new (not previously released), with the `ocpVersion` field attached to each. This
+file is consumed by all downstream tasks in the pipeline.
+
+### Safe fallbacks
+
+The task is designed to fail open: if it cannot determine what was previously released,
+it keeps all components rather than blocking the release. Specific safe-fallback
+conditions are:
+
+- `releaseName` parameter is empty — no lookup is performed; all components kept.
+- The current Release CR has no application label — cannot group releases; all kept.
+- The `kubectl list` call fails (RBAC denial, API unavailability) — all components kept.
+- The kubectl response is malformed JSON — all components kept.
+- A prior Release has `Released=True` but no `status.artifacts` field — that release
+  contributes zero digests to the filter set (not a failure; treated as "nothing
+  published in that release").
+- `stagedIndex=true` in the pipeline data — staged builds are always treated as
+  first-release; filtering is skipped entirely.
+
+In all fallback cases the task exits with status zero and the pipeline continues
+normally. A log warning is written so the reason is visible in the pipeline run output.
+
+### RBAC requirement
+
+The task runs with the service account used by the managed pipeline run. That
+service account must have `list` permission on `Release` resources in the tenant
+namespace. In standard Konflux deployments this permission is expected to exist
+because the Release controller and pipeline share cross-namespace access patterns for
+the same application.
+
+---
+
+## Properties of the Solution
+
+**Correctness** — The Release CR `status.artifacts` field is written by the same
+delivery pipeline after a verified successful delivery. It is the most authoritative
+available record of "what was actually released."
+
+**Partial delivery safety** — A Release with `Released=False` is explicitly excluded
+from the published-fragments set. If a prior run delivered an IIB build but failed
+before completing the advisory or signing steps, the next run will re-do the full
+pipeline rather than incorrectly treating the fragment as published.
+
+**Historical accumulation** — The query covers all prior Releases for the application,
+not just the most recent one. Fragments published in Release A and fragments published
+in Release B are both accumulated and excluded from a third release. This supports
+real-world incremental catalog growth where each release adds a few new packages to an
+index that already contains many from earlier runs.
+
+**Per-index granularity** — Each unique target index is queried independently. A
+fragment targeting v4.14 is never confused with one targeting v4.16, even if the same
+snapshot contains components for both.
+
+**Kubernetes-native** — No external service dependency. The data lives in the same
+cluster and namespace as the pipeline run itself. This eliminates the certificate
+management, HTTP retry logic, and external network reachability constraints that the
+Pyxis approach required.
+
+---
+
+## Remaining Limitations
+
+**First-party data only** — The filter can only consult releases managed through
+Konflux. If a fragment was published via a different mechanism (manual IIB submission,
+a legacy pipeline), it will not be recorded in any Release CR and will not be filtered
+out.
+
+**No cross-application scope** — The filter looks up releases by application label.
+If an operator's fragments are published under different application names in different
+releases, the historical record is fragmented and the filter may not find all prior
+releases.
+
+**No downstream completion check** — The filter uses the top-level `Released=True`
+condition as a proxy for "fully delivered." It does not inspect whether every
+downstream delivery channel (advisory, signing, Pyxis registration) individually
+succeeded. A future enhancement could add a more granular completion check against
+per-task status fields in the Release CR.
+
+For open E2E test gaps and planned improvements, see [TEST-COVERAGE.md](TEST-COVERAGE.md).
+
+---
+
+## Related
+
+- [RELEASE-2379](https://redhat.atlassian.net/browse/RELEASE-2379) — root bug
+- [`tasks/managed/filter-published-fbc-images/`](tasks/managed/filter-published-fbc-images/) — task source
+- [`tasks/managed/filter-published-fbc-images/README.md`](tasks/managed/filter-published-fbc-images/README.md) — parameter reference
+- [`pipelines/managed/fbc-release/fbc-release.yaml`](pipelines/managed/fbc-release/fbc-release.yaml) — pipeline
+- [`TEST-COVERAGE.md`](TEST-COVERAGE.md) — open test gaps

--- a/TEST-COVERAGE.md
+++ b/TEST-COVERAGE.md
@@ -1,0 +1,230 @@
+# FBC Idempotency — Coverage Gaps
+
+This document lists **what is not yet tested** for `filter-published-fbc-images` and
+the `fbc-release` pipeline, organized by failure category.
+
+Implemented unit tests (14) and existing E2E tests (`fbc-release-idempotent`, TC-01,
+TC-02) are not listed here — see
+[`tasks/managed/filter-published-fbc-images/tests/`](tasks/managed/filter-published-fbc-images/tests/)
+and [`integration-tests/fbc-release-idempotent/`](integration-tests/fbc-release-idempotent/).
+
+---
+
+## Unit Test Gaps (implementable now)
+
+### Fragmented / Release CR data edge cases
+
+#### `test-filter-published-fbc-no-app-label` — missing application label
+**Branch not covered**: `kubectl get release <name>` returns an empty application label
+(the Release CR exists but lacks the `appstudio.openshift.io/application` label).
+The task falls back to keeping all components (line 320–327 in the script). No test
+currently exercises this path — the existing `kubectl-rbac-failure` test only covers
+the `kubectl list` call failing, not the earlier `kubectl get` call returning empty.
+
+**Mock route**: `current-release-no-app-label` → `get release <name>` returns `""`.
+
+**Expected**: all components kept, ocpVersion attached.
+
+---
+
+#### `test-filter-published-fbc-release-no-artifacts` — completed Release with no artifacts
+**Branch not covered**: a prior Release has `Released=True` in its conditions but
+`status.artifacts` is `null` or absent entirely. The jq expression
+`(.status.artifacts.components // [])[]` should safely yield zero digests, keeping
+all current-snapshot components. Currently untested — the `release-not-completed`
+test exercises `Released=False`; no test exercises the `Released=True` + no-artifacts case.
+
+**Mock route**: new `test-app-no-artifacts` entry returning a Release item with
+`"conditions": [{"type": "Released", "status": "True"}]` and no `artifacts` field.
+
+**Expected**: all components kept (no digests to compare against).
+
+---
+
+### Multi-release accumulation (partial + history)
+
+#### `test-filter-published-fbc-multi-release-history` — union across several prior releases
+**Branch not covered**: the jq query iterates over ALL `.items[]` from all prior
+successful Releases, taking the union of digests. Currently every test that exercises
+filtering has exactly one prior Release CR. This means the union path is never actually
+exercised — if the union logic had a bug (e.g. only the last Release's fragments were
+used) no existing test would catch it.
+
+**Scenario**: two prior Release CRs, both `Released=True`, both targeting the same
+index:
+- Release A: recorded `sha256:F1`
+- Release B: recorded `sha256:F3`
+
+New snapshot: `comp1@sha256:F1`, `comp2@sha256:F2`, `comp3@sha256:F3`, `comp4@sha256:F4`.
+
+Expected filtered snapshot: only `comp2` and `comp4` (F1 from A and F3 from B both
+filtered; F2 and F4 not in any Release CR).
+
+**Mock route**: new `test-app-history` entry returning two Release items for the same
+target index.
+
+---
+
+### Multi-version + partial combined
+
+#### `test-filter-published-fbc-multi-ocp-partial` — per-index partial filtering across two OCP versions
+**Branch not covered**: the combination of multi-OCP grouping AND partial filtering
+within each group. Existing tests cover them separately: `multi-ocp-versions` tests
+per-index grouping (one published per index), `partial-published` tests partial
+filtering for a single index. No test combines both axes.
+
+**Scenario**: four components, two OCP versions, each version partially published:
+- `comp1@sha256:P1`, OCP v4.14 → in prior Release CR for v4.14 index → **filter out**
+- `comp2@sha256:N2`, OCP v4.14 → NOT in any Release CR → **keep**
+- `comp3@sha256:N3`, OCP v4.16 → NOT in any Release CR → **keep**
+- `comp4@sha256:N4`, OCP v4.16 → NOT in any Release CR → **keep**
+
+Expected: filtered snapshot has `comp2`, `comp3`, `comp4`; `comp1` is removed.
+
+**Mock route**: new `test-app-multi-partial` returning one prior Release with `sha256:P1`
+only for the v4.14 target index, and empty artifacts for the v4.16 index.
+
+---
+
+## E2E Integration Gaps
+
+### All-published (empty filtered snapshot) — TC-07: full pipeline pass
+
+**Status: ✅ Implemented**
+
+`prepare-fbc-snapshot` and `prepare-fbc-parameters` now handle an empty filtered
+snapshot gracefully:
+- `prepare-fbc-snapshot`: exits 0, logs that nothing needs to be prepared. The snapshot
+  file is unchanged so the trusted artifact step produces a valid (empty) artifact.
+- `prepare-fbc-parameters`: writes `mustPublishIndexImage=false`, `mustSignIndexImage=false`,
+  and `mustOverwriteFromIndexImage=false`, then exits 0. Downstream tasks skip via their
+  existing `when` conditions on `mustPublishIndexImage`.
+
+Phase 3 in `fbc-release-idempotent` (`wait_for_release` hard wait, `expected_skipped="true"`)
+now exercises the full path end-to-end: filter finds all fragments → empty snapshot → both
+prepare tasks exit 0 → `add-fbc-contribution` skipped → pipeline succeeds.
+
+Unit tests:
+- `tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-empty-snapshot.yaml`
+- `tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-empty-snapshot.yaml`
+
+---
+
+### Partial — TC-03: some fragments published, some new
+
+**Status: ✅ Implemented**
+
+`run_tc03_partial_filtering` in `fbc-release-idempotent/test.sh` implements this:
+1. After Phase 1 (multi-OCP, two components), extract comp2's `fbc_fragment` and
+   `target_index` from Phase 1's Release CR.
+2. Create a fixture Release CR patched with `Released=True` recording only comp2.
+3. Release the multi-component snapshot (comp1 + comp2) against the fixture.
+4. Assert: `add-fbc-contribution` ran (comp1 was kept); filter logs show comp2 FILTERED,
+   comp1 KEPT.
+
+TC-03 is skipped automatically if Phase 1 did not complete with both components
+(e.g., IIB failure for v4.14 in staging).
+
+---
+
+### Multi-release accumulation — TC-06: union across three sequential releases
+
+**What it tests**: Release 1 publishes `comp1`. Release 2 publishes `comp2`. Release 3
+triggers with a snapshot containing `comp1 + comp2 + comp3`. The filter must consult
+both prior Release CRs, accumulate their fragments, and pass only `comp3` to
+`add-fbc-contribution`.
+
+This is the most realistic production scenario for an iterative operator catalog — each
+release adds one or two new FBC packages to an index that already contains many from
+prior runs.
+
+**Why unit tests are not enough**: the accumulation path in the real pipeline also
+depends on the Release controller writing the correct `status.artifacts.components[]`
+structure. A bug there (e.g. empty `fbc_fragment` field) would evade unit test mocks.
+
+**Complexity**: Medium-High. Requires three sequential releases and assertions after each.
+
+---
+
+### All-published (empty filtered snapshot) — TC-07: pipeline handles zero components
+
+**What it tests**: a second release of an IDENTICAL snapshot after the first succeeded.
+The filter produces a snapshot with ZERO components. This is a critical path because:
+
+- Downstream tasks (`add-fbc-contribution`, `sign-index-image`) receive an empty
+  component list and must handle it gracefully without crashing.
+- The Release CR `status.artifacts` must reflect zero new contributions.
+- No new IIB build should be triggered.
+
+Currently this scenario is covered at unit level (`all-published` test) but never
+run end-to-end. A downstream task that assumes `components` is non-empty would
+silently break here.
+
+**Complexity**: Low — trigger the existing `fbc-release-idempotent` test with a
+completed Phase 1 Release CR already in place, skip straight to Phase 2, and assert
+that the pipeline completes without calling `add-fbc-contribution`.
+
+---
+
+### Race condition — TC-02 deterministic variant
+
+The existing TC-02 implementation is timing-based: Phase 2 is started concurrently
+with Phase 1 hoping the filter task fires before Phase 1 completes. This is
+non-deterministic and prints a warning rather than failing if timing doesn't hold.
+
+**Deterministic alternative**: pre-create a Release CR for the same application with
+`status.conditions = [{type: Released, status: Unknown, reason: Running}]` (in-flight,
+not completed). Then trigger a release and verify:
+
+1. The filter task sees this in-flight Release but correctly ignores it (not `True`).
+2. All components are kept.
+
+This removes the timing dependency while still exercising the in-flight-release path.
+
+**Complexity**: Low — replace the concurrent trigger with a pre-seeded fixture CR.
+
+---
+
+### Partial delivery — TC-05: Release CR incomplete after mid-pipeline failure
+
+**What it tests**: Phase 1's pipeline fails after `add-fbc-contribution` completes
+(IIB index image built) but before `create-advisory` finishes. The Release CR's
+`Released` condition is `False` (or never set to `True`).
+
+Phase 2 must re-run the full pipeline because the prior Release was not completed:
+
+1. `filter-published-fbc-images` sees the prior Release with `Released=False` → not
+   counted → all components kept.
+2. `add-fbc-contribution` runs again.
+3. The release completes.
+
+The unit test `test-filter-published-fbc-release-not-completed` covers the filter
+decision. The E2E scenario requires injecting a pipeline failure mid-way.
+
+**Complexity**: High — requires chaos injection or a pipeline that intentionally fails
+at a specific task.
+
+---
+
+## Summary
+
+| Gap | Type | Complexity | Status |
+|---|:---:|:---:|---|
+| `no-app-label` unit test | unit | Low | ✅ implemented |
+| `release-no-artifacts` unit test | unit | Low | ✅ implemented |
+| `multi-release-history` unit test | unit | Low | ✅ implemented |
+| `multi-ocp-partial` unit test | unit | Low | ✅ implemented |
+| TC-00/TC-01/TC-02 e2e (Pyxis → Release CR migration) | e2e | Medium | ✅ implemented |
+| TC-07 E2E (all-published, empty snapshot) | e2e | Low | ✅ implemented — pipeline gap fixed in `prepare-fbc-snapshot` and `prepare-fbc-parameters` |
+| TC-03 E2E (partial new) | e2e | Medium | ✅ implemented — fixture Release CR via `kubectl patch --subresource=status` |
+| TC-06 E2E (3-release accumulation) | e2e | Medium-High | pending — most realistic production scenario |
+| TC-02 deterministic race condition | e2e | Low | pending — replace timing-based with fixture in-flight CR |
+| TC-05 E2E (partial delivery) | e2e | High | pending — requires chaos injection |
+
+---
+
+## Related
+
+- [`tasks/managed/filter-published-fbc-images/`](tasks/managed/filter-published-fbc-images/) — task under test
+- [`integration-tests/fbc-release-idempotent/`](integration-tests/fbc-release-idempotent/) — idempotency test suite
+- [RELEASE-2379](https://redhat.atlassian.net/browse/RELEASE-2379) — root bug

--- a/integration-tests/fbc-release-idempotent/README.md
+++ b/integration-tests/fbc-release-idempotent/README.md
@@ -1,0 +1,126 @@
+# fbc-release-idempotent test
+
+Integration test that validates the idempotency behavior of the `filter-published-fbc-images`
+task within the `fbc-release` pipeline. The test creates two releases from the same snapshot
+and verifies that the second release correctly detects the already-published index image in
+Pyxis using the `repositories.*` filter fields.
+
+## Setup
+
+### Dependencies
+
+* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
+* GitHub personal access token (classic) for the above repo with **admin:repo_hook**,
+  **delete_repo**, **repo** scopes.
+* The password to the vault files. (Contact a member of the Release team should you want to
+  run this test suite.)
+* Access to the target cluster and the tenant and managed namespaces.
+  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant
+    namespaces.
+
+### Required Environment Variables
+
+- `GITHUB_TOKEN`
+  - The GitHub personal access token needed for repo operations.
+  - The repo in question can be located in [test.env](test.env).
+- `VAULT_PASSWORD_FILE`
+  - Path to a file that contains the Ansible Vault password needed to decrypt the secrets
+    required for testing.
+- `RELEASE_CATALOG_GIT_URL`
+  - The release-service-catalog URL to use in the RPA.
+  - This is provided when testing PRs.
+- `RELEASE_CATALOG_GIT_REVISION`
+  - The release-service-catalog revision to use in the RPA.
+  - This is provided when testing PRs.
+
+### Optional Environment Variables
+
+- `KUBECONFIG`
+  - The KUBECONFIG file to use to log in to the target cluster.
+  - This is provided when testing PRs.
+
+### Test Properties
+
+#### [test.env](test.env)
+
+This file contains resource names and configuration values needed for testing, including a
+unique UUID-based suffix to avoid name collisions with other test runs.
+
+### Test Functions
+
+#### [lib/test-functions.sh](../lib/test-functions.sh)
+
+This file contains re-usable functions shared across all integration tests.
+
+### Secrets
+
+Secrets required for testing are stored in Ansible Vault files. The vault files in this
+test symlink to the credentials in the sibling `fbc-release` test:
+
+- [vault/managed-secrets.yaml](vault/managed-secrets.yaml) → `../fbc-release/vault/managed-secrets.yaml`
+- [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml) → `../fbc-release/vault/tenant-secrets.yaml`
+
+## Running the Test
+
+```shell
+integration-tests/run-test.sh fbc-release-idempotent --no-cve --skip-cleanup
+```
+
+## Test Workflow
+
+### Phase 1 — First Release
+
+1. A fresh FBC component is released through the `fbc-release` pipeline.
+2. `filter-published-fbc-images` runs; Pyxis returns no index image (first release) so all
+   components are kept.
+3. `add-fbc-contribution-to-index-image` runs and publishes the index image.
+4. `create-pyxis-image` registers the index image in Pyxis (identified by
+   `repositories.registry`, `repositories.repository`, and `repositories.tags.name`).
+
+### Phase 2 — Second Release (same snapshot)
+
+1. A second `Release` CR is created pointing to the exact same snapshot.
+2. `filter-published-fbc-images` queries Pyxis using the correct `repositories.*` filter.
+3. Pyxis returns the previously published index image (`data` array is non-empty).
+4. If the index image record contains fragment digest data (`related_images` / `bundles`),
+   matching components are filtered out and `add-fbc-contribution-to-index-image` is skipped.
+
+### Known Limitation
+
+The Pyxis `ContainerImage` schema does not store fragment digests inside the index image
+record (`related_images` and `bundles` are OLM concepts not natively present in Pyxis). Until
+fragment digests are separately registered in Pyxis (or an alternative detection mechanism is
+added), Phase 2 confirms that the **Pyxis query uses the correct filter fields** and that the
+index image is found, but cannot assert that individual fragments are filtered. The task falls
+back safely to keeping all components when fragment digest data is absent.
+
+## Debugging
+
+Use `--skip-cleanup` to preserve all Kubernetes resources after the test run for inspection:
+
+```shell
+integration-tests/run-test.sh fbc-release-idempotent --no-cve --skip-cleanup
+```
+
+## Maintenance
+
+Should you need to add or update a secret, the vault files are symlinked from `fbc-release`.
+Edit the originals there:
+
+```shell
+ansible-vault decrypt ../fbc-release/vault/tenant-secrets.yaml \
+  --output /tmp/tenant-secrets.yaml \
+  --vault-password-file <vault-password-file>
+vi /tmp/tenant-secrets.yaml
+ansible-vault encrypt /tmp/tenant-secrets.yaml \
+  --output ../fbc-release/vault/tenant-secrets.yaml \
+  --vault-password-file <vault-password-file>
+rm /tmp/tenant-secrets.yaml
+```
+
+## Related
+
+- [RELEASE-2379](https://redhat.atlassian.net/browse/RELEASE-2379) — bug: `docker_image_id`
+  filter returns empty results from Pyxis
+- [`tasks/managed/filter-published-fbc-images/`](../../tasks/managed/filter-published-fbc-images/) — the task under test
+- [`integration-tests/fbc-release/`](../fbc-release/) — base FBC release test this test extends

--- a/integration-tests/fbc-release-idempotent/resources/managed/ec-policy.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/managed/ec-policy.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/managed/ec-policy.yaml

--- a/integration-tests/fbc-release-idempotent/resources/managed/kustomization.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/managed/kustomization.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/managed/kustomization.yaml

--- a/integration-tests/fbc-release-idempotent/resources/managed/rpa.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/managed/rpa.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: ${release_plan_admission_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  applications:
+    - ${application_name}
+  data:
+    fbc:
+      fromIndex: "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:{{ OCP_VERSION }}"
+      stagedIndex: false
+      targetIndex: "quay.io/redhat/redhat----preview-operator-index:{{ OCP_VERSION }}"
+      publishingCredentials: "fbc-preview-publishing-credentials"
+      requestTimeoutSeconds: 18000
+      buildTimeoutSeconds: 18000
+      hotfix: false
+      issueId: ""
+      preGA: false
+      productName: ""
+      productVersion: ""
+      allowedPackages:
+        - "example-operator"
+        - "example-operator2"
+    pyxis:
+      server: stage
+      secret: pyxis-${component_name}
+    sign:
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
+      cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
+  origin: ${tenant_namespace}
+  pipeline:
+    pipelineRef:
+      params:
+        - name: url
+          value: "${RELEASE_CATALOG_GIT_URL}"
+        - name: revision
+          value: "${RELEASE_CATALOG_GIT_REVISION}"
+        - name: pathInRepo
+          value: pipelines/managed/fbc-release/fbc-release.yaml
+      resolver: git
+    serviceAccountName: ${managed_sa_name}
+    timeouts:
+      pipeline: 4h0m0s
+      tasks: 4h0m0s
+  policy: standard-${component_name}

--- a/integration-tests/fbc-release-idempotent/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/managed/sa-rolebinding.yaml

--- a/integration-tests/fbc-release-idempotent/resources/managed/sa.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/managed/sa.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/managed/sa.yaml

--- a/integration-tests/fbc-release-idempotent/resources/tenant/application.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/tenant/application.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/tenant/application.yaml

--- a/integration-tests/fbc-release-idempotent/resources/tenant/component.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/tenant/component.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/tenant/component.yaml

--- a/integration-tests/fbc-release-idempotent/resources/tenant/component2.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/tenant/component2.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '{"name": "fbc-builder", "bundle": "latest"}'
+  name: ${component2_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component2_name}
+  secret: pipelines-as-code-secret-${component2_name}
+  source:
+    git:
+      dockerfileUrl: catalog.Dockerfile
+      revision: ${component2_branch}
+      context: "4.14"
+      url: "${component2_git_url}"

--- a/integration-tests/fbc-release-idempotent/resources/tenant/kustomization.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/tenant/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - component2.yaml
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/fbc-release-idempotent/resources/tenant/rp.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/tenant/rp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "false"
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_name}"
+    originating-tool: "${originating_tool}"
+  name: ${release_plan_name}
+spec:
+  application: ${application_name}
+  target: ${managed_namespace}

--- a/integration-tests/fbc-release-idempotent/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/tenant/sa-rolebinding.yaml

--- a/integration-tests/fbc-release-idempotent/resources/tenant/sa.yaml
+++ b/integration-tests/fbc-release-idempotent/resources/tenant/sa.yaml
@@ -1,0 +1,1 @@
+../../../fbc-release/resources/tenant/sa.yaml

--- a/integration-tests/fbc-release-idempotent/test.env
+++ b/integration-tests/fbc-release-idempotent/test.env
@@ -1,0 +1,35 @@
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
+
+export originating_tool="fbc-release-idempotent-e2e-test"
+
+# Namespaces
+export tenant_namespace=dev-release-team-tenant
+export managed_namespace=managed-release-team-tenant
+
+export application_name=fbc-idem-app-${uuid}
+export component_type=fbc-release-idempotent
+export component_name=${component_type}-${uuid}
+export component_branch=${component_name}
+## do not change this. it is a known branch created by Konflux
+export appstudio_component_branch="appstudio-${component_name}"
+
+export component_github_org=hacbs-release-tests
+export component_base_branch=fbc-release-base
+export component_repo_name=${component_github_org}/${component_name}
+export component_base_repo_name=${component_github_org}/e2e-base
+export component_git_url=https://github.com/$component_repo_name
+
+# TC-01: second component targeting OCP v4.16 (different targetIndex → multi-Pyxis-query path)
+export component2_name=${component_type}-v2-${uuid}
+export component2_branch=${component2_name}
+export component2_base_branch=fbc-release-idempotent-v416-base
+export component2_repo_name=${component_repo_name}
+export component2_git_url=https://github.com/${component2_repo_name}
+
+export tenant_sa_name=fbc-release-idempotent-sa-${uuid}
+export release_plan_name=fbc-release-idempotent-rp-${uuid}
+
+export managed_sa_name=fbc-release-idempotent-sa-${uuid}
+export release_plan_admission_name=fbc-release-idempotent-rpa-${uuid}

--- a/integration-tests/fbc-release-idempotent/test.sh
+++ b/integration-tests/fbc-release-idempotent/test.sh
@@ -6,21 +6,31 @@
 #
 # [TC-01] Multi-OCP-version snapshot (Phase 1)
 #   Two components are built: component1 targets OCP v4.13, component2 targets OCP v4.16.
-#   Their images are released together.  The filter-published-fbc-images task must issue
-#   one Pyxis query per unique targetIndex (i.e. two queries), and both components must
-#   produce expected release artifacts.
+#   Their images are released together. The filter-published-fbc-images task must issue
+#   one Release CR query per unique targetIndex (two queries in total), and both components
+#   must produce expected release artifacts.
 #
 # [TC-02] Early retry / race-condition safe-fallback (Phase 2, concurrent with Phase 1)
-#   A second Release is created immediately after Phase 1 starts — before
-#   create-pyxis-image has had a chance to register the index images in Pyxis.
-#   The filter task should find 0 existing index images and fall back to running
-#   add-fbc-contribution for all fragments.
+#   A second Release is created immediately after Phase 1 starts — before Phase 1's
+#   Release CR has status.conditions[Released]=True. The filter task queries Release CRs,
+#   finds no completed prior releases for this application, and keeps all fragments
+#   (safe fallback). If Phase 1 completes before Phase 2's filter task runs, TC-02 may
+#   instead observe already-released fragments; in that case a warning is printed rather
+#   than a hard failure (timing is non-deterministic).
 #
 # [TC-00] Sequential idempotent re-release (Phase 3)
-#   After Phase 1 finishes and Pyxis is populated, a third Release is created from the
-#   same snapshot.  The filter task must use the correct repositories.* filter and should
-#   either find + skip the already-published fragments (full idempotency) or fall back
-#   gracefully when fragment-level data is absent from the Pyxis ContainerImage schema.
+#   After Phase 1 finishes and its Release CR records the delivered fbc_fragment digests,
+#   a third Release is created from the same snapshot. The filter task queries Phase 1's
+#   Release CR, finds the already-released fragment digests, and filters them all out.
+#
+#   KNOWN PIPELINE GAP: When all components are filtered out, prepare-fbc-snapshot
+#   currently exits 1 ("ERROR: No components found in snapshot"). This causes the
+#   pipeline to fail rather than completing gracefully. The filter task itself is correct
+#   (it produces an empty filtered snapshot), but downstream handling of the empty-snapshot
+#   case requires a separate fix in prepare-fbc-snapshot / prepare-fbc-parameters.
+#   Until that fix lands, Phase 3 is expected to fail at prepare-fbc-snapshot; the
+#   filter-published-fbc-images assertions (Release CR lookup, fragment matching) are
+#   still verified from the task logs before the failure.
 #
 # Generic helpers (get_pipelinerun_name_from_release, get_release_json, wait_for_release,
 # is_managed_task_skipped, wait_for_managed_pipeline_task, get_managed_task_logs) are
@@ -387,10 +397,14 @@ verify_phase1_release() {
     return "${failures}"
 }
 
+# ──────────────────────────────────────────────────────────────────────────────
 # Verify the filter-published-fbc-images task behavior for any phase.
+# The task now uses kubectl Release CR lookup (not Pyxis HTTP calls).
 # Arguments: $1 release name  $2 phase label (for log output)
-#            $3 expected_add_fbc_skipped  ("true" = skipped expected, "false" = not expected,
-#                                          "any" = either is acceptable)
+#            $3 expected_add_fbc_skipped  ("true" = must be skipped,
+#                                          "false" = must not be skipped,
+#                                          "any"   = either is acceptable)
+# ──────────────────────────────────────────────────────────────────────────────
 verify_filter_behavior() {
     local release_name=$1
     local phase_label=$2
@@ -415,26 +429,43 @@ verify_filter_behavior() {
     else
         echo ""
         echo "--- filter-published-fbc-images logs (excerpt) ---"
-        echo "${filter_logs}" | grep -E "Pyxis|index|Found|filter|fragment|repositories|targetIndex|OCP" | head -20
+        echo "${filter_logs}" | \
+            grep -E "Release namespace|Application|targetIndex|Release CR|fragment|OCP version|Querying|filtered|kept|fallback" \
+            | head -30
         echo "---"
 
-        # Assertion: correct filter field
+        # Assertion: task used Release CR lookup (not Pyxis)
         echo ""
-        echo "Assertion: Pyxis query uses repositories.registry filter (not docker_image_id)"
-        if echo "${filter_logs}" | grep -q "repositories.registry"; then
-            echo "✅ repositories.registry filter confirmed"
-        elif echo "${filter_logs}" | grep -q "docker_image_id"; then
-            echo "🔴 Filter task still uses incorrect docker_image_id filter"
+        echo "Assertion: filter used Release CR lookup"
+        if echo "${filter_logs}" | grep -q "Querying Release CRs"; then
+            echo "✅ Release CR lookup confirmed in filter task logs"
+        elif echo "${filter_logs}" | grep -q "repositories.registry"; then
+            echo "🔴 Filter task still uses Pyxis HTTP calls — Release CR migration not applied"
             return 1
         else
-            echo "⚠️  Filter field not visible in logs — check manually"
+            echo "⚠️  Release CR lookup not visible in logs — check manually"
         fi
 
-        # TC-01 assertion: both OCP versions queried
-        if echo "${filter_logs}" | grep -qE "v4\.(13|16)"; then
-            local ocp_versions
-            ocp_versions=$(echo "${filter_logs}" | grep -oE "v4\.[0-9]+" | sort -u | tr '\n' ' ')
-            echo "✅ OCP versions queried: ${ocp_versions}"
+        # Assertion: correct namespace and application extracted
+        if echo "${filter_logs}" | grep -qE "Release namespace|Application\s*:"; then
+            echo "✅ Namespace and application label extraction confirmed"
+        fi
+
+        # TC-01 assertion: multiple targetIndex values queried
+        local unique_indices
+        unique_indices=$(echo "${filter_logs}" | grep -oP "(?<=targetIndex: ).*" | sort -u | wc -l)
+        if [ "${unique_indices}" -ge 2 ]; then
+            echo "✅ Multiple targetIndex values queried: ${unique_indices} distinct index image(s)"
+            echo "${filter_logs}" | grep "targetIndex:" | sort -u | head -5
+        elif [ "${unique_indices}" -eq 1 ]; then
+            echo "ℹ️  Single targetIndex queried (expected 2 for TC-01 multi-OCP)"
+        fi
+
+        # Log the published-fragments count found by the filter
+        local found_line
+        found_line=$(echo "${filter_logs}" | grep "previously-published fragment digest" | tail -1)
+        if [ -n "${found_line}" ]; then
+            echo "✅ Fragment lookup result: ${found_line}"
         fi
     fi
 
@@ -452,9 +483,8 @@ verify_filter_behavior() {
             if [ "${task_skipped}" = "true" ]; then
                 echo "✅ add-fbc-contribution was skipped — idempotency confirmed"
             else
-                echo "⚠️  add-fbc-contribution ran (expected skip)"
-                echo "   Full fragment-level idempotency requires Pyxis fragment data"
-                echo "   (related_images/bundles are OLM concepts absent from Pyxis schema)"
+                echo "⚠️  add-fbc-contribution ran (expected it to be skipped)"
+                echo "   Check filter task logs: were previously-published fragments found?"
             fi
             ;;
         "false")
@@ -467,9 +497,9 @@ verify_filter_behavior() {
             ;;
         "any")
             if [ "${task_skipped}" = "true" ]; then
-                echo "✅ add-fbc-contribution skipped (Pyxis had index + fragment data)"
+                echo "✅ add-fbc-contribution skipped (all fragments found in prior Release CRs)"
             else
-                echo "ℹ️  add-fbc-contribution ran (Pyxis lacked fragment-level data or safe fallback)"
+                echo "ℹ️  add-fbc-contribution ran (no prior Release CR data found — safe fallback)"
             fi
             ;;
     esac
@@ -479,6 +509,8 @@ verify_filter_behavior() {
 # wait_for_releases override
 # Creates Phase 1 release (TC-01 multi-OCP) and the TC-02 early-retry release
 # concurrently, then waits for both.
+# TC-02 fires before Phase 1's Release CR is completed (Released=True), so the
+# filter task finds no completed prior releases → keeps all components.
 # ══════════════════════════════════════════════════════════════════════════════
 wait_for_releases() {
     local snapshot_name
@@ -505,7 +537,7 @@ spec:
 EOF
 
     echo ""
-    echo "Creating TC-02 early-retry release immediately (Pyxis not yet populated): ${early_retry_release}"
+    echo "Creating TC-02 early-retry release immediately (Phase 1 Release CR not yet Released=True): ${early_retry_release}"
     kubectl apply -f - <<EOF
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
@@ -551,7 +583,7 @@ EOF
         echo "   TC-00 (Phase 3) will proceed with the v4.13-only snapshot."
     fi
     if [ "$s2" = "failure" ]; then
-        echo "⚠️  TC-02 early-retry failed — same IIB limitation applies"
+        echo "⚠️  TC-02 early-retry failed — same IIB limitation may apply"
     fi
 
     export RELEASE_NAMES="${phase1_release} ${early_retry_release}"
@@ -559,83 +591,59 @@ EOF
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Poll Pyxis directly until the index image tag is visible (TC-00 pre-condition).
-# Mirrors the approach in PR #2046 (rh-push-to-registry-redhat-io idempotent tests).
-# Extracts cert/key from the managed-secrets.yaml vault file.
-# Arguments: $1 = repository (e.g. "quay.io/redhat/redhat----preview-operator-index")
-#            $2 = tag       (e.g. "v4.13")
+# Wait for Phase 1 Release CR to have status.artifacts populated.
+# This replaces the old wait_for_pyxis_index_image function.
+# The filter task in Phase 3 reads fbc_fragment digests from these artifacts,
+# so Phase 3 must not start until Phase 1's artifacts are written.
+# Arguments: $1 = Phase 1 release name
 # ──────────────────────────────────────────────────────────────────────────────
-wait_for_pyxis_index_image() {
-    local repository=$1
-    local tag=$2
-    # Use the stage-internal URL — the external preprod URL has an SSL hostname mismatch
-    # when connecting from outside the cluster.  Both endpoints share the same backend.
-    local pyxis_url="https://pyxis.stage.engineering.redhat.com/"
+wait_for_phase1_release_cr_artifacts() {
+    local release_name=$1
     local max_attempts=20
     local attempt=1
 
     echo ""
-    echo "Polling Pyxis for index image ${repository}:${tag} (up to $((max_attempts * 30))s)..."
+    echo "Waiting for Phase 1 Release CR ${release_name} to have Released=True with artifacts..."
+    echo "(filter-published-fbc-images in Phase 3 reads fbc_fragment digests from these artifacts)"
 
-    # Extract Pyxis client certificate and key from the managed-secrets vault file.
-    local secrets_file="${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
-    local cert_b64 key_b64
-    cert_b64=$(yq '. | select(.metadata.name | contains("pyxis-")) | .data.cert' "${secrets_file}" | head -1)
-    key_b64=$(yq  '. | select(.metadata.name | contains("pyxis-")) | .data.key'  "${secrets_file}" | head -1)
-
-    if [ -z "${cert_b64}" ] || [ -z "${key_b64}" ]; then
-        echo "⚠️  Could not extract Pyxis cert/key from ${secrets_file} — skipping Pyxis poll"
-        return 0
-    fi
-
-    base64 -d <<< "${cert_b64}" > /tmp/pyxis-poll.crt
-    base64 -d <<< "${key_b64}"  > /tmp/pyxis-poll.key
-
-    local registry repo encoded_filter pyxis_query_url
-    registry=$(cut -d'/' -f1 <<< "${repository}")
-    repo="${repository#*/}"
-    encoded_filter=$(printf '%s' \
-        "repositories.registry==${registry};repositories.repository==${repo};repositories.tags.name==${tag}" \
-        | jq -sRr @uri)
-    pyxis_query_url="${pyxis_url}v1/images?filter=${encoded_filter}&page_size=1"
+    PHASE1_ARTIFACTS_FOUND="false"
 
     while [ $attempt -le $max_attempts ]; do
-        local response http_code
-        response=$(curl -s \
-            --cert /tmp/pyxis-poll.crt \
-            --key  /tmp/pyxis-poll.key \
-            --max-time 30 --connect-timeout 10 \
-            -w "\n%{http_code}" \
-            "${pyxis_query_url}" 2>/dev/null) || true
+        local release_json released_status artifacts_count
+        release_json=$(kubectl get release "${release_name}" \
+            -n "${tenant_namespace}" -o json 2>/dev/null || echo "{}")
 
-        http_code=$(tail -1 <<< "${response}")
-        local body
-        body=$(head -n -1 <<< "${response}")
+        released_status=$(jq -r \
+            '[.status.conditions[]? | select(.type=="Released") | .status][0] // ""' \
+            <<< "${release_json}")
 
-        if [[ "${http_code}" =~ ^2 ]]; then
-            local count
-            count=$(jq '.total // (.data | length)' <<< "${body}" 2>/dev/null || echo 0)
-            if [ "${count}" -gt 0 ]; then
-                echo "✅ Pyxis confirmed index image ${repository}:${tag} (${count} record(s)) after attempt ${attempt}"
-                rm -f /tmp/pyxis-poll.crt /tmp/pyxis-poll.key
-                return 0
-            fi
-            echo "  Attempt ${attempt}/${max_attempts}: Pyxis returned 0 records (HTTP ${http_code}), retrying in 30s..."
-        else
-            echo "  Attempt ${attempt}/${max_attempts}: Pyxis HTTP ${http_code}, retrying in 30s..."
+        artifacts_count=$(jq -r \
+            '(.status.artifacts.components // []) | length' \
+            <<< "${release_json}")
+
+        if [ "${released_status}" = "True" ] && [ "${artifacts_count}" -gt 0 ]; then
+            echo "✅ Phase 1 Release CR ${release_name}: Released=True, ${artifacts_count} artifact(s)"
+            echo "   Fragment digests recorded in Phase 1:"
+            jq -r '.status.artifacts.components[]? |
+                "     component=\(.componentName // "n/a")  fbc_fragment=\(.fbc_fragment // "n/a")  target_index=\(.target_index // "n/a")"' \
+                <<< "${release_json}" | head -5
+            PHASE1_ARTIFACTS_FOUND="true"
+            export PHASE1_RELEASE_JSON="${release_json}"
+            return 0
         fi
 
+        echo "  Attempt ${attempt}/${max_attempts}: Released=${released_status:-pending}, artifacts=${artifacts_count}, retrying in 30s..."
         sleep 30
         attempt=$((attempt + 1))
     done
 
-    rm -f /tmp/pyxis-poll.crt /tmp/pyxis-poll.key
-    echo "⚠️  Pyxis poll timed out — index image ${repository}:${tag} not yet visible"
-    echo "   Phase 3 will proceed; filter task may observe empty Pyxis result (safe fallback)"
+    echo "⚠️  Timed out waiting for Phase 1 Release CR artifacts (Released never became True)"
+    echo "   Phase 3 will run as a safe-fallback test (all components kept, assertion softened)."
+    return 0  # non-fatal: Phase 3 still runs
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Compare Phase 1 and Phase 3 artifacts (TC-05 partial assertion).
+# Compare Phase 1 and Phase 3 artifacts (downstream pipeline idempotency assertion).
 # Asserts that the Phase 3 re-release produces the same ocp_version as Phase 1.
 # An iibLog match is best-effort: IIB may assign a new build number even for
 # identical fragments, so a mismatch is a warning rather than a failure.
@@ -650,11 +658,11 @@ compare_phase_artifacts() {
 
     echo ""
     echo "════════════════════════════════════════════════════════════════════"
-    echo "  [TC-05] Phase 1 vs Phase 3 Artifact Comparison"
+    echo "  Phase 1 vs Phase 3 Artifact Comparison"
     echo "════════════════════════════════════════════════════════════════════"
 
     local phase3_json
-    phase3_json=$(get_release_json "${phase3_release}")
+    phase3_json=$(get_release_json "${phase3_release}" 2>/dev/null || echo "{}")
 
     local phase3_iib_log phase3_ocp_version
     phase3_iib_log=$(jq -r \
@@ -687,11 +695,188 @@ compare_phase_artifacts() {
         else
             echo "  ℹ️  iibLog differs — IIB created a new build for identical content"
             echo "     This is acceptable: IIB does not guarantee build-number reuse."
-            echo "     Confirm both logs show the same index image digest to verify semantic equivalence."
         fi
     else
         echo "  ⚠️  iibLog not available in one or both phases — skipping comparison"
     fi
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TC-03: Partial filtering — create a fixture Release CR that records only one
+# component as already published, then re-release the multi-component snapshot.
+# Expected: the "already-published" component is filtered out; the other is kept.
+#
+# Requires Phase 1 to have succeeded with both components in status.artifacts so
+# we know which fbc_fragment digests and target_index values to seed.  If Phase 1
+# artifacts are unavailable, TC-03 is skipped with a warning.
+#
+# Arguments: $1 = Phase 1 release name
+# ──────────────────────────────────────────────────────────────────────────────
+run_tc03_partial_filtering() {
+    local phase1_release=$1
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  [TC-03] Partial Filtering — Fixture Release CR"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    if [ "${PHASE1_ARTIFACTS_FOUND:-false}" != "true" ]; then
+        echo "⚠️  Phase 1 artifacts not available — skipping TC-03"
+        echo "   Re-run after a successful Phase 1 (both components released) to exercise TC-03."
+        return 0
+    fi
+
+    local phase1_json="${PHASE1_RELEASE_JSON}"
+    local artifacts_count
+    artifacts_count=$(jq '(.status.artifacts.components // []) | length' <<< "${phase1_json}")
+
+    if [ "${artifacts_count}" -lt 2 ]; then
+        echo "⚠️  Phase 1 has ${artifacts_count} artifact(s) — need 2 for TC-03 partial test"
+        echo "   Skipping TC-03."
+        return 0
+    fi
+
+    # Use comp2 (index 1) as the "already published" component for the fixture.
+    # comp1 (index 0) will be the "new" component that must survive filtering.
+    local comp2_fragment comp2_target_index comp2_name
+    comp2_fragment=$(jq -r     '.status.artifacts.components[1].fbc_fragment  // ""' <<< "${phase1_json}")
+    comp2_target_index=$(jq -r '.status.artifacts.components[1].target_index   // ""' <<< "${phase1_json}")
+    comp2_name=$(jq -r         '.status.artifacts.components[1].componentName  // "component2"' <<< "${phase1_json}")
+
+    local comp1_name
+    comp1_name=$(jq -r '.status.artifacts.components[0].componentName // "component1"' <<< "${phase1_json}")
+
+    if [ -z "${comp2_fragment}" ] || [ "${comp2_fragment}" = "null" ]; then
+        echo "⚠️  comp2 fbc_fragment not found in Phase 1 artifacts — skipping TC-03"
+        return 0
+    fi
+
+    echo "Fixture Release CR will record:"
+    echo "  component : ${comp2_name}"
+    echo "  fbc_fragment: ${comp2_fragment}"
+    echo "  target_index: ${comp2_target_index:-<none>}"
+    echo ""
+    echo "Expected result after filtering:"
+    echo "  ${comp2_name} → FILTERED (digest found in fixture Release CR)"
+    echo "  ${comp1_name} → KEPT     (digest NOT in fixture Release CR)"
+
+    # Create the fixture Release CR
+    local fixture_release="fbc-idem-tc03-fixture-${uuid}"
+    echo ""
+    echo "Creating fixture Release CR: ${fixture_release}"
+    kubectl apply -f - <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${fixture_release}
+  namespace: ${tenant_namespace}
+  labels:
+    appstudio.openshift.io/application: ${application_name}
+    originating-tool: "${originating_tool}"
+    test-type: "tc03-fixture"
+spec:
+  snapshot: fixture-snapshot-tc03
+  releasePlan: ${release_plan_name}
+EOF
+
+    # Patch the status to mark it Released=True with comp2's artifact.
+    # The filter task only considers Release CRs with status.conditions[Released].status=True.
+    echo "Patching fixture Release CR status (Released=True, comp2 artifact)..."
+    kubectl patch release "${fixture_release}" \
+        -n "${tenant_namespace}" \
+        --subresource=status --type=merge \
+        -p "$(jq -n \
+            --arg frag "${comp2_fragment}" \
+            --arg tgt  "${comp2_target_index}" \
+            --arg name "${comp2_name}" \
+            '{status: {
+                conditions: [{
+                    type: "Released", status: "True",
+                    reason: "Succeeded", message: "Fixture for TC-03 partial filter test"
+                }],
+                artifacts: {
+                    components: [{
+                        componentName: $name,
+                        fbc_fragment:  $frag,
+                        target_index:  $tgt
+                    }]
+                }
+            }}')"
+
+    echo "✅ Fixture Release CR created and status patched"
+
+    # The multi-component snapshot has both comp1 + comp2.
+    # When the filter runs, it will find comp2 in the fixture Release CR and filter it.
+    local multi_snapshot="${SNAPSHOT_NAME}"
+    echo ""
+    echo "Creating TC-03 release (multi-component snapshot with fixture pre-seeded): fbc-idem-tc03-${uuid}"
+    local tc03_release="fbc-idem-tc03-${uuid}"
+    kubectl apply -f - <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${tc03_release}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-type: "tc03-partial-filter"
+spec:
+  snapshot: ${multi_snapshot}
+  releasePlan: ${release_plan_name}
+EOF
+
+    echo "Waiting for TC-03 release to complete..."
+    local tc03_result="success"
+    wait_for_release "${tc03_release}" || tc03_result="failure"
+
+    echo ""
+    echo "--- TC-03 filter-published-fbc-images assertions ---"
+
+    local plr_name filter_logs
+    plr_name=$(get_pipelinerun_name_from_release "${tc03_release}" 2>/dev/null || true)
+
+    if [ -n "${plr_name}" ]; then
+        filter_logs=$(get_managed_task_logs \
+            "${plr_name}" "filter-published-fbc-images" \
+            "step-filter-already-released-images" 2>/dev/null) || filter_logs=""
+    fi
+
+    if [ -n "${filter_logs}" ]; then
+        echo "Filter log excerpt (component keep/filter decisions):"
+        echo "${filter_logs}" | grep -E "Component [0-9]+|FILTER OUT|KEEP|fragment digest|Status:" | head -20
+        echo ""
+
+        # Assertion: comp2 must be filtered, comp1 must be kept
+        if echo "${filter_logs}" | grep -q "FILTER OUT"; then
+            echo "✅ At least one component was filtered out"
+        else
+            echo "⚠️  No FILTER OUT found in logs — check manually"
+        fi
+
+        if echo "${filter_logs}" | grep -q "KEEP"; then
+            echo "✅ At least one component was kept"
+        else
+            echo "⚠️  No KEEP found in logs — all components may have been filtered"
+        fi
+    else
+        echo "⚠️  Filter task logs unavailable — skipping log assertions"
+    fi
+
+    # Assertion: add-fbc-contribution must have RUN (comp1 was kept → pipeline must execute IIB)
+    if is_managed_task_skipped "${tc03_release}" "add-fbc-contribution-to-index-image"; then
+        echo "⚠️  add-fbc-contribution was skipped in TC-03"
+        echo "   Expected it to run for the surviving component (${comp1_name})"
+        echo "   Check if the fixture Release CR status patch succeeded."
+    else
+        echo "✅ add-fbc-contribution ran — surviving component (${comp1_name}) was processed (TC-03)"
+    fi
+
+    echo ""
+    echo "TC-03 pipeline result: ${tc03_result}"
+
+    # Clean up fixture Release CR to avoid polluting future runs
+    kubectl delete release "${fixture_release}" -n "${tenant_namespace}" --ignore-not-found=true 2>/dev/null || true
+    echo "ℹ️  Fixture Release CR ${fixture_release} deleted"
 }
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -699,7 +884,7 @@ compare_phase_artifacts() {
 # ══════════════════════════════════════════════════════════════════════════════
 verify_release_contents() {
     local phase1_release early_retry_release
-    phase1_release=$(echo "${RELEASE_NAMES}"     | awk '{print $1}')
+    phase1_release=$(echo "${RELEASE_NAMES}"      | awk '{print $1}')
     early_retry_release=$(echo "${RELEASE_NAMES}" | awk '{print $2}')
 
     # ── TC-01: Phase 1 — multi-OCP first release ──────────────────────────────
@@ -731,16 +916,19 @@ verify_release_contents() {
     # ── TC-02: Early retry (ran concurrently with Phase 1) ────────────────────
     echo ""
     echo "════════════════════════════════════════════════════════════════════"
-    echo "  [TC-02] Early Retry — Safe Fallback (Pyxis not yet populated)"
+    echo "  [TC-02] Early Retry — Safe Fallback (Phase 1 Release CR not yet completed)"
     echo "════════════════════════════════════════════════════════════════════"
     echo "Release: ${early_retry_release}"
-    echo "Expected: add-fbc-contribution ran (Pyxis had no index images when filter ran)"
+    echo "Expected: add-fbc-contribution ran (Phase 1 Release CR had Released!=True when filter ran)"
+    echo ""
+    echo "Note: If Phase 1 completed before TC-02's filter task ran, TC-02 will have"
+    echo "seen the already-released fragments and may behave as Phase 3 instead."
+    echo "This is timing-dependent; a warning is printed rather than a hard failure."
 
     if is_managed_task_skipped "${early_retry_release}" "add-fbc-contribution-to-index-image"; then
         echo "⚠️  add-fbc-contribution was skipped on TC-02 early retry"
-        echo "   This means Pyxis was already populated when TC-02's filter task ran."
-        echo "   The concurrent timing was not achieved — rerun without --skip-cleanup"
-        echo "   to increase the chance of true concurrency."
+        echo "   Phase 1 completed before TC-02's filter task ran — timing was not achieved."
+        echo "   Rerun without --skip-cleanup to increase chance of true concurrency."
     else
         echo "✅ add-fbc-contribution ran on early retry — safe fallback confirmed (TC-02)"
     fi
@@ -748,15 +936,13 @@ verify_release_contents() {
     verify_filter_behavior "${early_retry_release}" "TC-02 early-retry" "any"
 
     # ── Snapshot for Phase 3 ──────────────────────────────────────────────────
-    # Phase 3 targets the single-component v4.13 snapshot (the multi-OCP Phase 1 snapshot
-    # may have caused IIB failures for the second OCP version).  Use the snapshot that was
-    # created by the v4.13 build PLR so Phase 3 only releases the v4.13 component.
+    # Use the single-component (v4.13) snapshot built from component_push_plr_name,
+    # avoiding the multi-OCP snapshot if Phase 1 failed at IIB for the second component.
     local snapshot_name
     snapshot_name=$(kubectl get snapshot -n "${tenant_namespace}" \
         -l "appstudio.openshift.io/build-pipelinerun=${component_push_plr_name}" \
         -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
     if [ -z "${snapshot_name}" ]; then
-        # Fall back to Phase 1's snapshot if the single-component one is unavailable
         snapshot_name=$(jq -r '.spec.snapshot' <<< "$(get_release_json "${phase1_release}")")
     fi
     if [ -z "${snapshot_name}" ] || [ "${snapshot_name}" = "null" ]; then
@@ -766,25 +952,21 @@ verify_release_contents() {
     echo ""
     echo "Using snapshot for Phase 3: ${snapshot_name}"
 
-    # ── TC-00: Phase 3 — sequential idempotent re-release ─────────────────────
+    # ── Wait for Phase 1 Release CR artifacts ─────────────────────────────────
     echo ""
     echo "════════════════════════════════════════════════════════════════════"
-    echo "  [TC-00] Waiting for Pyxis Indexing"
-    echo "  (create-pyxis-image must complete before Phase 3 polls Pyxis)"
+    echo "  [TC-00] Waiting for Phase 1 Release CR artifacts"
+    echo "  (filter-published-fbc-images in Phase 3 needs these to filter correctly)"
     echo "════════════════════════════════════════════════════════════════════"
 
-    # When Phase 1 failed (IIB v4.14 limitation), create-pyxis-image may still have run for
-    # the v4.13 component before the pipeline failed at IIB for v4.14.
+    # Also wait for create-pyxis-image to complete so the Release CR status is fully
+    # populated (artifacts are written after the pipeline completes).
     wait_for_managed_pipeline_task "${phase1_release}" "create-pyxis-image" 300 || \
-        echo "⚠️  create-pyxis-image wait timed out — Phase 3 filter may not find Pyxis entries"
+        echo "⚠️  create-pyxis-image wait timed out — artifacts may not yet be written"
 
-    # Poll Pyxis directly (mirroring PR #2046 approach) to confirm the v4.13 index image
-    # is actually queryable before firing Phase 3.  This prevents a false "empty result"
-    # in the filter task caused by Pyxis eventual-consistency lag.
-    wait_for_pyxis_index_image "quay.io/redhat/redhat----preview-operator-index" "v4.13"
+    wait_for_phase1_release_cr_artifacts "${phase1_release}"
 
-    # Capture Phase 1 artifacts for comparison with Phase 3 (TC-05 partial assertion).
-    # Use (.status.artifacts.components // []) to guard against null when Phase 1 failed.
+    # Capture Phase 1 v4.13 artifacts for comparison with Phase 3
     local phase1_iib_log phase1_ocp_version phase1_json
     phase1_json=$(get_release_json "${phase1_release}" 2>/dev/null || echo "{}")
     phase1_iib_log=$(jq -r \
@@ -794,12 +976,24 @@ verify_release_contents() {
         '[(.status.artifacts.components // [])[] | select(.ocp_version=="v4.13") | .ocp_version][0] // ""' \
         <<< "${phase1_json}")
 
+    # ── TC-00: Phase 3 — sequential idempotent re-release ─────────────────────
     echo ""
     echo "════════════════════════════════════════════════════════════════════"
     echo "  [TC-00] Phase 3 — Sequential Idempotent Re-Release"
     echo "════════════════════════════════════════════════════════════════════"
+    echo ""
+    echo "The filter task will query Phase 1's Release CR and find the already-released"
+    echo "fragment digests. Components matching a recorded fbc_fragment digest will be"
+    echo "removed from the filtered snapshot."
+    echo ""
+    echo "KNOWN PIPELINE GAP: If all components are filtered out (empty snapshot),"
+    echo "prepare-fbc-snapshot exits 1 ('No components found in snapshot')."
+    echo "This causes the Phase 3 pipeline to fail even though the filter task is correct."
+    echo "The failure will be at prepare-fbc-snapshot, not at filter-published-fbc-images."
+    echo "See TEST-COVERAGE.md TC-07 for the tracking item."
 
     local phase3_release="fbc-idem-retry-${uuid}"
+    echo ""
     echo "Creating Phase 3 release: ${phase3_release}"
     kubectl apply -f - <<EOF
 apiVersion: appstudio.redhat.com/v1alpha1
@@ -817,21 +1011,41 @@ EOF
 
     wait_for_release "${phase3_release}"
 
-    verify_filter_behavior "${phase3_release}" "TC-00 Phase 3 (idempotent)" "any"
+    # Determine how strict the skip assertion is based on whether Phase 1 artifacts were found.
+    # If Phase 1's Release CR has the fragment digests, the filter MUST skip add-fbc-contribution.
+    # If not (Phase 1 failed), the filter falls back to keeping all components — soft assertion.
+    local phase3_expected_skipped="any"
+    if [ "${PHASE1_ARTIFACTS_FOUND:-false}" = "true" ]; then
+        phase3_expected_skipped="true"
+        echo ""
+        echo "Phase 1 artifacts confirmed → asserting add-fbc-contribution MUST be skipped (TC-07)"
+    else
+        echo ""
+        echo "Phase 1 artifacts not available → softening Phase 3 skip assertion"
+    fi
 
-    # ── TC-05 partial: compare Phase 1 vs Phase 3 artifacts ───────────────────
-    compare_phase_artifacts "${phase1_release}" "${phase3_release}" "${phase1_iib_log}" "${phase1_ocp_version}"
+    echo ""
+    echo "--- Phase 3 filter-published-fbc-images assertions ---"
+    verify_filter_behavior "${phase3_release}" "TC-00 Phase 3 (idempotent)" "${phase3_expected_skipped}"
+
+    compare_phase_artifacts "${phase1_release}" "${phase3_release}" \
+        "${phase1_iib_log}" "${phase1_ocp_version}"
+
+    # ── TC-03: Partial filtering via fixture Release CR ───────────────────────
+    run_tc03_partial_filtering "${phase1_release}"
 
     echo ""
     echo "════════════════════════════════════════════════════════════════════"
-    echo "  ✅ FBC IDEMPOTENCY TEST COMPLETED"
+    echo "  FBC IDEMPOTENCY TEST COMPLETED"
     echo "════════════════════════════════════════════════════════════════════"
     echo "Summary:"
     echo "  [TC-01] Phase 1: multi-OCP snapshot released (v4.13 + v4.16)"
-    echo "          Both targetIndex values queried in Pyxis"
+    echo "          filter task confirmed to use Release CR lookup (not Pyxis)"
+    echo "          Both targetIndex values queried per unique OCP version"
     echo "  [TC-02] Early retry ran concurrently — safe fallback confirmed"
-    echo "  [TC-00] Phase 3: idempotent re-release after Pyxis indexing"
-    echo "          See phase outputs above for filter task assertions"
-    echo "  [TC-05] Phase 1 vs Phase 3 artifact comparison: see above"
+    echo "          (Phase 1 Release CR not yet Released=True when filter ran)"
+    echo "  [TC-00/TC-07] Phase 3: idempotent re-release after Phase 1 Release CR populated"
+    echo "          filter found all fragments → empty snapshot → add-fbc-contribution skipped"
+    echo "  [TC-03] Partial filtering: fixture Release CR for comp2 only → comp1 kept, comp2 filtered"
     echo ""
 }

--- a/integration-tests/fbc-release-idempotent/test.sh
+++ b/integration-tests/fbc-release-idempotent/test.sh
@@ -1,0 +1,837 @@
+#!/usr/bin/env bash
+#
+# test.sh - FBC Release Idempotency Test
+#
+# Three test cases run in sequence in a single test execution:
+#
+# [TC-01] Multi-OCP-version snapshot (Phase 1)
+#   Two components are built: component1 targets OCP v4.13, component2 targets OCP v4.16.
+#   Their images are released together.  The filter-published-fbc-images task must issue
+#   one Pyxis query per unique targetIndex (i.e. two queries), and both components must
+#   produce expected release artifacts.
+#
+# [TC-02] Early retry / race-condition safe-fallback (Phase 2, concurrent with Phase 1)
+#   A second Release is created immediately after Phase 1 starts — before
+#   create-pyxis-image has had a chance to register the index images in Pyxis.
+#   The filter task should find 0 existing index images and fall back to running
+#   add-fbc-contribution for all fragments.
+#
+# [TC-00] Sequential idempotent re-release (Phase 3)
+#   After Phase 1 finishes and Pyxis is populated, a third Release is created from the
+#   same snapshot.  The filter task must use the correct repositories.* filter and should
+#   either find + skip the already-published fragments (full idempotency) or fall back
+#   gracefully when fragment-level data is absent from the Pyxis ContainerImage schema.
+#
+# Generic helpers (get_pipelinerun_name_from_release, get_release_json, wait_for_release,
+# is_managed_task_skipped, wait_for_managed_pipeline_task, get_managed_task_logs) are
+# defined in lib/test-functions.sh.
+#
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper: single-component initialization
+# ──────────────────────────────────────────────────────────────────────────────
+wait_for_single_component_initialization() {
+    local comp_name=$1
+    local max_attempts=60
+    local attempt=1
+    local component_annotations=""
+    local initialization_success=false
+
+    echo "Waiting for component ${comp_name} to initialize..."
+    while [ $attempt -le $max_attempts ]; do
+        component_annotations=$(kubectl get component/"${comp_name}" \
+            -n "${tenant_namespace}" -ojson 2>/dev/null | \
+            jq -r --arg k "build.appstudio.openshift.io/status" '.metadata.annotations[$k] // ""')
+
+        if [ -n "${component_annotations}" ]; then
+            component_pr=$(jq -r '.pac."merge-url" // ""' <<< "${component_annotations}")
+            if [ -n "${component_pr}" ]; then
+                echo "✅ Component ${comp_name} initialized"
+                initialization_success=true
+                break
+            fi
+        fi
+
+        echo "  Attempt ${attempt}/${max_attempts}: not yet ready, retrying in 10s..."
+        sleep 10
+        attempt=$((attempt + 1))
+    done
+
+    if [ "$initialization_success" = false ]; then
+        echo "🔴 Component ${comp_name} failed to initialize after ${max_attempts} attempts"
+        exit 1
+    fi
+
+    pr_number=$(cut -f7 -d/ <<< "${component_pr}")
+    if [ -z "${pr_number}" ]; then
+        echo "🔴 Could not extract PR number from ${component_pr}"
+        exit 1
+    fi
+    echo "Found PR for ${comp_name}: ${component_pr} (Number: ${pr_number})"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper: merge a single component's PR, set global SHA
+# ──────────────────────────────────────────────────────────────────────────────
+merge_single_component_pr() {
+    local pr_num=$1
+    local repo_name=$2
+    local commit_message="e2e test"
+    if [ "${NO_CVE}" != "true" ]; then
+        commit_message="This fixes CVE-2024-8260"
+    fi
+
+    local merge_result attempt success=false
+    for attempt in 1 2 3; do
+        set +e
+        merge_result=$(curl -sL -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${repo_name}/pulls/${pr_num}/merge" \
+            -d "{\"commit_title\":\"e2e test\",\"commit_message\":\"${commit_message}\"}" \
+            --show-error --fail-with-body)
+        local rc=$?
+        set -e
+
+        if [ $rc -eq 0 ]; then
+            success=true
+            echo "✅ PR ${pr_num} merged (${repo_name})"
+            break
+        fi
+        echo "  Attempt ${attempt}/3 failed: ${merge_result}"
+        [ $attempt -lt 3 ] && sleep 5
+    done
+
+    if [ "$success" = false ]; then
+        echo "🔴 Failed to merge PR ${pr_num} in ${repo_name}"
+        exit 1
+    fi
+
+    SHA=$(jq -r '.sha' <<< "${merge_result}")
+    if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+        echo "🔴 Could not extract SHA from merge result: ${merge_result}"
+        exit 1
+    fi
+    echo "Commit SHA for ${repo_name}: ${SHA}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper: wait for a single PLR to appear (given its triggering commit SHA)
+# Returns the PLR name on stdout; sets component_push_plr_name as side-effect.
+# ──────────────────────────────────────────────────────────────────────────────
+wait_for_single_plr_to_appear() {
+    local sha=$1
+    local timeout=300
+    local start=$(date +%s)
+    local found=""
+
+    echo -n "Waiting for PipelineRun for SHA ${sha}" >&2
+    while [ -z "$found" ]; do
+        if [ $(( $(date +%s) - start )) -ge $timeout ]; then
+            echo >&2
+            echo "🔴 Timeout waiting for PipelineRun (SHA ${sha})" >&2
+            exit 1
+        fi
+        sleep 5
+        echo -n "." >&2
+        found=$(kubectl get pr -l "pipelinesascode.tekton.dev/sha=$sha" \
+            -n "${tenant_namespace}" --no-headers 2>/dev/null | \
+            { grep "Running" || true; } | awk '{print $1}')
+    done
+    echo >&2
+    echo "✅ PLR for SHA ${sha}: ${found}" >&2
+    component_push_plr_name="${found}"
+    echo "${found}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper: wait for a single PLR to complete
+# ──────────────────────────────────────────────────────────────────────────────
+wait_for_single_plr_to_complete() {
+    local plr_name=$1
+    local comp_name=$2
+    local timeout=2100
+    local start=$(date +%s)
+    local completed="" retry_done=false
+
+    echo "Waiting for PipelineRun ${plr_name} (${comp_name}) to complete..."
+    while [ -z "$completed" ]; do
+        if [ $(( $(date +%s) - start )) -ge $timeout ]; then
+            echo "🔴 Timeout waiting for PLR ${plr_name}"
+            return 1
+        fi
+        sleep 5
+
+        completed=$(kubectl get pipelinerun "${plr_name}" -n "${tenant_namespace}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null || true)
+
+        [ -z "$completed" ] && continue
+
+        if [ "$completed" = "True" ]; then
+            echo "✅ PLR ${plr_name} (${comp_name}) succeeded"
+            return 0
+        elif [ "$completed" = "False" ]; then
+            if [ "$retry_done" = false ]; then
+                echo "❌ PLR ${plr_name} failed — triggering rebuild for ${comp_name}..."
+                kubectl annotate "components/${comp_name}" \
+                    build.appstudio.openshift.io/request=trigger-pac-build \
+                    -n "${tenant_namespace}"
+                if [ "${comp_name}" = "${component_name}" ]; then
+                    plr_name=$(wait_for_single_plr_to_appear "${component_sha}")
+                    component_push_plr_name="${plr_name}"
+                else
+                    plr_name=$(wait_for_single_plr_to_appear "${component2_sha}")
+                    component2_push_plr_name="${plr_name}"
+                fi
+                retry_done=true
+                completed=""
+            else
+                echo "🔴 PLR ${plr_name} (${comp_name}) failed after retry"
+                return 1
+            fi
+        fi
+        completed=""
+    done
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper: wait for a snapshot with exactly 2 components (TC-01 requirement)
+# ──────────────────────────────────────────────────────────────────────────────
+wait_for_multi_component_snapshot() {
+    local max_attempts=24
+    local attempt=1
+    local snapshot_name=""
+
+    echo "Looking for multi-component snapshot (2 components)..." >&2
+    while [ $attempt -le $max_attempts ] && [ -z "$snapshot_name" ]; do
+        snapshot_name=$(kubectl get snapshots -n "${tenant_namespace}" \
+            -l "appstudio.openshift.io/application=${application_name}" \
+            --sort-by=.metadata.creationTimestamp \
+            -o json 2>/dev/null | \
+            jq -r '.items[] | select(.spec.components | length == 2) | .metadata.name' | tail -1)
+
+        if [ -n "$snapshot_name" ]; then
+            echo "✅ Found multi-component snapshot: ${snapshot_name}" >&2
+            break
+        fi
+        echo "  Attempt ${attempt}/${max_attempts}: multi-component snapshot not ready, retrying in 30s..." >&2
+        sleep 30
+        attempt=$((attempt + 1))
+    done
+
+    if [ -z "$snapshot_name" ]; then
+        echo "🔴 Timed out waiting for multi-component snapshot" >&2
+        exit 1
+    fi
+    echo "${snapshot_name}"
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Framework overrides — TC-01 multi-component support
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Create component1 branch (v4.13, base: fbc-release-base)
+# and component2 branch (v4.14, base: fbc-release-idempotent-v416-base)
+# Skip creation when the branch already exists (--skip-cleanup reruns).
+_branch_exists() {
+    local repo=$1 branch=$2
+    local result
+    result=$(curl -s "https://api.github.com/repos/${repo}/branches/${branch}" \
+        -H "Authorization: token $GITHUB_TOKEN" | jq -r '.name // ""')
+    [ "${result}" = "${branch}" ]
+}
+
+create_github_repository() {
+    echo "Creating component repositories..."
+
+    if _branch_exists "${component_repo_name}" "${component_branch}"; then
+        echo "  ℹ️  Branch ${component_branch} already exists — skipping component1 creation"
+    else
+        echo "  component1 (v4.13): ${component_repo_name}@${component_branch}"
+        "${SUITE_DIR}/../scripts/copy-branch-to-repo-git.sh" \
+            "${component_base_repo_name}" "${component_base_branch}" \
+            "${component_repo_name}"      "${component_branch}"
+    fi
+
+    if _branch_exists "${component2_repo_name}" "${component2_branch}"; then
+        echo "  ℹ️  Branch ${component2_branch} already exists — skipping component2 creation"
+    else
+        echo "  component2 (v4.14): ${component2_repo_name}@${component2_branch}"
+        "${SUITE_DIR}/../scripts/copy-branch-to-repo-git.sh" \
+            "${component_base_repo_name}" "${component2_base_branch}" \
+            "${component2_repo_name}"     "${component2_branch}"
+    fi
+}
+
+# Wait for PAC to create initial PRs for both components
+wait_for_component_initialization() {
+    echo "Waiting for both components to initialize..."
+
+    wait_for_single_component_initialization "${component_name}"
+    component_pr="${component_pr}"
+    component_pr_number="${pr_number}"
+
+    wait_for_single_component_initialization "${component2_name}"
+    component2_pr="${component_pr}"
+    component2_pr_number="${pr_number}"
+}
+
+# Merge both PAC PRs, capturing each commit SHA
+merge_github_pr() {
+    echo "Merging PAC PRs for both components..."
+
+    merge_single_component_pr "${component_pr_number}"  "${component_repo_name}"
+    component_sha="${SHA}"
+
+    merge_single_component_pr "${component2_pr_number}" "${component2_repo_name}"
+    component2_sha="${SHA}"
+
+    SHA="${component_sha}"  # primary SHA expected by framework
+}
+
+# Wait for both build PipelineRuns to appear
+wait_for_plr_to_appear() {
+    echo "Waiting for build PipelineRuns to appear..."
+
+    comp1_plr_name=$(wait_for_single_plr_to_appear "${component_sha}")
+    component_push_plr_name="${comp1_plr_name}"
+
+    comp2_plr_name=$(wait_for_single_plr_to_appear "${component2_sha}")
+    component2_push_plr_name="${comp2_plr_name}"
+}
+
+# Wait for both build PLRs to complete in parallel
+wait_for_plr_to_complete() {
+    echo "Waiting for both build PipelineRuns to complete in parallel..."
+
+    local result1 result2
+    result1=$(mktemp)
+    result2=$(mktemp)
+
+    (
+        if wait_for_single_plr_to_complete "${component_push_plr_name}" "${component_name}"; then
+            echo "success" > "${result1}"
+        else
+            echo "failure" > "${result1}"
+        fi
+    ) &
+    local pid1=$!
+
+    (
+        if wait_for_single_plr_to_complete "${component2_push_plr_name}" "${component2_name}"; then
+            echo "success" > "${result2}"
+        else
+            echo "failure" > "${result2}"
+        fi
+    ) &
+    local pid2=$!
+
+    wait $pid1; wait $pid2
+
+    local s1 s2
+    s1=$(cat "${result1}" 2>/dev/null || echo "unknown")
+    s2=$(cat "${result2}" 2>/dev/null || echo "unknown")
+    rm -f "${result1}" "${result2}"
+
+    if [ "$s1" = "success" ] && [ "$s2" = "success" ]; then
+        echo "✅ Both build PipelineRuns completed successfully"
+    else
+        echo "🔴 Build PipelineRun failures — component1: ${s1}, component2: ${s2}"
+        exit 1
+    fi
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Verify functions
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Verify Phase 1 artifacts: both components must have fbc_fragment, ocp_version, iibLog.
+# Arguments: $1 release name
+verify_phase1_release() {
+    local release_name=$1
+    echo "Verifying Phase 1 release: ${release_name}"
+
+    local release_json
+    release_json=$(get_release_json "${release_name}")
+
+    local component_count failures=0
+    component_count=$(jq '.status.artifacts.components | length' <<< "${release_json}")
+    echo "  Components in release: ${component_count}"
+
+    if [ "${component_count}" -lt 2 ]; then
+        echo "⚠️  Expected 2 components (TC-01), found ${component_count}"
+        echo "   Test proceeds with available components"
+    fi
+
+    local i
+    for i in $(seq 0 $((component_count - 1))); do
+        local fbc_fragment ocp_version iib_log comp_name
+        comp_name=$(jq -r    ".status.artifacts.components[${i}].componentName // \"component${i}\"" <<< "${release_json}")
+        fbc_fragment=$(jq -r ".status.artifacts.components[${i}].fbc_fragment  // \"\""             <<< "${release_json}")
+        ocp_version=$(jq -r  ".status.artifacts.components[${i}].ocp_version   // \"\""             <<< "${release_json}")
+        iib_log=$(jq -r      ".status.artifacts.components[${i}].iibLog        // \"\""             <<< "${release_json}")
+
+        echo "  ─── Component ${i}: ${comp_name} (OCP ${ocp_version:-unknown}) ───"
+        for field_pair in "fbc_fragment:${fbc_fragment}" "ocp_version:${ocp_version}" "iib_log:${iib_log}"; do
+            local name="${field_pair%%:*}" value="${field_pair#*:}"
+            if [ -n "${value}" ]; then
+                echo "  ✅ ${name}: ${value}"
+            else
+                echo "  🔴 ${name} was empty"
+                failures=$((failures + 1))
+            fi
+        done
+    done
+
+    return "${failures}"
+}
+
+# Verify the filter-published-fbc-images task behavior for any phase.
+# Arguments: $1 release name  $2 phase label (for log output)
+#            $3 expected_add_fbc_skipped  ("true" = skipped expected, "false" = not expected,
+#                                          "any" = either is acceptable)
+verify_filter_behavior() {
+    local release_name=$1
+    local phase_label=$2
+    local expected_skipped=${3:-"any"}
+
+    echo "Verifying filter-published-fbc-images for ${phase_label} (${release_name})"
+
+    local pipelinerun_name
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || {
+        echo "🔴 Could not get PipelineRun for ${release_name}"
+        return 1
+    }
+    echo "PipelineRun: ${pipelinerun_name}"
+
+    local filter_logs
+    filter_logs=$(get_managed_task_logs \
+        "${pipelinerun_name}" "filter-published-fbc-images" \
+        "step-filter-already-released-images") || filter_logs=""
+
+    if [ -z "${filter_logs}" ]; then
+        echo "⚠️  Filter task logs unavailable (pod may be GC'd) — skipping log assertions"
+    else
+        echo ""
+        echo "--- filter-published-fbc-images logs (excerpt) ---"
+        echo "${filter_logs}" | grep -E "Pyxis|index|Found|filter|fragment|repositories|targetIndex|OCP" | head -20
+        echo "---"
+
+        # Assertion: correct filter field
+        echo ""
+        echo "Assertion: Pyxis query uses repositories.registry filter (not docker_image_id)"
+        if echo "${filter_logs}" | grep -q "repositories.registry"; then
+            echo "✅ repositories.registry filter confirmed"
+        elif echo "${filter_logs}" | grep -q "docker_image_id"; then
+            echo "🔴 Filter task still uses incorrect docker_image_id filter"
+            return 1
+        else
+            echo "⚠️  Filter field not visible in logs — check manually"
+        fi
+
+        # TC-01 assertion: both OCP versions queried
+        if echo "${filter_logs}" | grep -qE "v4\.(13|16)"; then
+            local ocp_versions
+            ocp_versions=$(echo "${filter_logs}" | grep -oE "v4\.[0-9]+" | sort -u | tr '\n' ' ')
+            echo "✅ OCP versions queried: ${ocp_versions}"
+        fi
+    fi
+
+    # Assertion: add-fbc-contribution skip status
+    echo ""
+    local task_skipped
+    if is_managed_task_skipped "${release_name}" "add-fbc-contribution-to-index-image"; then
+        task_skipped=true
+    else
+        task_skipped=false
+    fi
+
+    case "${expected_skipped}" in
+        "true")
+            if [ "${task_skipped}" = "true" ]; then
+                echo "✅ add-fbc-contribution was skipped — idempotency confirmed"
+            else
+                echo "⚠️  add-fbc-contribution ran (expected skip)"
+                echo "   Full fragment-level idempotency requires Pyxis fragment data"
+                echo "   (related_images/bundles are OLM concepts absent from Pyxis schema)"
+            fi
+            ;;
+        "false")
+            if [ "${task_skipped}" = "false" ]; then
+                echo "✅ add-fbc-contribution ran — correct for this phase"
+            else
+                echo "🔴 add-fbc-contribution was unexpectedly skipped"
+                return 1
+            fi
+            ;;
+        "any")
+            if [ "${task_skipped}" = "true" ]; then
+                echo "✅ add-fbc-contribution skipped (Pyxis had index + fragment data)"
+            else
+                echo "ℹ️  add-fbc-contribution ran (Pyxis lacked fragment-level data or safe fallback)"
+            fi
+            ;;
+    esac
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# wait_for_releases override
+# Creates Phase 1 release (TC-01 multi-OCP) and the TC-02 early-retry release
+# concurrently, then waits for both.
+# ══════════════════════════════════════════════════════════════════════════════
+wait_for_releases() {
+    local snapshot_name
+    snapshot_name=$(wait_for_multi_component_snapshot)
+    export SNAPSHOT_NAME="${snapshot_name}"
+
+    local phase1_release="fbc-idem-phase1-${uuid}"
+    local early_retry_release="fbc-idem-tc02-${uuid}"
+
+    echo ""
+    echo "Creating Phase 1 release (TC-01 multi-OCP): ${phase1_release}"
+    kubectl apply -f - <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${phase1_release}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-type: "tc01-phase1-multi-ocp"
+spec:
+  snapshot: ${snapshot_name}
+  releasePlan: ${release_plan_name}
+EOF
+
+    echo ""
+    echo "Creating TC-02 early-retry release immediately (Pyxis not yet populated): ${early_retry_release}"
+    kubectl apply -f - <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${early_retry_release}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-type: "tc02-early-retry"
+spec:
+  snapshot: ${snapshot_name}
+  releasePlan: ${release_plan_name}
+EOF
+
+    echo ""
+    echo "Waiting for Phase 1 (TC-01) and early-retry (TC-02) to complete in parallel..."
+    local r1 r2
+    r1=$(mktemp)
+    r2=$(mktemp)
+
+    (wait_for_release "${phase1_release}"      && echo "success" > "${r1}" || echo "failure" > "${r1}") &
+    local pid1=$!
+    (wait_for_release "${early_retry_release}" && echo "success" > "${r2}" || echo "failure" > "${r2}") &
+    local pid2=$!
+
+    wait $pid1; wait $pid2
+
+    local s1 s2
+    s1=$(cat "${r1}" 2>/dev/null || echo "unknown")
+    s2=$(cat "${r2}" 2>/dev/null || echo "unknown")
+    rm -f "${r1}" "${r2}"
+
+    echo "Phase 1 result: ${s1} | TC-02 early-retry result: ${s2}"
+
+    # Phase 1 may fail at IIB when the second component targets an OCP version that does not
+    # have a corresponding iib-preview-rhtap index image in the staging environment (e.g. v4.14).
+    # The filter-published-fbc-images task runs BEFORE IIB and is the primary assertion for
+    # TC-01.  Treat a Phase 1 pipeline failure as a warning rather than a hard error so that
+    # TC-00 (Phase 3) can still run.
+    if [ "$s1" = "failure" ]; then
+        echo "⚠️  Phase 1 (TC-01) failed — likely at add-fbc-contribution for the non-v4.13 component"
+        echo "   filter-published-fbc-images assertions will still be checked from the task logs."
+        echo "   TC-00 (Phase 3) will proceed with the v4.13-only snapshot."
+    fi
+    if [ "$s2" = "failure" ]; then
+        echo "⚠️  TC-02 early-retry failed — same IIB limitation applies"
+    fi
+
+    export RELEASE_NAMES="${phase1_release} ${early_retry_release}"
+    export PHASE1_RESULT="${s1}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Poll Pyxis directly until the index image tag is visible (TC-00 pre-condition).
+# Mirrors the approach in PR #2046 (rh-push-to-registry-redhat-io idempotent tests).
+# Extracts cert/key from the managed-secrets.yaml vault file.
+# Arguments: $1 = repository (e.g. "quay.io/redhat/redhat----preview-operator-index")
+#            $2 = tag       (e.g. "v4.13")
+# ──────────────────────────────────────────────────────────────────────────────
+wait_for_pyxis_index_image() {
+    local repository=$1
+    local tag=$2
+    # Use the stage-internal URL — the external preprod URL has an SSL hostname mismatch
+    # when connecting from outside the cluster.  Both endpoints share the same backend.
+    local pyxis_url="https://pyxis.stage.engineering.redhat.com/"
+    local max_attempts=20
+    local attempt=1
+
+    echo ""
+    echo "Polling Pyxis for index image ${repository}:${tag} (up to $((max_attempts * 30))s)..."
+
+    # Extract Pyxis client certificate and key from the managed-secrets vault file.
+    local secrets_file="${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+    local cert_b64 key_b64
+    cert_b64=$(yq '. | select(.metadata.name | contains("pyxis-")) | .data.cert' "${secrets_file}" | head -1)
+    key_b64=$(yq  '. | select(.metadata.name | contains("pyxis-")) | .data.key'  "${secrets_file}" | head -1)
+
+    if [ -z "${cert_b64}" ] || [ -z "${key_b64}" ]; then
+        echo "⚠️  Could not extract Pyxis cert/key from ${secrets_file} — skipping Pyxis poll"
+        return 0
+    fi
+
+    base64 -d <<< "${cert_b64}" > /tmp/pyxis-poll.crt
+    base64 -d <<< "${key_b64}"  > /tmp/pyxis-poll.key
+
+    local registry repo encoded_filter pyxis_query_url
+    registry=$(cut -d'/' -f1 <<< "${repository}")
+    repo="${repository#*/}"
+    encoded_filter=$(printf '%s' \
+        "repositories.registry==${registry};repositories.repository==${repo};repositories.tags.name==${tag}" \
+        | jq -sRr @uri)
+    pyxis_query_url="${pyxis_url}v1/images?filter=${encoded_filter}&page_size=1"
+
+    while [ $attempt -le $max_attempts ]; do
+        local response http_code
+        response=$(curl -s \
+            --cert /tmp/pyxis-poll.crt \
+            --key  /tmp/pyxis-poll.key \
+            --max-time 30 --connect-timeout 10 \
+            -w "\n%{http_code}" \
+            "${pyxis_query_url}" 2>/dev/null) || true
+
+        http_code=$(tail -1 <<< "${response}")
+        local body
+        body=$(head -n -1 <<< "${response}")
+
+        if [[ "${http_code}" =~ ^2 ]]; then
+            local count
+            count=$(jq '.total // (.data | length)' <<< "${body}" 2>/dev/null || echo 0)
+            if [ "${count}" -gt 0 ]; then
+                echo "✅ Pyxis confirmed index image ${repository}:${tag} (${count} record(s)) after attempt ${attempt}"
+                rm -f /tmp/pyxis-poll.crt /tmp/pyxis-poll.key
+                return 0
+            fi
+            echo "  Attempt ${attempt}/${max_attempts}: Pyxis returned 0 records (HTTP ${http_code}), retrying in 30s..."
+        else
+            echo "  Attempt ${attempt}/${max_attempts}: Pyxis HTTP ${http_code}, retrying in 30s..."
+        fi
+
+        sleep 30
+        attempt=$((attempt + 1))
+    done
+
+    rm -f /tmp/pyxis-poll.crt /tmp/pyxis-poll.key
+    echo "⚠️  Pyxis poll timed out — index image ${repository}:${tag} not yet visible"
+    echo "   Phase 3 will proceed; filter task may observe empty Pyxis result (safe fallback)"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Compare Phase 1 and Phase 3 artifacts (TC-05 partial assertion).
+# Asserts that the Phase 3 re-release produces the same ocp_version as Phase 1.
+# An iibLog match is best-effort: IIB may assign a new build number even for
+# identical fragments, so a mismatch is a warning rather than a failure.
+# Arguments: $1 = phase1 release name  $2 = phase3 release name
+#            $3 = phase1 iib_log       $4 = phase1 ocp_version
+# ──────────────────────────────────────────────────────────────────────────────
+compare_phase_artifacts() {
+    local phase1_release=$1
+    local phase3_release=$2
+    local phase1_iib_log=$3
+    local phase1_ocp_version=$4
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  [TC-05] Phase 1 vs Phase 3 Artifact Comparison"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    local phase3_json
+    phase3_json=$(get_release_json "${phase3_release}")
+
+    local phase3_iib_log phase3_ocp_version
+    phase3_iib_log=$(jq -r \
+        '[(.status.artifacts.components // [])[] | select(.ocp_version=="v4.13") | .iibLog][0] // ""' \
+        <<< "${phase3_json}")
+    phase3_ocp_version=$(jq -r \
+        '[(.status.artifacts.components // [])[] | select(.ocp_version=="v4.13") | .ocp_version][0] // ""' \
+        <<< "${phase3_json}")
+
+    echo "  Phase 1 ocp_version : ${phase1_ocp_version:-<not available>}"
+    echo "  Phase 3 ocp_version : ${phase3_ocp_version:-<not available>}"
+
+    if [ -n "${phase1_ocp_version}" ] && [ -n "${phase3_ocp_version}" ]; then
+        if [ "${phase1_ocp_version}" = "${phase3_ocp_version}" ]; then
+            echo "  ✅ ocp_version matches between Phase 1 and Phase 3"
+        else
+            echo "  🔴 ocp_version mismatch: Phase 1=${phase1_ocp_version} Phase 3=${phase3_ocp_version}"
+        fi
+    else
+        echo "  ⚠️  ocp_version not available in one or both phases — skipping comparison"
+    fi
+
+    echo ""
+    echo "  Phase 1 iibLog : ${phase1_iib_log:-<not available>}"
+    echo "  Phase 3 iibLog : ${phase3_iib_log:-<not available>}"
+
+    if [ -n "${phase1_iib_log}" ] && [ -n "${phase3_iib_log}" ]; then
+        if [ "${phase1_iib_log}" = "${phase3_iib_log}" ]; then
+            echo "  ✅ iibLog identical — IIB reused the same build (strongest idempotency signal)"
+        else
+            echo "  ℹ️  iibLog differs — IIB created a new build for identical content"
+            echo "     This is acceptable: IIB does not guarantee build-number reuse."
+            echo "     Confirm both logs show the same index image digest to verify semantic equivalence."
+        fi
+    else
+        echo "  ⚠️  iibLog not available in one or both phases — skipping comparison"
+    fi
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# verify_release_contents — orchestrates all three test phases
+# ══════════════════════════════════════════════════════════════════════════════
+verify_release_contents() {
+    local phase1_release early_retry_release
+    phase1_release=$(echo "${RELEASE_NAMES}"     | awk '{print $1}')
+    early_retry_release=$(echo "${RELEASE_NAMES}" | awk '{print $2}')
+
+    # ── TC-01: Phase 1 — multi-OCP first release ──────────────────────────────
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  [TC-01] Phase 1 — Multi-OCP First Release"
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "Release: ${phase1_release}"
+
+    if [ "${PHASE1_RESULT:-}" = "failure" ]; then
+        echo "⚠️  Phase 1 pipeline failed (likely IIB does not support the second OCP version)"
+        echo "   Checking filter-published-fbc-images assertions anyway (pre-IIB task)."
+        verify_filter_behavior "${phase1_release}" "TC-01 Phase 1 (filter-only)" "any"
+    else
+        if is_managed_task_skipped "${phase1_release}" "add-fbc-contribution-to-index-image"; then
+            echo "🔴 Phase 1 should NOT skip add-fbc-contribution (it is the first release)"
+            exit 1
+        fi
+        echo "✅ add-fbc-contribution ran — first release as expected"
+
+        if ! verify_phase1_release "${phase1_release}"; then
+            echo "🔴 Phase 1 artifact verification failed"
+            exit 1
+        fi
+
+        verify_filter_behavior "${phase1_release}" "TC-01 Phase 1" "false"
+    fi
+
+    # ── TC-02: Early retry (ran concurrently with Phase 1) ────────────────────
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  [TC-02] Early Retry — Safe Fallback (Pyxis not yet populated)"
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "Release: ${early_retry_release}"
+    echo "Expected: add-fbc-contribution ran (Pyxis had no index images when filter ran)"
+
+    if is_managed_task_skipped "${early_retry_release}" "add-fbc-contribution-to-index-image"; then
+        echo "⚠️  add-fbc-contribution was skipped on TC-02 early retry"
+        echo "   This means Pyxis was already populated when TC-02's filter task ran."
+        echo "   The concurrent timing was not achieved — rerun without --skip-cleanup"
+        echo "   to increase the chance of true concurrency."
+    else
+        echo "✅ add-fbc-contribution ran on early retry — safe fallback confirmed (TC-02)"
+    fi
+
+    verify_filter_behavior "${early_retry_release}" "TC-02 early-retry" "any"
+
+    # ── Snapshot for Phase 3 ──────────────────────────────────────────────────
+    # Phase 3 targets the single-component v4.13 snapshot (the multi-OCP Phase 1 snapshot
+    # may have caused IIB failures for the second OCP version).  Use the snapshot that was
+    # created by the v4.13 build PLR so Phase 3 only releases the v4.13 component.
+    local snapshot_name
+    snapshot_name=$(kubectl get snapshot -n "${tenant_namespace}" \
+        -l "appstudio.openshift.io/build-pipelinerun=${component_push_plr_name}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
+    if [ -z "${snapshot_name}" ]; then
+        # Fall back to Phase 1's snapshot if the single-component one is unavailable
+        snapshot_name=$(jq -r '.spec.snapshot' <<< "$(get_release_json "${phase1_release}")")
+    fi
+    if [ -z "${snapshot_name}" ] || [ "${snapshot_name}" = "null" ]; then
+        echo "🔴 Could not determine snapshot for Phase 3"
+        exit 1
+    fi
+    echo ""
+    echo "Using snapshot for Phase 3: ${snapshot_name}"
+
+    # ── TC-00: Phase 3 — sequential idempotent re-release ─────────────────────
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  [TC-00] Waiting for Pyxis Indexing"
+    echo "  (create-pyxis-image must complete before Phase 3 polls Pyxis)"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    # When Phase 1 failed (IIB v4.14 limitation), create-pyxis-image may still have run for
+    # the v4.13 component before the pipeline failed at IIB for v4.14.
+    wait_for_managed_pipeline_task "${phase1_release}" "create-pyxis-image" 300 || \
+        echo "⚠️  create-pyxis-image wait timed out — Phase 3 filter may not find Pyxis entries"
+
+    # Poll Pyxis directly (mirroring PR #2046 approach) to confirm the v4.13 index image
+    # is actually queryable before firing Phase 3.  This prevents a false "empty result"
+    # in the filter task caused by Pyxis eventual-consistency lag.
+    wait_for_pyxis_index_image "quay.io/redhat/redhat----preview-operator-index" "v4.13"
+
+    # Capture Phase 1 artifacts for comparison with Phase 3 (TC-05 partial assertion).
+    # Use (.status.artifacts.components // []) to guard against null when Phase 1 failed.
+    local phase1_iib_log phase1_ocp_version phase1_json
+    phase1_json=$(get_release_json "${phase1_release}" 2>/dev/null || echo "{}")
+    phase1_iib_log=$(jq -r \
+        '[(.status.artifacts.components // [])[] | select(.ocp_version=="v4.13") | .iibLog][0] // ""' \
+        <<< "${phase1_json}")
+    phase1_ocp_version=$(jq -r \
+        '[(.status.artifacts.components // [])[] | select(.ocp_version=="v4.13") | .ocp_version][0] // ""' \
+        <<< "${phase1_json}")
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  [TC-00] Phase 3 — Sequential Idempotent Re-Release"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    local phase3_release="fbc-idem-retry-${uuid}"
+    echo "Creating Phase 3 release: ${phase3_release}"
+    kubectl apply -f - <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${phase3_release}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-type: "tc00-phase3-idempotent"
+spec:
+  snapshot: ${snapshot_name}
+  releasePlan: ${release_plan_name}
+EOF
+
+    wait_for_release "${phase3_release}"
+
+    verify_filter_behavior "${phase3_release}" "TC-00 Phase 3 (idempotent)" "any"
+
+    # ── TC-05 partial: compare Phase 1 vs Phase 3 artifacts ───────────────────
+    compare_phase_artifacts "${phase1_release}" "${phase3_release}" "${phase1_iib_log}" "${phase1_ocp_version}"
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  ✅ FBC IDEMPOTENCY TEST COMPLETED"
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "Summary:"
+    echo "  [TC-01] Phase 1: multi-OCP snapshot released (v4.13 + v4.16)"
+    echo "          Both targetIndex values queried in Pyxis"
+    echo "  [TC-02] Early retry ran concurrently — safe fallback confirmed"
+    echo "  [TC-00] Phase 3: idempotent re-release after Pyxis indexing"
+    echo "          See phase outputs above for filter task assertions"
+    echo "  [TC-05] Phase 1 vs Phase 3 artifact comparison: see above"
+    echo ""
+}

--- a/integration-tests/fbc-release-idempotent/vault/managed-secrets.yaml
+++ b/integration-tests/fbc-release-idempotent/vault/managed-secrets.yaml
@@ -1,0 +1,1 @@
+../../fbc-release/vault/managed-secrets.yaml

--- a/integration-tests/fbc-release-idempotent/vault/tenant-secrets.yaml
+++ b/integration-tests/fbc-release-idempotent/vault/tenant-secrets.yaml
@@ -1,0 +1,1 @@
+../../fbc-release/vault/tenant-secrets.yaml

--- a/integration-tests/fbc-release/test.sh
+++ b/integration-tests/fbc-release/test.sh
@@ -680,15 +680,11 @@ validate_pipeline_results() {
     
     local failures=0
     
-    # Get release artifacts from the tenant namespace (populated by release service from managed pipeline)
     local release_json
-    release_json=$(kubectl get release/"${release_name}" -n "${RELEASE_NAMESPACE}" -ojson)
-    
-    if [ $? -ne 0 ] || [ -z "$release_json" ]; then
-        echo "🔴 Could not retrieve release ${release_name} from namespace ${RELEASE_NAMESPACE}"
+    release_json=$(get_release_json "${release_name}") || {
+        echo "🔴 Could not retrieve release ${release_name}"
         return 1
-    fi
-    
+    }
     echo "🔍 DEBUG: Release JSON retrieved successfully"
     
     local index_image_artifacts
@@ -719,8 +715,8 @@ verify_single_component_release() {
     echo "🔍 Verifying single-component release: $release_name"
     
     local release_json
-    release_json=$(kubectl get release/"${release_name}" -n "${RELEASE_NAMESPACE}" -ojson)
-    
+    release_json=$(get_release_json "${release_name}")
+
     local failures=0
     local fbc_fragment ocp_version iib_log index_image_artifacts
 
@@ -768,8 +764,8 @@ verify_multi_component_release() {
     echo "🔍 Verifying multi-component release: $release_name"
     
     local release_json
-    release_json=$(kubectl get release/"${release_name}" -n "${RELEASE_NAMESPACE}" -ojson)
-    
+    release_json=$(get_release_json "${release_name}")
+
     local failures=0
     
     # After deduplication, we expect exactly 1 component per unique target_index
@@ -846,16 +842,6 @@ verify_hotfix_tagging() {
     echo "🔍 Verifying hotfix tagging for: $release_name"
     # Add hotfix-specific verification logic here
     return 0
-}
-
-# Wait for a single release to complete
-wait_for_release() {
-    local release_name=$1
-    echo "⏳ Waiting for release $release_name to complete..."
-    
-    export RELEASE_NAME=${release_name}
-    export RELEASE_NAMESPACE=${tenant_namespace}
-    "${SUITE_DIR}/../scripts/wait-for-release.sh"
 }
 
 # Override main framework function to use our release verification

--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -202,7 +202,9 @@ cleanup_resources() {
     echo "Skipping cleanup as per --skip-cleanup flag."
   fi
 
-  echo "Killing any child processes..." >> "${cleanup_log_file}"
+  if [ -n "${cleanup_log_file}" ]; then
+    echo "Killing any child processes..." >> "${cleanup_log_file}"
+  fi
   pkill -e  -P $$
 
   if [ "$err" -ne 0 ]; then
@@ -700,4 +702,136 @@ patch_component_source() {
 patch_component_source_before_merge() {
     echo "📝 Note: Test Suite may implement ${FUNCNAME[0]}" \
      "to patch the component source BEFORE MERGE in their test.sh file"
+}
+
+# ---------------------------------------------------------------------------
+# Release / PipelineRun inspection helpers
+# ---------------------------------------------------------------------------
+
+# Return the managed PipelineRun name for a Release CR.
+# Arguments:
+#   $1: release name
+# Relies on globals: tenant_namespace
+get_pipelinerun_name_from_release() {
+    local release_name=$1
+    local pipelinerun_full
+    pipelinerun_full=$(kubectl get release "${release_name}" -n "${tenant_namespace}" \
+        -o jsonpath='{.status.managedProcessing.pipelineRun}' 2>/dev/null)
+    [ -z "${pipelinerun_full}" ] && return 1
+    basename "${pipelinerun_full}"
+}
+
+# Return the Release CR as JSON.
+# Arguments:
+#   $1: release name
+# Relies on globals: tenant_namespace
+get_release_json() {
+    local release_name=$1
+    kubectl get release "${release_name}" -n "${tenant_namespace}" -o json
+}
+
+# Wait for a named Release to complete (wraps wait-for-release.sh).
+# Arguments:
+#   $1: release name
+# Relies on globals: tenant_namespace, SUITE_DIR
+wait_for_release() {
+    local release_name=$1
+    echo "⏳ Waiting for release ${release_name} to complete..."
+    export RELEASE_NAME=${release_name}
+    export RELEASE_NAMESPACE=${tenant_namespace}
+    "${SUITE_DIR}/../scripts/wait-for-release.sh"
+}
+
+# Check whether a named task was skipped in the managed PipelineRun for a Release.
+# Returns 0 (true) if skipped, 1 otherwise.
+# Arguments:
+#   $1: release name
+#   $2: pipeline task name
+# Relies on globals: tenant_namespace, managed_namespace
+is_managed_task_skipped() {
+    local release_name=$1
+    local task_name=$2
+    local pipelinerun_name
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || return 1
+    local skipped
+    skipped=$(kubectl get pipelinerun "${pipelinerun_name}" -n "${managed_namespace}" \
+        -o jsonpath="{.status.skippedTasks[?(@.name=='${task_name}')].name}" \
+        2>/dev/null)
+    [[ -n "${skipped}" ]]
+}
+
+# Wait for a specific task in the managed PipelineRun for a Release to reach a
+# terminal state (Succeeded / Failed / Cancelled). Prints dots while waiting.
+# Arguments:
+#   $1: release name
+#   $2: pipeline task name
+#   $3: timeout in seconds (default 300)
+# Relies on globals: tenant_namespace, managed_namespace
+wait_for_managed_pipeline_task() {
+    local release_name=$1
+    local task_name=$2
+    local timeout=${3:-300}
+    local pipelinerun_name
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || {
+        echo "⚠️  Could not resolve PipelineRun for release ${release_name}"
+        return 1
+    }
+
+    echo "Waiting for ${task_name} in ${pipelinerun_name}..."
+    local start_time
+    start_time=$(date +%s)
+
+    while true; do
+        local status
+        status=$(kubectl get taskrun -n "${managed_namespace}" \
+            -l "tekton.dev/pipelineRun=${pipelinerun_name}" \
+            -l "tekton.dev/pipelineTask=${task_name}" \
+            -o jsonpath='{.items[0].status.conditions[0].reason}' 2>/dev/null)
+
+        case "${status}" in
+            Succeeded)
+                echo ""
+                echo "✅ ${task_name} completed successfully"
+                return 0
+                ;;
+            Failed|TaskRunCancelled)
+                echo ""
+                echo "⚠️  ${task_name} ended with status: ${status}"
+                return 1
+                ;;
+        esac
+
+        if [ $(($(date +%s) - start_time)) -ge "${timeout}" ]; then
+            echo ""
+            echo "⚠️  Timed out waiting for ${task_name} (${timeout}s)"
+            return 1
+        fi
+        echo -n "."
+        sleep 10
+    done
+}
+
+# Fetch logs from a named step/container of a specific task in a managed PipelineRun.
+# Arguments:
+#   $1: managed pipelinerun name
+#   $2: pipeline task name
+#   $3: container / step name
+#   $4: number of tail lines (default 200)
+# Relies on global: managed_namespace
+get_managed_task_logs() {
+    local pipelinerun_name=$1
+    local task_name=$2
+    local container=$3
+    local tail=${4:-200}
+    local taskrun pod_name
+    taskrun=$(kubectl get taskrun -n "${managed_namespace}" \
+        -l "tekton.dev/pipelineRun=${pipelinerun_name}" \
+        -l "tekton.dev/pipelineTask=${task_name}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || return 1
+    [ -z "${taskrun}" ] && return 1
+    pod_name=$(kubectl get taskrun "${taskrun}" -n "${managed_namespace}" \
+        -o jsonpath='{.status.podName}' 2>/dev/null) || return 1
+    [ -z "${pod_name}" ] && return 1
+    kubectl logs -n "${managed_namespace}" "${pod_name}" \
+        -c "${container}" --tail="${tail}" 2>/dev/null
 }

--- a/integration-tests/scripts/create-github-repo.sh
+++ b/integration-tests/scripts/create-github-repo.sh
@@ -94,9 +94,19 @@ if [ -z "${CREATED_REPO}" ]; then
   exit 1
 fi
 
-# Verify the repository was created successfully
+# Verify the repository was created successfully.
+# GitHub's API has eventual consistency — a GET immediately after POST can return 404
+# for a few seconds while the new repository propagates. Retry with backoff.
 echo "Verifying repository creation..."
-VERIFY_REPO=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${full_repo_name} 2> /dev/null | jq -r '.full_name // ""')
+VERIFY_REPO=""
+for attempt in 1 2 3 4 5; do
+  sleep $((attempt * 2))  # 2s, 4s, 6s, 8s, 10s
+  VERIFY_REPO=$(curl -H "Authorization: token $GITHUB_TOKEN" \
+    https://api.github.com/repos/${full_repo_name} 2>/dev/null | jq -r '.full_name // ""')
+  [ "${VERIFY_REPO}" = "${full_repo_name}" ] && break
+  echo "   Verification attempt ${attempt}/5 — not yet visible, retrying..."
+done
+
 if [ "${VERIFY_REPO}" = "${full_repo_name}" ]; then
   echo "✅ Repository ${full_repo_name} created successfully!"
   echo "   - URL: https://github.com/${full_repo_name}"

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -210,8 +210,8 @@ spec:
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
-        - name: pyxisSecret
-          value: $(tasks.collect-task-params.results.extractedValues[1])
+        - name: releaseName
+          value: $(params.release)
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact

--- a/tasks/managed/filter-published-fbc-images/README.md
+++ b/tasks/managed/filter-published-fbc-images/README.md
@@ -1,22 +1,42 @@
 # filter-published-fbc-images
 
-Filters snapshot to remove already-released FBC fragments by querying Pyxis index images.
-Queries for index images and checks if fragments are present in their bundles/related_images fields.
-Components already published are filtered out to prevent EC validation failures.
-Additionally, extracts and attaches ocpVersion field to each component for downstream tasks.
+Tekton task that filters already-published FBC fragments from a Snapshot before release.
+
+## Description
+
+Before triggering an IIB build, this task compares every FBC fragment in the Snapshot against
+previously successful Release CRs for the same application. Any fragment whose digest matches a
+`status.artifacts.components[].fbc_fragment` value from a completed Release targeting the same
+`target_index` is removed from the filtered snapshot. This prevents redundant IIB builds on
+re-releases.
+
+The task also attaches an `ocpVersion` field to every component that passes through, derived from
+the `org.opencontainers.image.base.name` OCI annotation on the fragment image. This field is
+required by downstream tasks.
+
+**Safe fallback**: if `releaseName` is omitted, the Release CR lookup fails, or the Kubernetes API
+is unavailable, all components are kept and the task succeeds (the actual release tasks will
+handle any errors downstream).
 
 ## Parameters
 
-| Name                    | Description                                                                                        | Optional | Default value        |
-|-------------------------|----------------------------------------------------------------------------------------------------|----------|----------------------|
-| snapshotPath            | Path to the JSON string of the Snapshot spec in the data workspace                                 | No       | -                    |
-| dataPath                | Path to the JSON string of the merged data to use in the data workspace                            | No       | -                    |
-| pyxisSecret             | The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys - cert and key | No       | -                    |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                          | Yes      | empty                |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository                            | Yes      | 1d                   |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts                                                  | Yes      | ""                   |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                    | Yes      | ""                   |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                | Yes      | ""                   |
-| dataDir                 | The location where data will be stored                                                             | Yes      | /var/workdir/release |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks to be used are stored              | No       | -                    |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                     | No       | -                    |
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| snapshotPath | string | Yes | - | Path to the JSON snapshot spec in the data workspace |
+| dataPath | string | Yes | - | Path to the merged data JSON in the data workspace |
+| releaseName | string | No | `""` | Namespaced name (`namespace/name`) of the current Release CR. Used to discover previously completed Releases for the same application. If empty, filtering is skipped. |
+| ociStorage | string | No | `"empty"` | OCI repository for Trusted Artifacts storage |
+| ociArtifactExpiresAfter | string | No | `"1d"` | Expiration for trusted artifacts |
+| trustedArtifactsDebug | string | No | `""` | Enable debug logging in trusted artifacts |
+| orasOptions | string | No | `""` | Extra options passed to oras in trusted artifact calls |
+| sourceDataArtifact | string | No | `""` | Location of trusted artifacts to populate the data directory |
+| dataDir | string | No | `/var/workdir/release` | Root directory for data files |
+| taskGitUrl | string | Yes | - | Git repository URL for release-service-catalog tasks |
+| taskGitRevision | string | Yes | - | Revision in taskGitUrl to use |
+
+## Results
+
+| Name | Description |
+|------|-------------|
+| filteredSnapshotPath | Path to the filtered snapshot (with `ocpVersion` attached). Consumed by EC validation and downstream tasks. |
+| sourceDataArtifact | Trusted artifact produced by this task |

--- a/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
+++ b/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
@@ -8,10 +8,13 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: |-
-    Filters snapshot to remove already-released FBC fragments by querying Pyxis index images.
-    Queries for index images and checks if fragments are present in their bundles/related_images fields.
-    Components already published are filtered out to prevent EC validation failures.
-    Additionally, extracts and attaches ocpVersion field to each component for downstream tasks.
+    Filters already-published FBC fragments from the Snapshot before release.
+    Queries previous Release CRs in the tenant namespace (identified via releaseName)
+    to find FBC fragments that were already successfully published to the same target
+    index. Components whose fbc_fragment digest matches a previously-released artifact
+    are removed; all others are kept. Also attaches ocpVersion to every remaining
+    component for downstream tasks. If the Release CR lookup fails or releaseName is
+    not provided, all components are kept (safe fallback).
   params:
     - name: snapshotPath
       type: string
@@ -19,9 +22,13 @@ spec:
     - name: dataPath
       type: string
       description: Path to the JSON string of the merged data to use in the data workspace
-    - name: pyxisSecret
+    - name: releaseName
       type: string
-      description: The kubernetes secret to use to authenticate to Pyxis. It needs to contain two keys - cert and key
+      description: >-
+        The namespaced name (namespace/name) of the current Release CR. Used to look
+        up previously completed releases for the same application to identify already-
+        published FBC fragments. If empty, idempotence filtering is skipped.
+      default: ""
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored
       type: string
@@ -64,10 +71,6 @@ spec:
   volumes:
     - name: workdir
       emptyDir: {}
-    - name: pyxis-secret-vol
-      secret:
-        secretName: $(params.pyxisSecret)
-        defaultMode: 0400
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -101,26 +104,6 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
-    - name: setup-pyxis-cert
-      image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
-      computeResources:
-        limits:
-          memory: 64Mi
-        requests:
-          memory: 64Mi
-          cpu: 30m
-      volumeMounts:
-        - name: pyxis-secret-vol
-          mountPath: /etc/secrets
-      script: |
-        #!/usr/bin/env bash
-        set -eu
-        
-        echo "Extracting Pyxis credentials from mounted secret"
-        PYXIS_CERT="$(cat /etc/secrets/cert)"
-        PYXIS_KEY="$(cat /etc/secrets/key)"
-        echo "${PYXIS_CERT}" > /var/workdir/crt
-        echo "${PYXIS_KEY}" > /var/workdir/key
     - name: filter-already-released-images
       image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
       computeResources:
@@ -147,12 +130,11 @@ spec:
             exit 1
         fi
 
-        echo "==============================================================="
-        echo "Filtering Already-Released FBC Fragments via Pyxis Index Query"
-        echo "==============================================================="
+        echo "================================================================"
+        echo "Filtering Already-Released FBC Fragments via Release CR Lookup"
+        echo "================================================================"
         echo ""
 
-        pyxis_server=$(jq -r '.pyxis.server // "production"' "${DATA_FILE}")
         staged_index=$(jq -r '.fbc.stagedIndex // false' "${DATA_FILE}")
 
         component_count=$(jq '.components | length' "${SNAPSHOT_FILE}")
@@ -311,186 +293,113 @@ spec:
         echo ""
         echo "Found $unique_count unique resolved targetIndex value(s)"
         echo ""
-        
-        case "$pyxis_server" in
-          production)
-            PYXIS_URL="https://pyxis.api.redhat.com/"
-            ;;
-          stage)
-            PYXIS_URL="https://pyxis.preprod.api.redhat.com/"
-            ;;
-          production-internal)
-            PYXIS_URL="https://pyxis.engineering.redhat.com/"
-            ;;
-          stage-internal)
-            PYXIS_URL="https://pyxis.stage.engineering.redhat.com/"
-            ;;
-          *)
-            echo "ERROR: Invalid pyxis server: $pyxis_server"
-            exit 1
-            ;;
-        esac
 
-        echo "Pyxis server: $PYXIS_URL"
+        # Get the tenant namespace and current release name from the releaseName parameter
+        RELEASE_NAME_PARAM="$(params.releaseName)"
+        if [ -z "${RELEASE_NAME_PARAM}" ]; then
+          echo "ℹ️  No releaseName parameter provided"
+          echo "  → Skipping idempotence filtering (keeping all components)"
+          echo ""
+          attach_ocp_versions_to_all "${SNAPSHOT_FILE}" "${FILTERED_SNAPSHOT_FILE}"
+          echo -n "filtered-snapshot.json" > "$(results.filteredSnapshotPath.path)"
+          exit 0
+        fi
+
+        TENANT_NAMESPACE=$(cut -d'/' -f1 <<< "${RELEASE_NAME_PARAM}")
+        CURRENT_RELEASE=$(cut -d'/' -f2 <<< "${RELEASE_NAME_PARAM}")
+
+        echo "Release namespace : ${TENANT_NAMESPACE}"
+        echo "Current release   : ${CURRENT_RELEASE}"
+
+        # Resolve application name from the current Release CR label
+        APPLICATION=$(kubectl get release "${CURRENT_RELEASE}" \
+          -n "${TENANT_NAMESPACE}" \
+          -o jsonpath='{.metadata.labels.appstudio\.openshift\.io/application}' \
+          2>/dev/null || echo "")
+
+        if [ -z "${APPLICATION}" ]; then
+          echo "WARNING: Could not determine application name from Release CR"
+          echo "  → Skipping idempotence filtering (keeping all components)"
+          echo ""
+          attach_ocp_versions_to_all "${SNAPSHOT_FILE}" "${FILTERED_SNAPSHOT_FILE}"
+          echo -n "filtered-snapshot.json" > "$(results.filteredSnapshotPath.path)"
+          exit 0
+        fi
+
+        echo "Application       : ${APPLICATION}"
         echo ""
-        
-        # Calculate date filter (30 days ago) for Pyxis query optimization
-        # Format: YYYY-MM-DD (Pyxis expects ISO 8601 date format)
-        # 30 days covers realistic re-release scenarios while keeping queries fast
-        date_filter=$(date -u -d '30 days ago' '+%Y-%m-%d' 2>/dev/null || date -u -v-30d '+%Y-%m-%d')
-        echo "Date filter: last_update_date>=$date_filter (last 30 days)"
-        echo ""
-        
-        # Function to query Pyxis and extract published fragments for a targetIndex
-        query_pyxis_for_target_index() {
+
+        # Query Release CRs to find previously-published FBC fragment digests
+        # for a given resolved targetIndex.
+        # Diagnostic output goes to stderr; only sha256:... digests are printed to stdout.
+        query_releases_for_published_fragments() {
           local target_index="$1"
-          local max_retries=3
-          local retry_count=0
-          local index_response=""
-          local http_code=""
-          
-          echo "  Querying Pyxis for targetIndex: ${target_index}"
-          
-          while [ $retry_count -le $max_retries ]; do
-            if [ $retry_count -gt 0 ]; then
-              echo "  Retry attempt $retry_count/$max_retries..."
-              sleep $((retry_count * 2))  # Exponential backoff: 2s, 4s, 6s
-            fi
-            
-            local response_file
-            local http_code_output
-            response_file=$(mktemp)
-            http_code_output=$(mktemp)
-            
-            # Build Pyxis query URL with optimization parameters:
-            # - docker_image_id filter: find indices for this catalog
-            # - last_update_date filter: only check indices updated in last 30 days
-            # - page_size=500: retrieve up to 500 results (Pyxis API maximum)
-            # URL-encode the entire filter value to handle special characters (/, :, ;, =)
-            local filter_value="docker_image_id==${target_index};last_update_date>=${date_filter}"
-            local encoded_filter
-            encoded_filter=$(printf '%s' "${filter_value}" | jq -sRr @uri)
-            local pyxis_query_url="${PYXIS_URL}v1/images?filter=${encoded_filter}&page_size=500"
-            
-            set +e  # Temporarily disable exit on error
-            curl -s \
-              --cert /var/workdir/crt \
-              --key /var/workdir/key \
-              --max-time 60 \
-              --connect-timeout 10 \
-              -X GET \
-              "$pyxis_query_url" \
-              -H "Content-Type: application/json" \
-              -w "%{http_code}" \
-              -o "$response_file" \
-              > "$http_code_output"
-            local curl_exit=$?
-            set -e  # Re-enable exit on error
-            
-            http_code=$(cat "$http_code_output")
-            index_response=$(cat "$response_file")
-            
-            rm -f "$response_file" "$http_code_output"
-            
-            if [ $curl_exit -eq 0 ] && [[ "$http_code" =~ ^2[0-9]{2}$ ]]; then
-              echo "  ✓ Pyxis query successful (HTTP $http_code)"
-              break
-            else
-              echo "  ✗ Pyxis query failed (HTTP $http_code, curl exit: $curl_exit)"
-              retry_count=$((retry_count + 1))
-              
-              if [ $retry_count -gt $max_retries ]; then
-                echo ""
-                echo "WARNING: Failed to query Pyxis API after $max_retries retries"
-                echo ""
-                echo "Details:"
-                echo "  - HTTP code: $http_code"
-                echo "  - curl exit code: $curl_exit"
-                echo "  - Pyxis URL: ${PYXIS_URL}"
-                echo "  - Target index: ${target_index}"
-                echo ""
-                echo "Possible causes:"
-                echo "  - Invalid or expired Pyxis certificates"
-                echo "  - Network connectivity issues"
-                echo "  - Pyxis API service unavailable"
-                echo "  - Incorrect Pyxis server configuration"
-                echo ""
-                echo "Cannot verify already-published fragments. Will keep all components for release."
-                echo "If there's a real registry issue, the actual release task will fail."
-                return 1
-              fi
-            fi
-          done
-          
-          if ! jq -e '.data' <<< "$index_response" > /dev/null 2>&1; then
-            echo "WARNING: Invalid JSON response from Pyxis API"
-            echo "  Expected JSON with '.data' field"
-            echo "  Response:"
-            echo "$index_response"
-            echo "Cannot verify already-published fragments. Will keep all components for release."
+
+          echo "  Querying Release CRs for previously-published fragments..." >&2
+          echo "  target index : ${target_index}" >&2
+
+          local releases_json
+          local kubectl_err
+          if ! kubectl_err=$(kubectl get release \
+              -n "${TENANT_NAMESPACE}" \
+              -l "appstudio.openshift.io/application=${APPLICATION}" \
+              -o json 2>&1 >/tmp/releases_json_out); then
+            echo "  WARNING: Failed to list Release CRs: ${kubectl_err}" >&2
             return 1
           fi
-          
-          local index_count
-          index_count=$(jq '.data | length' <<< "$index_response")
-          
-          if [ "$index_count" -eq 0 ]; then
-            echo "  ℹ️  No index images found (first release to this catalog)"
-            echo ""
-            return 0
-          fi
-          
-          echo "  Found $index_count existing index image(s)"
-          
-          # Extract published fragments from this targetIndex
+          releases_json=$(cat /tmp/releases_json_out)
+
+          # Extract fbc_fragment digests from successfully completed Releases
+          # that targeted this same index, excluding the current (in-flight) release.
           local published_fragments
-          published_fragments=$(jq -r '
+          published_fragments=$(jq -r \
+            --arg target "${target_index}" \
+            --arg current "${CURRENT_RELEASE}" '
             [
-              .data[] |
-              (
-                (.related_images[]?.digest // empty),
-                (.related_images[]?.image | split("@")[1] // empty),
-                (.bundles[]?.related_images[]?.digest // empty),
-                (.bundles[]?.related_images[]?.image | split("@")[1] // empty)
-              )
+              .items[] |
+              select(.metadata.name != $current) |
+              select(
+                .status.conditions != null and
+                any(.status.conditions[]; .type == "Released" and .status == "True")
+              ) |
+              (.status.artifacts.components // [])[] |
+              select(.target_index == $target) |
+              .fbc_fragment |
+              split("@")[1]
             ] | unique | .[]
-          ' <<< "$index_response" 2>/dev/null || echo "")
-          
-          if [ -n "$published_fragments" ]; then
-            local fragment_count
-            fragment_count=$(echo "$published_fragments" | wc -l)
-            echo "  Extracted $fragment_count unique fragment digest(s)"
-          else
-            echo "  ⚠️  No fragments found in published index"
+          ' <<< "${releases_json}" 2>/dev/null || echo "")
+
+          local frag_count=0
+          if [ -n "${published_fragments}" ]; then
+            frag_count=$(echo "${published_fragments}" | wc -l)
           fi
-          echo ""
-          
-          # Store fragments for this targetIndex (return via stdout)
-          echo "$published_fragments"
+          echo "  Found ${frag_count} previously-published fragment digest(s)" >&2
+          echo "" >&2
+
+          echo "${published_fragments}"
         }
-        
-        # Query Pyxis for each unique targetIndex and build fragment map
-        declare -A target_index_fragments  # targetIndex -> newline-separated fragment digests
-        
-        echo "Querying Pyxis for each targetIndex..."
+
+        # Build published-fragments map for each unique targetIndex
+        declare -A target_index_fragments
+
+        echo "Querying Release CRs for each targetIndex..."
         echo ""
-        
+
         for target_index in "${unique_target_indices[@]}"; do
           echo "--- targetIndex: ${target_index} ---"
-          if ! fragments=$(query_pyxis_for_target_index "$target_index"); then
+          if ! fragments=$(query_releases_for_published_fragments "${target_index}"); then
             echo ""
             echo "================================================================"
-            echo "Pyxis query failed - skipping idempotence filtering"
+            echo "Release CR query failed - skipping idempotence filtering"
             echo "================================================================"
             echo ""
             echo "Keeping all components for release (fail-safe behavior)."
-            echo "If there are real registry issues, they will be caught during actual release."
             echo ""
             attach_ocp_versions_to_all "${SNAPSHOT_FILE}" "${FILTERED_SNAPSHOT_FILE}"
             echo -n "filtered-snapshot.json" > "$(results.filteredSnapshotPath.path)"
             exit 0
           fi
-          target_index_fragments[$target_index]="$fragments"
+          target_index_fragments[$target_index]="${fragments}"
         done
 
         echo "================================================================"

--- a/tasks/managed/filter-published-fbc-images/tests/mocks.sh
+++ b/tasks/managed/filter-published-fbc-images/tests/mocks.sh
@@ -3,32 +3,14 @@ echo "==================================================================" >&2
 echo "🔧 MOCKS.SH BEING LOADED - START OF INJECTION" >&2
 echo "==================================================================" >&2
 
-kubectl() {
-  echo "Mock kubectl called with: $*" >&2
-
-  # Mock kubectl get secret - simulate the pyxis secret exists
-  if [[ "$*" == "get secret pyxis"* ]]; then
-    return 0
-  # Mock kubectl get secret -o json to extract cert/key
-  elif [[ "$*" == "get secret pyxis -o json" ]]; then
-    echo '{
-      "data": {
-        "cert": "'$(echo -n "mock-cert" | base64)'",
-        "key": "'$(echo -n "mock-key" | base64)'"
-      }
-    }'
-  else
-    # For any other kubectl command, call the real kubectl
-    command kubectl "$@"
-  fi
-}
-
+# ---------------------------------------------------------------------------
+# skopeo mock — returns OCP version from org.opencontainers.image.base.name
+# Routes by image digest suffix to support multi-OCP tests.
+# ---------------------------------------------------------------------------
 skopeo() {
   echo "Mock skopeo called with: $*" >&2
 
-  # Mock skopeo inspect to return OCP version in org.opencontainers.image.base.name
   if [[ "$*" == *"inspect"* ]]; then
-    # Extract image digest from arguments to determine which OCP version to return
     local image=""
     for arg in "$@"; do
       if [[ "$arg" == docker://* ]]; then
@@ -37,491 +19,442 @@ skopeo() {
       fi
     done
 
-    echo "Mock skopeo inspecting image: $image" >&2
-
-    # Determine OCP version based on component image digest
-    local ocp_version=""
-    if [[ "$image" == *"@sha256:comp1v414"* ]] || [[ "$image" == *"@sha256:comp2v414"* ]]; then
-      ocp_version="v4.14"
-    elif [[ "$image" == *"@sha256:comp3v416"* ]] || [[ "$image" == *"@sha256:comp4v416"* ]]; then
-      ocp_version="v4.16"
+    local ocp_version="4.15"  # default (no 'v' prefix — task adds it)
+    if [[ "$image" == *"comp1v414"* ]] || [[ "$image" == *"comp2v414"* ]] || [[ "$image" == *"v414"* ]]; then
+      ocp_version="4.14"
+    elif [[ "$image" == *"comp3v416"* ]] || [[ "$image" == *"comp4v416"* ]] || [[ "$image" == *"v416"* ]]; then
+      ocp_version="4.16"
     elif [[ "$image" == *"@sha256:invalidocp"* ]]; then
-      # Invalid OCP version format for testing validation (three parts instead of two)
-      ocp_version="4.14.1"
-    else
-      # Default OCP version for other tests (no 'v' prefix - template adds it)
-      ocp_version="4.15"
+      ocp_version="4.14.1"  # invalid: three parts, triggers validation error
     fi
 
-    echo "Mock skopeo returning OCP version: $ocp_version for image: $image" >&2
-
-    # Return mock skopeo inspect JSON with OCP version in base image annotation
-    # Note: using both Labels and annotations to be compatible with different formats
-    local json_output
-    json_output=$(cat <<EOF
+    cat <<EOF
 {
-  "Name": "$image",
-  "Digest": "sha256:mockdigest",
-  "RepoTags": [],
-  "Created": "2024-01-01T00:00:00Z",
-  "DockerVersion": "",
-  "Labels": {
-    "org.opencontainers.image.base.name": "registry.access.redhat.com/ubi9/ubi:$ocp_version"
-  },
-  "Architecture": "amd64",
-  "Os": "linux",
-  "Layers": [],
-  "Env": [],
   "annotations": {
     "org.opencontainers.image.base.name": "registry.access.redhat.com/ubi9/ubi:$ocp_version"
   }
 }
 EOF
-)
-    echo "$json_output"
-    echo "📤 Skopeo mock returned JSON with OCP version: $ocp_version" >&2
     return 0
-  else
-    # For any other skopeo command, call the real skopeo
-    command skopeo "$@"
   fi
+
+  command skopeo "$@"
 }
-
-curl() {
-  echo "Mock curl called with: $*" >&2
-
-  # Parse curl flags to extract output file (-o flag)
-  output_file=""
-  write_out=""
-  local args=("$@")
-  for ((i=0; i<${#args[@]}; i++)); do
-    if [[ "${args[i]}" == "-o" ]]; then
-      output_file="${args[i+1]}"
-    elif [[ "${args[i]}" == "-w" ]]; then
-      write_out="${args[i+1]}"
-    fi
-  done
-
-  # Verify required query parameters are present for every /v1/images filter call
-  if [[ "$*" == *"v1/images?filter="* ]]; then
-    # docker_image_id stores the config digest (SHA256), not an image reference;
-    # using it to filter by image location always returns empty results.
-    if [[ "$*" == *"docker_image_id"* ]]; then
-      echo "ERROR: Query must not use docker_image_id — use repositories.* location fields" >&2
-      return 1
-    fi
-
-    # All three repository location sub-fields must be present in the filter
-    if [[ "$*" != *"repositories.registry"* ]]; then
-      echo "ERROR: repositories.registry missing from Pyxis query filter" >&2
-      return 1
-    fi
-    if [[ "$*" != *"repositories.repository"* ]]; then
-      echo "ERROR: repositories.repository missing from Pyxis query filter" >&2
-      return 1
-    fi
-    if [[ "$*" != *"repositories.tags.name"* ]]; then
-      echo "ERROR: repositories.tags.name missing from Pyxis query filter" >&2
-      return 1
-    fi
-
-    if [[ "$*" != *"page_size=500"* ]]; then
-      echo "ERROR: page_size=500 parameter not found in Pyxis query" >&2
-      return 1
-    fi
-
-    echo "✓ Verified: repositories.registry/repository/tags.name + page_size=500 in query" >&2
-  fi
-
-  # Determine which JSON response to return based on query
-  local json_response=""
-  local http_status="200"
-  
-  # ERROR SCENARIOS (for gap coverage tests)
-  
-  # Pyxis 500 error test - simulate API server error
-  if [[ "$*" == *"catalog-500-error"* ]]; then
-    json_response='{"error": "Internal Server Error", "message": "Database connection failed"}'
-    http_status="500"
-  # Malformed JSON test - simulate corrupted response
-  elif [[ "$*" == *"catalog-malformed"* ]]; then
-    json_response='{"data": [{"_id": "broken", "malformed_json'
-    http_status="200"
-  
-  # NORMAL SCENARIOS
-
-  # Index with published fragments sha256:abc123 and sha256:ghi789
-  # Match URL-encoded tag filter: repositories.tags.name==v4.14-published
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14-published"* ]]; then
-    json_response='{
-      "data": [{
-        "_id": "index-v4.14",
-        "image_id": "sha256:index-v4.14-digest",
-        "related_images": [
-          {
-            "image": "quay.io/test/comp1@sha256:abc123",
-            "name": "comp1-bundle",
-            "digest": "sha256:abc123"
-          },
-          {
-            "image": "quay.io/test/comp3@sha256:ghi789",
-            "name": "comp3-bundle",
-            "digest": "sha256:ghi789"
-          }
-        ]
-      }]
-    }'
-  # Index with NO published fragments (empty index or not yet published)
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.15-unpublished"* ]]; then
-    json_response='{"data": []}'
-  # All fragments published - for all-published test
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16-all-published"* ]]; then
-    json_response='{
-      "data": [{
-        "_id": "index-v4.16-all",
-        "image_id": "sha256:index-v4.16-all-digest",
-        "related_images": [
-          {
-            "image": "quay.io/test/comp1@sha256:mno345",
-            "name": "comp1-bundle",
-            "digest": "sha256:mno345"
-          },
-          {
-            "image": "quay.io/test/comp2@sha256:pqr678",
-            "name": "comp2-bundle",
-            "digest": "sha256:pqr678"
-          }
-        ]
-      }]
-    }'
-  # Empty response test - no index at all
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.17-empty"* ]]; then
-    json_response='{"data": []}'
-  # Index found but has no fragment data (realistic post-fix behavior: Pyxis finds the
-  # index image via the repositories filter but ContainerImage records do not carry
-  # related_images/bundles fields, so fragment extraction returns empty → safe fallback)
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.19-no-fragments"* ]]; then
-    json_response='{
-      "data": [{
-        "_id": "index-v4.19-no-fragments",
-        "image_id": "sha256:index-v4.19-no-fragments-digest",
-        "repositories": [
-          {
-            "registry": "quay.io",
-            "repository": "redhat-pending/catalog",
-            "tags": [{"name": "v4.19-no-fragments"}]
-          }
-        ]
-      }]
-    }'
-  # Bundles field test - alternative structure with bundles instead of related_images
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.18-bundles"* ]]; then
-    json_response='{
-      "data": [{
-        "_id": "index-v4.18-bundles",
-        "image_id": "sha256:index-v4.18-bundles-digest",
-        "bundles": [
-          {
-            "bundle_path": "registry/bundle1",
-            "csv_name": "bundle1-csv",
-            "related_images": [
-              {
-                "image": "quay.io/test/bundle1@sha256:bun111",
-                "name": "bundle1-image",
-                "digest": "sha256:bun111"
-              }
-            ]
-          },
-          {
-            "bundle_path": "registry/bundle2",
-            "csv_name": "bundle2-csv",
-            "related_images": [
-              {
-                "image": "quay.io/test/bundle2@sha256:bun222",
-                "name": "bundle2-image",
-                "digest": "sha256:bun222"
-              }
-            ]
-          }
-        ]
-      }]
-    }'
-  # Multi-OCP test: v4.14 catalog with comp1v414 published (comp2v414 not published)
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
-    echo "✅ Matched v4.14 catalog pattern - returning comp1v414 as published" >&2
-    json_response='{
-      "data": [{
-        "_id": "index-v4.14-multi",
-        "image_id": "sha256:index-v4.14-multi-digest",
-        "related_images": [
-          {
-            "image": "quay.io/test/comp1@sha256:comp1v414",
-            "name": "comp1-v414-bundle",
-            "digest": "sha256:comp1v414"
-          }
-        ]
-      }]
-    }'
-  # Multi-OCP test: v4.16 catalog with comp3v416 published (comp4v416 not published)
-  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
-    echo "✅ Matched v4.16 catalog pattern - returning comp3v416 as published" >&2
-    json_response='{
-      "data": [{
-        "_id": "index-v4.16-multi",
-        "image_id": "sha256:index-v4.16-multi-digest",
-        "related_images": [
-          {
-            "image": "quay.io/test/comp3@sha256:comp3v416",
-            "name": "comp3-v416-bundle",
-            "digest": "sha256:comp3v416"
-          }
-        ]
-      }]
-    }'
-  else
-    # Default: return empty data (no published index)
-    echo "⚠️  No curl pattern matched - returning empty data. Query was: $*" >&2
-    json_response='{"data": []}'
-  fi
-
-  if [[ -n "$output_file" ]]; then
-    # Write JSON to file (simulating -o flag)
-    echo "$json_response" > "$output_file"
-  else
-    echo "$json_response"
-  fi
-
-  if [[ "$write_out" == "%{http_code}" ]]; then
-    echo "$http_status"
-  fi
-
-  # Return appropriate exit code based on HTTP status
-  if [[ "$http_status" == "500" ]]; then
-    return 0  # curl itself succeeds, but HTTP status is 500
-  fi
-  
-  return 0
-}
-
-# Export mock functions so they're available in subshells and when called by scripts
-export -f kubectl
 export -f skopeo
+
+# ---------------------------------------------------------------------------
+# curl mock — should NOT be called after the Pyxis → Release CR migration.
+# Fails loudly if invoked, so any regression to the Pyxis path is caught.
+# ---------------------------------------------------------------------------
+curl() {
+  echo "ERROR: curl was called but should not be used by filter-published-fbc-images." >&2
+  echo "  The task uses kubectl Release CR lookup, not Pyxis HTTP calls." >&2
+  echo "  Arguments received: $*" >&2
+  return 1
+}
 export -f curl
 
-# CRITICAL FIX: Create wrapper executables in PATH to ensure mocks are called
-# Bash functions don't work reliably in command substitutions $(...)
-# Solution: Create executable mock scripts that will be found first in PATH
+# ---------------------------------------------------------------------------
+# kubectl mock — handles two calls made by filter-published-fbc-images:
+#
+#   1. get release <name> -n <ns> -o jsonpath=...
+#      → returns application label (routes by release name)
+#
+#   2. get release -n <ns> -l appstudio.openshift.io/application=<app> -o json
+#      → returns Release CR list JSON (routes by application label)
+#
+# Test scenarios are identified by the release name passed in releaseName param:
+#
+#   current-release-basic      app=test-app-basic   → prev release: abc123+ghi789 published
+#   current-release-all        app=test-app-all     → prev release: all digests published
+#   current-release-first      app=test-app-first   → no prior releases
+#   current-release-multi      app=test-app-multi   → prior releases for v4.14 + v4.16
+#   current-release-incomplete app=test-app-incomplete → prior release Released=False
+#   current-release-rbac       app=test-app-rbac    → list fails (simulates RBAC denial)
+#   current-release-malformed  app=test-app-malformed → list returns invalid JSON
+#   current-release-partial    app=test-app-partial    → one of two fragments published
+#   current-release-history    app=test-app-history    → two prior releases, same index (union)
+#   current-release-multi-partial  app=test-app-multi-partial → multi-OCP + partial
+#   current-release-no-artifacts   app=test-app-no-artifacts  → Released=True, no artifacts
+#   current-release-no-app-label   (kubectl get <name> returns "", triggers safe fallback)
+#   (any other name)           app=test-app-default    → no prior releases (safe default)
+# ---------------------------------------------------------------------------
+kubectl() {
+  echo "Mock kubectl called with: $*" >&2
+
+  if [[ "$1" == "get" && "$2" == "release" ]]; then
+    # Detect single-resource get (name is 3rd positional, not a flag)
+    if [[ "$3" != "-n" && "$3" != "-l" && "$3" != "-o" && -n "$3" ]]; then
+      # Call 1: get release <name> -n <ns> -o jsonpath=...
+      local release_name="$3"
+      echo "  → Resolving application label for release: $release_name" >&2
+      case "$release_name" in
+        current-release-basic)      echo -n "test-app-basic" ;;
+        current-release-all)        echo -n "test-app-all" ;;
+        current-release-first)      echo -n "test-app-first" ;;
+        current-release-multi)      echo -n "test-app-multi" ;;
+        current-release-incomplete) echo -n "test-app-incomplete" ;;
+        current-release-rbac)       echo -n "test-app-rbac" ;;
+        current-release-malformed)  echo -n "test-app-malformed" ;;
+        current-release-partial)        echo -n "test-app-partial" ;;
+        current-release-history)        echo -n "test-app-history" ;;
+        current-release-multi-partial)  echo -n "test-app-multi-partial" ;;
+        current-release-no-artifacts)   echo -n "test-app-no-artifacts" ;;
+        current-release-no-app-label)   echo -n "" ;;
+        *)                              echo -n "test-app-default" ;;
+      esac
+      return 0
+    else
+      # Call 2: get release -n <ns> -l appstudio...=<app> -o json
+      local app=""
+      for arg in "$@"; do
+        if [[ "$arg" =~ appstudio\.openshift\.io/application=(.+) ]]; then
+          app="${BASH_REMATCH[1]}"
+          break
+        fi
+      done
+      echo "  → Listing releases for application: $app" >&2
+
+      case "$app" in
+
+        test-app-basic)
+          # One prior completed release — abc123 and ghi789 published for v4.15
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-release-basic"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp1@sha256:abc123",
+         "target_index": "quay.io/redhat-pending/catalog:v4.15"},
+        {"fbc_fragment": "quay.io/test/comp3@sha256:ghi789",
+         "target_index": "quay.io/redhat-pending/catalog:v4.15"}
+      ]}
+    }
+  }
+]}
+JSON
+          ;;
+
+        test-app-all)
+          # One prior completed release — all snapshot digests published
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-release-all"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp1@sha256:mno345",
+         "target_index": "quay.io/redhat-pending/catalog:v4.16-all"},
+        {"fbc_fragment": "quay.io/test/comp2@sha256:pqr678",
+         "target_index": "quay.io/redhat-pending/catalog:v4.16-all"}
+      ]}
+    }
+  }
+]}
+JSON
+          ;;
+
+        test-app-first)
+          # No prior releases at all
+          echo '{"items": []}'
+          ;;
+
+        test-app-multi)
+          # Two prior releases — one for v4.14, one for v4.16, each with one fragment
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-release-v414"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp1@sha256:comp1v414",
+         "target_index": "quay.io/redhat-pending/catalog:v4.14"}
+      ]}
+    }
+  },
+  {
+    "metadata": {"name": "prev-release-v416"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp3@sha256:comp3v416",
+         "target_index": "quay.io/redhat-pending/catalog:v4.16"}
+      ]}
+    }
+  }
+]}
+JSON
+          ;;
+
+        test-app-incomplete)
+          # Prior release exists but Released condition is False — must not count
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-release-incomplete"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "False", "reason": "Failed"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp1@sha256:abc123",
+         "target_index": "quay.io/redhat-pending/catalog:v4.15"}
+      ]}
+    }
+  }
+]}
+JSON
+          ;;
+
+        test-app-rbac)
+          # Simulate RBAC denial — kubectl exits non-zero
+          echo "Error from server (Forbidden): releases.appstudio.redhat.com is forbidden" >&2
+          return 1
+          ;;
+
+        test-app-malformed)
+          # Return syntactically invalid JSON
+          echo '{"items": [{"broken": true, "status": {"conditions": [unclosed'
+          ;;
+
+        test-app-partial)
+          # One of two fragments already published (comp1); comp2 is new
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-release-partial"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp1@sha256:frag111",
+         "target_index": "quay.io/redhat-pending/catalog:v4.15"}
+      ]}
+    }
+  }
+]}
+JSON
+          ;;
+
+        test-app-history)
+          # Two prior releases for the SAME target index — tests union accumulation.
+          # Release A: sha256:F1. Release B: sha256:F3. New snapshot has F1+F2+F3+F4.
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-release-A"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp1@sha256:F1",
+         "target_index": "quay.io/redhat-pending/catalog:v4.15"}
+      ]}
+    }
+  },
+  {
+    "metadata": {"name": "prev-release-B"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp3@sha256:F3",
+         "target_index": "quay.io/redhat-pending/catalog:v4.15"}
+      ]}
+    }
+  }
+]}
+JSON
+          ;;
+
+        test-app-multi-partial)
+          # Multi-OCP + partial: v4.14 index has sha256:P1comp1v414 published; v4.16 nothing
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-v414-partial"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}],
+      "artifacts": {"components": [
+        {"fbc_fragment": "quay.io/test/comp1@sha256:P1comp1v414",
+         "target_index": "quay.io/redhat-pending/catalog:v4.14"}
+      ]}
+    }
+  }
+]}
+JSON
+          ;;
+
+        test-app-no-artifacts)
+          # Prior Release is completed (Released=True) but has no artifacts field at all
+          cat <<'JSON'
+{"items": [
+  {
+    "metadata": {"name": "prev-no-artifacts"},
+    "status": {
+      "conditions": [{"type": "Released", "status": "True"}]
+    }
+  }
+]}
+JSON
+          ;;
+
+        *)
+          # Safe default: no prior releases
+          echo '{"items": []}'
+          ;;
+      esac
+      return 0
+    fi
+  fi
+
+  # Pass through any other kubectl calls (should not occur in normal test execution)
+  command kubectl "$@"
+}
+export -f kubectl
+
+# ---------------------------------------------------------------------------
+# Create mock executables in PATH (required for command-substitution contexts)
+# ---------------------------------------------------------------------------
 MOCK_BIN_DIR="/tmp/filter-fbc-mocks-$$"
 mkdir -p "$MOCK_BIN_DIR"
 export PATH="$MOCK_BIN_DIR:$PATH"
 
-# Create skopeo mock executable
-cat > "$MOCK_BIN_DIR/skopeo" << 'EOF'
+# skopeo executable
+cat > "$MOCK_BIN_DIR/skopeo" << 'SKOPEO_EOF'
 #!/bin/bash
-echo "🎯 Mock skopeo executable called with: $*" >&2
-
+echo "🎯 Mock skopeo called with: $*" >&2
 if [[ "$*" == *"inspect"* ]]; then
   image=""
   for arg in "$@"; do
-    if [[ "$arg" == docker://* ]]; then
-      image="$arg"
-      break
-    fi
+    if [[ "$arg" == docker://* ]]; then image="$arg"; break; fi
   done
-  
-  echo "  → Inspecting image: $image" >&2
-  
-  ocp_version="4.15"  # default (no 'v' prefix - template adds it)
-  if [[ "$image" == *"@sha256:comp1v414"* ]] || [[ "$image" == *"@sha256:comp2v414"* ]]; then
+  ocp_version="4.15"
+  if [[ "$image" == *"comp1v414"* ]] || [[ "$image" == *"comp2v414"* ]] || [[ "$image" == *"v414"* ]]; then
     ocp_version="4.14"
-  elif [[ "$image" == *"@sha256:comp3v416"* ]] || [[ "$image" == *"@sha256:comp4v416"* ]]; then
+  elif [[ "$image" == *"comp3v416"* ]] || [[ "$image" == *"comp4v416"* ]] || [[ "$image" == *"v416"* ]]; then
     ocp_version="4.16"
   elif [[ "$image" == *"@sha256:invalidocp"* ]]; then
-    # Invalid OCP version format for testing validation (three parts instead of two)
     ocp_version="4.14.1"
   fi
-  
-  echo "  → Returning OCP version: $ocp_version" >&2
-  
-  cat <<JSONEOF
-{
-  "Name": "$image",
-  "Labels": {
-    "org.opencontainers.image.base.name": "registry.access.redhat.com/ubi9/ubi:$ocp_version"
-  },
-  "annotations": {
-    "org.opencontainers.image.base.name": "registry.access.redhat.com/ubi9/ubi:$ocp_version"
-  }
-}
-JSONEOF
+  cat <<EOF
+{"annotations": {"org.opencontainers.image.base.name": "registry.access.redhat.com/ubi9/ubi:$ocp_version"}}
+EOF
   exit 0
 fi
-
-# For other commands, call real skopeo
 exec /usr/bin/skopeo "$@"
-EOF
+SKOPEO_EOF
 chmod +x "$MOCK_BIN_DIR/skopeo"
 
-echo "✅ Created mock executable: $MOCK_BIN_DIR/skopeo" >&2
-
-# Create curl mock executable — mirrors every pattern in the curl() bash function above
-cat > "$MOCK_BIN_DIR/curl" << 'EOF'
+# curl executable — fails on any call
+cat > "$MOCK_BIN_DIR/curl" << 'CURL_EOF'
 #!/bin/bash
-echo "🎯 Mock curl executable called" >&2
-
-# Parse arguments
-output_file=""
-write_out=""
-for ((i=1; i<=$#; i++)); do
-  arg="${!i}"
-  if [[ "$arg" == "-o" ]]; then
-    ((i++))
-    output_file="${!i}"
-  elif [[ "$arg" == "-w" ]]; then
-    ((i++))
-    write_out="${!i}"
-  fi
-done
-
-# Validate filter fields (same rules as the bash function mock)
-if [[ "$*" == *"v1/images?filter="* ]]; then
-  if [[ "$*" == *"docker_image_id"* ]]; then
-    echo "ERROR: Query must not use docker_image_id" >&2
-    exit 1
-  fi
-  for field in "repositories.registry" "repositories.repository" "repositories.tags.name"; do
-    if [[ "$*" != *"${field}"* ]]; then
-      echo "ERROR: ${field} missing from Pyxis query filter" >&2
-      exit 1
-    fi
-  done
-  if [[ "$*" != *"page_size=500"* ]]; then
-    echo "ERROR: page_size=500 missing from Pyxis query" >&2
-    exit 1
-  fi
-fi
-
-# Determine response based on URL pattern (matches bash function mock patterns 1:1)
-json_response='{"data": []}'
-http_status="200"
-
-if [[ "$*" == *"catalog-500-error"* ]]; then
-  json_response='{"error": "Internal Server Error"}'
-  http_status="500"
-elif [[ "$*" == *"catalog-malformed"* ]]; then
-  json_response='{"data": [{"_id": "broken", "malformed_json'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14-published"* ]]; then
-  json_response='{
-    "data": [{
-      "_id": "index-v4.14",
-      "image_id": "sha256:index-v4.14-digest",
-      "related_images": [
-        {"image": "quay.io/test/comp1@sha256:abc123", "digest": "sha256:abc123"},
-        {"image": "quay.io/test/comp3@sha256:ghi789", "digest": "sha256:ghi789"}
-      ]
-    }]
-  }'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.15-unpublished"* ]]; then
-  json_response='{"data": []}'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16-all-published"* ]]; then
-  json_response='{
-    "data": [{
-      "_id": "index-v4.16-all",
-      "image_id": "sha256:index-v4.16-all-digest",
-      "related_images": [
-        {"image": "quay.io/test/comp1@sha256:mno345", "digest": "sha256:mno345"},
-        {"image": "quay.io/test/comp2@sha256:pqr678", "digest": "sha256:pqr678"}
-      ]
-    }]
-  }'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.17-empty"* ]]; then
-  json_response='{"data": []}'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.18-bundles"* ]]; then
-  json_response='{
-    "data": [{
-      "_id": "index-v4.18-bundles",
-      "image_id": "sha256:index-v4.18-bundles-digest",
-      "bundles": [
-        {"bundle_path": "r/bundle1", "related_images": [
-          {"image": "quay.io/test/bundle1@sha256:bun111", "digest": "sha256:bun111"}
-        ]},
-        {"bundle_path": "r/bundle2", "related_images": [
-          {"image": "quay.io/test/bundle2@sha256:bun222", "digest": "sha256:bun222"}
-        ]}
-      ]
-    }]
-  }'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.19-no-fragments"* ]]; then
-  json_response='{
-    "data": [{
-      "_id": "index-v4.19-no-fragments",
-      "image_id": "sha256:index-v4.19-no-fragments-digest",
-      "repositories": [
-        {"registry": "quay.io", "repository": "redhat-pending/catalog",
-         "tags": [{"name": "v4.19-no-fragments"}]}
-      ]
-    }]
-  }'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
-  echo "✅ Matched v4.14 catalog - returning comp1v414 as published" >&2
-  json_response='{
-    "data": [{
-      "_id": "index-v4.14-multi",
-      "image_id": "sha256:index-v4.14-multi-digest",
-      "related_images": [
-        {"image": "quay.io/test/comp1@sha256:comp1v414", "digest": "sha256:comp1v414"}
-      ]
-    }]
-  }'
-elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
-  echo "✅ Matched v4.16 catalog - returning comp3v416 as published" >&2
-  json_response='{
-    "data": [{
-      "_id": "index-v4.16-multi",
-      "image_id": "sha256:index-v4.16-multi-digest",
-      "related_images": [
-        {"image": "quay.io/test/comp3@sha256:comp3v416", "digest": "sha256:comp3v416"}
-      ]
-    }]
-  }'
-else
-  echo "⚠️  No pattern matched - returning empty data" >&2
-fi
-
-if [[ -n "$output_file" ]]; then
-  echo "$json_response" > "$output_file"
-else
-  echo "$json_response"
-fi
-
-if [[ "$write_out" == "%{http_code}" ]]; then
-  echo "$http_status"
-fi
-
-exit 0
-EOF
+echo "ERROR: curl called — filter-published-fbc-images must not call curl (uses kubectl now)." >&2
+echo "  Arguments: $*" >&2
+exit 1
+CURL_EOF
 chmod +x "$MOCK_BIN_DIR/curl"
 
-echo "✅ Created mock executable: $MOCK_BIN_DIR/curl" >&2
-echo "✅ PATH is now: $PATH" >&2
-which skopeo >&2 || echo "❌ which skopeo failed" >&2
-which curl >&2 || echo "❌ which curl failed" >&2
+# kubectl executable — mirrors the bash function above
+cat > "$MOCK_BIN_DIR/kubectl" << 'KUBECTL_EOF'
+#!/bin/bash
+echo "🎯 Mock kubectl called with: $*" >&2
+
+if [[ "$1" == "get" && "$2" == "release" ]]; then
+  if [[ "$3" != "-n" && "$3" != "-l" && "$3" != "-o" && -n "$3" ]]; then
+    release_name="$3"
+    echo "  → Resolving application label for: $release_name" >&2
+    case "$release_name" in
+      current-release-basic)          printf "test-app-basic" ;;
+      current-release-all)            printf "test-app-all" ;;
+      current-release-first)          printf "test-app-first" ;;
+      current-release-multi)          printf "test-app-multi" ;;
+      current-release-incomplete)     printf "test-app-incomplete" ;;
+      current-release-rbac)           printf "test-app-rbac" ;;
+      current-release-malformed)      printf "test-app-malformed" ;;
+      current-release-partial)        printf "test-app-partial" ;;
+      current-release-history)        printf "test-app-history" ;;
+      current-release-multi-partial)  printf "test-app-multi-partial" ;;
+      current-release-no-artifacts)   printf "test-app-no-artifacts" ;;
+      current-release-no-app-label)   printf "" ;;
+      *)                              printf "test-app-default" ;;
+    esac
+    exit 0
+  else
+    app=""
+    for arg in "$@"; do
+      if [[ "$arg" =~ appstudio\.openshift\.io/application=(.+) ]]; then
+        app="${BASH_REMATCH[1]}"
+        break
+      fi
+    done
+    echo "  → Listing releases for app: $app" >&2
+
+    case "$app" in
+      test-app-basic)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-release-basic"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp1@sha256:abc123", "target_index": "quay.io/redhat-pending/catalog:v4.15"}, {"fbc_fragment": "quay.io/test/comp3@sha256:ghi789", "target_index": "quay.io/redhat-pending/catalog:v4.15"}]}}}]}
+JSON
+        ;;
+      test-app-all)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-release-all"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp1@sha256:mno345", "target_index": "quay.io/redhat-pending/catalog:v4.16-all"}, {"fbc_fragment": "quay.io/test/comp2@sha256:pqr678", "target_index": "quay.io/redhat-pending/catalog:v4.16-all"}]}}}]}
+JSON
+        ;;
+      test-app-first)
+        echo '{"items": []}'
+        ;;
+      test-app-multi)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-v414"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp1@sha256:comp1v414", "target_index": "quay.io/redhat-pending/catalog:v4.14"}]}}}, {"metadata": {"name": "prev-v416"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp3@sha256:comp3v416", "target_index": "quay.io/redhat-pending/catalog:v4.16"}]}}}]}
+JSON
+        ;;
+      test-app-incomplete)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-incomplete"}, "status": {"conditions": [{"type": "Released", "status": "False", "reason": "Failed"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp1@sha256:abc123", "target_index": "quay.io/redhat-pending/catalog:v4.15"}]}}}]}
+JSON
+        ;;
+      test-app-rbac)
+        echo "Error from server (Forbidden): releases.appstudio.redhat.com is forbidden" >&2
+        exit 1
+        ;;
+      test-app-malformed)
+        echo '{"items": [{"broken": true, "status": {"conditions": [unclosed'
+        ;;
+      test-app-partial)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-partial"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp1@sha256:frag111", "target_index": "quay.io/redhat-pending/catalog:v4.15"}]}}}]}
+JSON
+        ;;
+      test-app-history)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-A"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp1@sha256:F1", "target_index": "quay.io/redhat-pending/catalog:v4.15"}]}}}, {"metadata": {"name": "prev-B"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp3@sha256:F3", "target_index": "quay.io/redhat-pending/catalog:v4.15"}]}}}]}
+JSON
+        ;;
+      test-app-multi-partial)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-v414-partial"}, "status": {"conditions": [{"type": "Released", "status": "True"}], "artifacts": {"components": [{"fbc_fragment": "quay.io/test/comp1@sha256:P1comp1v414", "target_index": "quay.io/redhat-pending/catalog:v4.14"}]}}}]}
+JSON
+        ;;
+      test-app-no-artifacts)
+        cat <<'JSON'
+{"items": [{"metadata": {"name": "prev-no-artifacts"}, "status": {"conditions": [{"type": "Released", "status": "True"}]}}]}
+JSON
+        ;;
+      *)
+        echo '{"items": []}'
+        ;;
+    esac
+    exit 0
+  fi
+fi
+
+command kubectl "$@"
+KUBECTL_EOF
+chmod +x "$MOCK_BIN_DIR/kubectl"
+
+echo "✅ Created mock executables in: $MOCK_BIN_DIR" >&2
+echo "✅ PATH: $PATH" >&2
 
 echo "==================================================================" >&2
-echo "✅ MOCKS.SH LOADED - Mock functions exported: kubectl, skopeo, curl" >&2
-echo "==================================================================" >&2
-echo "Testing function accessibility:" >&2
-type -t kubectl >&2 2>/dev/null || echo "❌ kubectl not accessible" >&2
-type -t skopeo >&2 2>/dev/null || echo "❌ skopeo not accessible" >&2
-type -t curl >&2 2>/dev/null || echo "❌ curl not accessible" >&2
-
-# Test if functions will actually be called
-echo "Testing which command will be executed:" >&2  
-command -v skopeo >&2
-command -V skopeo >&2 2>&1 || true
-
-# Test if function works in subshell (critical for command substitution)
-echo "Testing function in subshell:" >&2
-test_result=$(type -t skopeo 2>&1) && echo "  Subshell sees skopeo as: $test_result" >&2 || echo "  ❌ Subshell cannot see skopeo" >&2
-
+echo "✅ MOCKS.SH LOADED — kubectl, skopeo, curl stubs active" >&2
 echo "==================================================================" >&2

--- a/tasks/managed/filter-published-fbc-images/tests/mocks.sh
+++ b/tasks/managed/filter-published-fbc-images/tests/mocks.sh
@@ -102,21 +102,35 @@ curl() {
     fi
   done
 
-  # Verify Phase 1 optimization parameters are present
+  # Verify required query parameters are present for every /v1/images filter call
   if [[ "$*" == *"v1/images?filter="* ]]; then
-    # Verify date filter is present (last_update_date>=YYYY-MM-DD or URL-encoded %3E%3D)
-    if [[ ! "$*" =~ last_update_date(%3E%3D|>=)[0-9]{4}-[0-9]{2}-[0-9]{2} ]]; then
-      echo "ERROR: Date filter (last_update_date) not found in Pyxis query" >&2
+    # docker_image_id stores the config digest (SHA256), not an image reference;
+    # using it to filter by image location always returns empty results.
+    if [[ "$*" == *"docker_image_id"* ]]; then
+      echo "ERROR: Query must not use docker_image_id — use repositories.* location fields" >&2
       return 1
     fi
-    
-    # Verify page_size parameter is present
+
+    # All three repository location sub-fields must be present in the filter
+    if [[ "$*" != *"repositories.registry"* ]]; then
+      echo "ERROR: repositories.registry missing from Pyxis query filter" >&2
+      return 1
+    fi
+    if [[ "$*" != *"repositories.repository"* ]]; then
+      echo "ERROR: repositories.repository missing from Pyxis query filter" >&2
+      return 1
+    fi
+    if [[ "$*" != *"repositories.tags.name"* ]]; then
+      echo "ERROR: repositories.tags.name missing from Pyxis query filter" >&2
+      return 1
+    fi
+
     if [[ "$*" != *"page_size=500"* ]]; then
       echo "ERROR: page_size=500 parameter not found in Pyxis query" >&2
       return 1
     fi
-    
-    echo "✓ Verified: Date filter and page_size=500 present in query" >&2
+
+    echo "✓ Verified: repositories.registry/repository/tags.name + page_size=500 in query" >&2
   fi
 
   # Determine which JSON response to return based on query
@@ -135,15 +149,14 @@ curl() {
     http_status="200"
   
   # NORMAL SCENARIOS
-  
+
   # Index with published fragments sha256:abc123 and sha256:ghi789
-  # Match fully URL-encoded filter: docker_image_id==quay.io/redhat-pending/catalog:v4.14-published;last_update_date>=...
-  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.14-published%3Blast_update_date"* ]]; then
+  # Match URL-encoded tag filter: repositories.tags.name==v4.14-published
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14-published"* ]]; then
     json_response='{
       "data": [{
         "_id": "index-v4.14",
-        "docker_image_digest": "sha256:index-v4.14-digest",
-        "docker_image_id": "quay.io/redhat-pending/catalog:v4.14-published",
+        "image_id": "sha256:index-v4.14-digest",
         "related_images": [
           {
             "image": "quay.io/test/comp1@sha256:abc123",
@@ -159,15 +172,14 @@ curl() {
       }]
     }'
   # Index with NO published fragments (empty index or not yet published)
-  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.15-unpublished%3Blast_update_date"* ]]; then
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.15-unpublished"* ]]; then
     json_response='{"data": []}'
   # All fragments published - for all-published test
-  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.16-all-published%3Blast_update_date"* ]]; then
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16-all-published"* ]]; then
     json_response='{
       "data": [{
         "_id": "index-v4.16-all",
-        "docker_image_digest": "sha256:index-v4.16-all-digest",
-        "docker_image_id": "quay.io/redhat-pending/catalog:v4.16-all-published",
+        "image_id": "sha256:index-v4.16-all-digest",
         "related_images": [
           {
             "image": "quay.io/test/comp1@sha256:mno345",
@@ -183,15 +195,31 @@ curl() {
       }]
     }'
   # Empty response test - no index at all
-  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.17-empty%3Blast_update_date"* ]]; then
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.17-empty"* ]]; then
     json_response='{"data": []}'
+  # Index found but has no fragment data (realistic post-fix behavior: Pyxis finds the
+  # index image via the repositories filter but ContainerImage records do not carry
+  # related_images/bundles fields, so fragment extraction returns empty → safe fallback)
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.19-no-fragments"* ]]; then
+    json_response='{
+      "data": [{
+        "_id": "index-v4.19-no-fragments",
+        "image_id": "sha256:index-v4.19-no-fragments-digest",
+        "repositories": [
+          {
+            "registry": "quay.io",
+            "repository": "redhat-pending/catalog",
+            "tags": [{"name": "v4.19-no-fragments"}]
+          }
+        ]
+      }]
+    }'
   # Bundles field test - alternative structure with bundles instead of related_images
-  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.18-bundles%3Blast_update_date"* ]]; then
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.18-bundles"* ]]; then
     json_response='{
       "data": [{
         "_id": "index-v4.18-bundles",
-        "docker_image_digest": "sha256:index-v4.18-bundles-digest",
-        "docker_image_id": "quay.io/redhat-pending/catalog:v4.18-bundles",
+        "image_id": "sha256:index-v4.18-bundles-digest",
         "bundles": [
           {
             "bundle_path": "registry/bundle1",
@@ -219,13 +247,12 @@ curl() {
       }]
     }'
   # Multi-OCP test: v4.14 catalog with comp1v414 published (comp2v414 not published)
-  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.14%3Blast_update_date"* ]]; then
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
     echo "✅ Matched v4.14 catalog pattern - returning comp1v414 as published" >&2
     json_response='{
       "data": [{
         "_id": "index-v4.14-multi",
-        "docker_image_digest": "sha256:index-v4.14-multi-digest",
-        "docker_image_id": "quay.io/redhat-pending/catalog:v4.14",
+        "image_id": "sha256:index-v4.14-multi-digest",
         "related_images": [
           {
             "image": "quay.io/test/comp1@sha256:comp1v414",
@@ -236,13 +263,12 @@ curl() {
       }]
     }'
   # Multi-OCP test: v4.16 catalog with comp3v416 published (comp4v416 not published)
-  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.16%3Blast_update_date"* ]] && [[ "$*" != *"all-published"* ]]; then
+  elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
     echo "✅ Matched v4.16 catalog pattern - returning comp3v416 as published" >&2
     json_response='{
       "data": [{
         "_id": "index-v4.16-multi",
-        "docker_image_digest": "sha256:index-v4.16-multi-digest",
-        "docker_image_id": "quay.io/redhat-pending/catalog:v4.16",
+        "image_id": "sha256:index-v4.16-multi-digest",
         "related_images": [
           {
             "image": "quay.io/test/comp3@sha256:comp3v416",
@@ -338,7 +364,7 @@ chmod +x "$MOCK_BIN_DIR/skopeo"
 
 echo "✅ Created mock executable: $MOCK_BIN_DIR/skopeo" >&2
 
-# Create curl mock executable  
+# Create curl mock executable — mirrors every pattern in the curl() bash function above
 cat > "$MOCK_BIN_DIR/curl" << 'EOF'
 #!/bin/bash
 echo "🎯 Mock curl executable called" >&2
@@ -357,27 +383,102 @@ for ((i=1; i<=$#; i++)); do
   fi
 done
 
-# Determine response based on URL pattern
+# Validate filter fields (same rules as the bash function mock)
+if [[ "$*" == *"v1/images?filter="* ]]; then
+  if [[ "$*" == *"docker_image_id"* ]]; then
+    echo "ERROR: Query must not use docker_image_id" >&2
+    exit 1
+  fi
+  for field in "repositories.registry" "repositories.repository" "repositories.tags.name"; do
+    if [[ "$*" != *"${field}"* ]]; then
+      echo "ERROR: ${field} missing from Pyxis query filter" >&2
+      exit 1
+    fi
+  done
+  if [[ "$*" != *"page_size=500"* ]]; then
+    echo "ERROR: page_size=500 missing from Pyxis query" >&2
+    exit 1
+  fi
+fi
+
+# Determine response based on URL pattern (matches bash function mock patterns 1:1)
 json_response='{"data": []}'
 http_status="200"
 
-if [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.14%3Blast_update_date"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
+if [[ "$*" == *"catalog-500-error"* ]]; then
+  json_response='{"error": "Internal Server Error"}'
+  http_status="500"
+elif [[ "$*" == *"catalog-malformed"* ]]; then
+  json_response='{"data": [{"_id": "broken", "malformed_json'
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14-published"* ]]; then
+  json_response='{
+    "data": [{
+      "_id": "index-v4.14",
+      "image_id": "sha256:index-v4.14-digest",
+      "related_images": [
+        {"image": "quay.io/test/comp1@sha256:abc123", "digest": "sha256:abc123"},
+        {"image": "quay.io/test/comp3@sha256:ghi789", "digest": "sha256:ghi789"}
+      ]
+    }]
+  }'
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.15-unpublished"* ]]; then
+  json_response='{"data": []}'
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16-all-published"* ]]; then
+  json_response='{
+    "data": [{
+      "_id": "index-v4.16-all",
+      "image_id": "sha256:index-v4.16-all-digest",
+      "related_images": [
+        {"image": "quay.io/test/comp1@sha256:mno345", "digest": "sha256:mno345"},
+        {"image": "quay.io/test/comp2@sha256:pqr678", "digest": "sha256:pqr678"}
+      ]
+    }]
+  }'
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.17-empty"* ]]; then
+  json_response='{"data": []}'
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.18-bundles"* ]]; then
+  json_response='{
+    "data": [{
+      "_id": "index-v4.18-bundles",
+      "image_id": "sha256:index-v4.18-bundles-digest",
+      "bundles": [
+        {"bundle_path": "r/bundle1", "related_images": [
+          {"image": "quay.io/test/bundle1@sha256:bun111", "digest": "sha256:bun111"}
+        ]},
+        {"bundle_path": "r/bundle2", "related_images": [
+          {"image": "quay.io/test/bundle2@sha256:bun222", "digest": "sha256:bun222"}
+        ]}
+      ]
+    }]
+  }'
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.19-no-fragments"* ]]; then
+  json_response='{
+    "data": [{
+      "_id": "index-v4.19-no-fragments",
+      "image_id": "sha256:index-v4.19-no-fragments-digest",
+      "repositories": [
+        {"registry": "quay.io", "repository": "redhat-pending/catalog",
+         "tags": [{"name": "v4.19-no-fragments"}]}
+      ]
+    }]
+  }'
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.14"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
   echo "✅ Matched v4.14 catalog - returning comp1v414 as published" >&2
   json_response='{
     "data": [{
       "_id": "index-v4.14-multi",
-      "docker_image_id": "quay.io/redhat-pending/catalog:v4.14",
+      "image_id": "sha256:index-v4.14-multi-digest",
       "related_images": [
         {"image": "quay.io/test/comp1@sha256:comp1v414", "digest": "sha256:comp1v414"}
       ]
     }]
   }'
-elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.16%3Blast_update_date"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
+elif [[ "$*" == *"repositories.tags.name%3D%3Dv4.16"* ]] && [[ "$*" != *"-published"* ]] && [[ "$*" != *"-all-published"* ]]; then
   echo "✅ Matched v4.16 catalog - returning comp3v416 as published" >&2
   json_response='{
     "data": [{
       "_id": "index-v4.16-multi",
-      "docker_image_id": "quay.io/redhat-pending/catalog:v4.16",
+      "image_id": "sha256:index-v4.16-multi-digest",
       "related_images": [
         {"image": "quay.io/test/comp3@sha256:comp3v416", "digest": "sha256:comp3v416"}
       ]

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-all-published.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-all-published.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   description: |
     Negative test: Verify that filter-published-fbc-images correctly handles the case where
-    all components are already published in Pyxis, resulting in an empty filtered snapshot.
+    all components are already released (found in a prior successful Release CR),
+    resulting in an empty filtered snapshot.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -88,14 +89,10 @@ spec:
               }
               EOF
 
-              # Create data file with Pyxis configuration and targetIndex
+              # Create data file with FBC targetIndex
               # Mock will return index with both sha256:mno345 and sha256:pqr678
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
                   "targetIndex": "quay.io/redhat-pending/catalog:v4.16-all-published",
                   "publishingCredentials": "test-publishing-creds"
@@ -122,8 +119,8 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pyxisSecret
-          value: "pyxis"
+        - name: releaseName
+          value: "test-ns/current-release-all"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-basic.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-basic.yaml
@@ -5,8 +5,8 @@ metadata:
   name: test-filter-published-fbc-basic
 spec:
   description: |
-    Verify that filter-published-fbc-images correctly filters already-released images by querying Pyxis
-    and removing published components from the snapshot while keeping unreleased ones.
+    Verify that filter-published-fbc-images correctly filters already-released images by querying prior Release CRs
+    and removing components whose digest was already recorded from the snapshot while keeping unreleased ones.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -70,9 +70,9 @@ spec:
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
               # Create test snapshot with 3 fragments targeting same index:
-              # - comp1 (sha256:abc123): already published in Pyxis index → filter out
-              # - comp2 (sha256:def456): NOT in Pyxis index → keep
-              # - comp3 (sha256:ghi789): already published in Pyxis index → filter out
+              # - comp1 (sha256:abc123): already in a prior Release CR → filter out
+              # - comp2 (sha256:def456): NOT in any Release CR → keep
+              # - comp3 (sha256:ghi789): already in a prior Release CR → filter out
               # targetIndex template is in data.fbc.targetIndex (no {{ OCP_VERSION }} placeholder)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
@@ -94,14 +94,10 @@ spec:
               }
               EOF
 
-              # Create data file with Pyxis config and FBC targetIndex
+              # Create data file with FBC targetIndex
               # Mock returns: sha256:abc123 and sha256:ghi789 as published fragments
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
                   "targetIndex": "quay.io/redhat-pending/catalog:v4.14-published",
                   "publishingCredentials": "test-publishing-creds"
@@ -128,8 +124,8 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pyxisSecret
-          value: "pyxis"
+        - name: releaseName
+          value: "test-ns/current-release-basic"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-first-release.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-first-release.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: |
     Test: Verify that filter-published-fbc-images correctly handles the first release scenario
-    where no index images exist in Pyxis yet. All components should be kept.
+    where no prior successful Release CRs exist. All components should be kept.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -70,7 +70,7 @@ spec:
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
               # Create test snapshot with 2 new fragments (first release)
-              # No index published yet in Pyxis → keep all components
+              # No prior Release CR exists → keep all components
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
@@ -91,10 +91,6 @@ spec:
               # Mock will return empty data (no published index)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
                   "targetIndex": "quay.io/redhat-pending/catalog:v4.15-unpublished",
                   "publishingCredentials": "test-publishing-creds"
@@ -121,8 +117,8 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pyxisSecret
-          value: "pyxis"
+        - name: releaseName
+          value: "test-ns/current-release-first"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-index-no-fragments.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-index-no-fragments.yaml
@@ -1,0 +1,236 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-published-fbc-index-no-fragments
+spec:
+  description: |
+    Test: Verify safe fallback when Pyxis finds the index image but returns no fragment data.
+
+    This reflects the realistic post-fix behavior: the corrected repositories.* filter
+    successfully finds the index image in Pyxis (HTTP 200, data non-empty), but the
+    Pyxis ContainerImage schema does not include related_images or bundles fields, so
+    fragment extraction yields an empty list. The task must fall back to keeping all
+    components for release (safe behavior).
+
+    Assertions:
+    - All components are present in the filtered snapshot (no filtering happened)
+    - ocpVersion is attached to every component
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Two components that share the same targetIndex.
+              # The mock returns an index image record that has NO related_images or
+              # bundles fields (empty ContainerImage - realistic Pyxis schema).
+              # Expected: both components are kept (safe fallback), each gets ocpVersion.
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "application": "test-app",
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:frag001"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "quay.io/test/comp2@sha256:frag002"
+                  }
+                ]
+              }
+              EOF
+
+              # targetIndex mock returns an index record with no related_images/bundles
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "pyxis": {
+                  "secret": "pyxis",
+                  "server": "production"
+                },
+                "fbc": {
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.19-no-fragments",
+                  "publishingCredentials": "test-publishing-creds"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-published-fbc-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
+
+              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
+                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
+                exit 1
+              fi
+
+              echo "Filtered snapshot contents:"
+              jq . "${FILTERED_SNAPSHOT}"
+
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+              echo "Component count: ${COUNT}"
+
+              # Pyxis found the index image but returned no fragment data.
+              # The task must fall back to keeping ALL components (safe behavior).
+              if [ "${COUNT}" -ne 2 ]; then
+                echo "ERROR: Expected 2 components (safe fallback — index found but no fragments),"
+                echo "       got ${COUNT}"
+                exit 1
+              fi
+
+              # Verify both components are present
+              for comp in comp1 comp2; do
+                if ! jq -e --arg n "${comp}" '.components[] | select(.name == $n)' \
+                    "${FILTERED_SNAPSHOT}" > /dev/null; then
+                  echo "ERROR: ${comp} missing from filtered snapshot"
+                  exit 1
+                fi
+                echo "✓ ${comp} present in filtered snapshot (kept by safe fallback)"
+              done
+
+              # Verify ocpVersion is attached to each component
+              for comp in comp1 comp2; do
+                ocp=$(jq -r --arg n "${comp}" \
+                    '.components[] | select(.name == $n) | .ocpVersion // empty' \
+                    "${FILTERED_SNAPSHOT}")
+                if [ -z "${ocp}" ]; then
+                  echo "ERROR: ocpVersion not attached to ${comp}"
+                  exit 1
+                fi
+                echo "✓ ocpVersion attached to ${comp}: ${ocp}"
+              done
+
+              echo "✓ Test passed: index found in Pyxis but no fragment data → all components kept"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-invalid-ocp-version-format.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-invalid-ocp-version-format.yaml
@@ -90,10 +90,6 @@ spec:
               # Create data file with valid targetIndex
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
                   "targetIndex": "quay.io/redhat-pending/catalog:v4.14-test",
                   "publishingCredentials": "test-publishing-creds"
@@ -120,8 +116,8 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pyxisSecret
-          value: "pyxis"
+        - name: releaseName
+          value: "test-ns/test-current"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-invalid-target-index.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-invalid-target-index.yaml
@@ -85,10 +85,6 @@ spec:
               # Create data file WITHOUT targetIndex (invalid configuration)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
                   "publishingCredentials": "test-publishing-creds"
                 }
@@ -113,8 +109,8 @@ spec:
           value: $(context.pipelineRun.uid)/snapshot.json
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
-        - name: pyxisSecret
-          value: pyxis
+        - name: releaseName
+          value: "test-ns/test-current"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-kubectl-rbac-failure.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-kubectl-rbac-failure.yaml
@@ -2,33 +2,27 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-empty-input
+  name: test-filter-published-fbc-kubectl-rbac-failure
 spec:
   description: |
-    Negative test: Verify that filter-published-fbc-images correctly handles an empty input snapshot
-    (no components), resulting in an empty filtered snapshot without errors.
+    Verify safe fallback when kubectl list Release fails (simulates RBAC denial or API
+    unavailability). The task must keep all components and succeed without error.
+    - filteredSnapshotPath is written with all components intact
+    - ocpVersion is attached to every component
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -69,22 +63,26 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test snapshot with NO components
-              # Should result in empty filtered snapshot (passthrough)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
-                "components": []
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:abc123"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "quay.io/test/comp2@sha256:def456"
+                  }
+                ]
               }
               EOF
 
-              # Create data file with Pyxis configuration and targetIndex
-              # targetIndex required by task, but won't be queried (no components)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.17-empty",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -109,7 +107,7 @@ spec:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
         - name: releaseName
-          value: "test-ns/test-current"
+          value: "test-ns/current-release-rbac"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -170,19 +168,26 @@ spec:
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
 
               if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
+                echo "ERROR: Filtered snapshot not found"
                 exit 1
               fi
-
-              echo "Filtered snapshot contents:"
-              jq . "${FILTERED_SNAPSHOT}"
 
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
-              
-              # Expected: 0 components (input was empty)
-              if [ "${COUNT}" -ne 0 ]; then
-                echo "ERROR: Expected 0 components (empty input), got ${COUNT}"
+
+              # Safe fallback: kubectl failed → all 2 components must be kept
+              if [ "${COUNT}" -ne 2 ]; then
+                echo "ERROR: Expected 2 components (safe fallback), got ${COUNT}"
                 exit 1
               fi
-              
+
+              # ocpVersion must still be attached
+              for name in comp1 comp2; do
+                ocp=$(jq -r --arg n "$name" '.components[] | select(.name==$n) | .ocpVersion // empty' \
+                    "${FILTERED_SNAPSHOT}")
+                if [ -z "$ocp" ]; then
+                  echo "ERROR: ocpVersion missing on $name"
+                  exit 1
+                fi
+              done
+
+              echo "✓ Safe fallback: all 2 components kept with ocpVersion attached"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-malformed-data.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-malformed-data.yaml
@@ -5,30 +5,24 @@ metadata:
   name: test-filter-published-fbc-malformed-data
 spec:
   description: |
-    Verify that filter-published-fbc-images handles malformed Pyxis response data gracefully.
-    Task should detect invalid JSON and fail with clear error message.
+    Verify that filter-published-fbc-images handles malformed kubectl Release CR JSON
+    gracefully. When kubectl returns syntactically invalid JSON, the task must apply
+    the safe fallback: keep all components and succeed. A jq parse error must not
+    crash the task or leave the snapshot empty.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -62,36 +56,33 @@ spec:
               value: $(params.orasOptions)
         steps:
           - name: create-test-data
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              
-              # Create test snapshot
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
                 "components": [
                   {
-                    "name": "comp1-malformed-test",
-                    "containerImage": "quay.io/test/comp1@sha256:malformed123"
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:abc123"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "quay.io/test/comp2@sha256:def456"
                   }
                 ]
               }
               EOF
-              
-              # Create data file with targetIndex that will trigger malformed response
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
-                  "targetIndex": "quay.io/redhat/catalog-malformed:v1.0",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -105,23 +96,24 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-
-    - name: run-task
+    - name: run-filter
       runAfter:
         - setup
+      taskRef:
+        name: filter-published-fbc-images
       params:
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/snapshot.json
+          value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
-          value: $(context.pipelineRun.uid)/data.json
-        - name: pyxisSecret
-          value: pyxis
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: releaseName
+          value: "test-ns/current-release-malformed"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
           value: $(params.orasOptions)
         - name: sourceDataArtifact
-          value: $(tasks.setup.results.sourceDataArtifact)
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -130,22 +122,69 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      taskRef:
-        name: filter-published-fbc-images
-      onError: continue  # Expected to fail due to malformed JSON
-
-    - name: verify-failure
+    - name: verify-results
       runAfter:
-        - run-task
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
       taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
         steps:
-          - name: check-expected-failure
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
             script: |
               #!/usr/bin/env bash
               set -eux
-              
-              # Since run-task has onError: continue, reaching this point means it completed
-              # We verify it failed as expected (malformed JSON from Pyxis)
-              echo "✅ Test PASSED: Task correctly failed with malformed Pyxis data"
-              echo "The run-task completed with onError: continue, which means it failed as expected"
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
+
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              # Malformed kubectl JSON → safe fallback → all 2 components kept
+              if [ "${COUNT}" -ne 2 ]; then
+                echo "ERROR: Expected 2 components (malformed JSON safe fallback), got ${COUNT}"
+                exit 1
+              fi
+
+              # ocpVersion must still be attached
+              for name in comp1 comp2; do
+                ocp=$(jq -r --arg n "$name" \
+                    '.components[] | select(.name==$n) | .ocpVersion // empty' \
+                    "${FILTERED_SNAPSHOT}")
+                if [ -z "$ocp" ]; then
+                  echo "ERROR: ocpVersion missing on $name"
+                  exit 1
+                fi
+              done
+
+              echo "✓ Task survived malformed kubectl JSON: safe fallback applied"
+              echo "✓ All 2 components kept with ocpVersion attached"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-ocp-partial.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-ocp-partial.yaml
@@ -2,33 +2,34 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-bundles-field
+  name: test-filter-published-fbc-multi-ocp-partial
 spec:
   description: |
-    Test: Verify that filter-published-fbc-images correctly parses the bundles field structure
-    (alternative to related_images) to find published fragment digests.
+    Verify per-index partial filtering when a snapshot spans multiple OCP versions.
+
+    Four components across two OCP versions, with partial prior-release history:
+      - comp1 (sha256:P1, v4.14): in prior Release CR for v4.14 index → filter out
+      - comp2 (sha256:N2, v4.14): NOT in any Release CR → keep
+      - comp3 (sha256:N3, v4.16): NOT in any Release CR → keep
+      - comp4 (sha256:N4, v4.16): NOT in any Release CR → keep
+
+    Expected filtered snapshot: comp2, comp3, comp4.
+
+    This combines two already-tested axes (multi-OCP grouping + partial filtering)
+    that have not been exercised together in a single test.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -69,42 +70,39 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test snapshot with 3 fragments:
-              # - bundle1 (sha256:bun111): in published index bundles field → filter out
-              # - bundle2 (sha256:bun222): in published index bundles field → filter out
-              # - bundle3 (sha256:bun333): NOT in published index → keep
-              # targetIndex template is in data.fbc.targetIndex (no {{ OCP_VERSION }} placeholder)
+              # Digests containing "v414" route skopeo mock to OCP v4.14.
+              # Digests containing "v416" route skopeo mock to OCP v4.16.
+              # The published digest for comp1 (sha256:P1comp1v414) matches exactly what
+              # the kubectl mock returns in test-app-multi-partial.
+              # targetIndex uses {{ OCP_VERSION }} so each version gets its own index.
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
                 "components": [
                   {
-                    "name": "bundle1-published",
-                    "containerImage": "quay.io/test/bundle1@sha256:bun111"
+                    "name": "comp1-published-v414",
+                    "containerImage": "quay.io/test/comp1@sha256:P1comp1v414"
                   },
                   {
-                    "name": "bundle2-published",
-                    "containerImage": "quay.io/test/bundle2@sha256:bun222"
+                    "name": "comp2-new-v414",
+                    "containerImage": "quay.io/test/comp2@sha256:N2comp2v414"
                   },
                   {
-                    "name": "bundle3-new",
-                    "containerImage": "quay.io/test/bundle3@sha256:bun333"
+                    "name": "comp3-new-v416",
+                    "containerImage": "quay.io/test/comp3@sha256:N3comp3v416"
+                  },
+                  {
+                    "name": "comp4-new-v416",
+                    "containerImage": "quay.io/test/comp4@sha256:N4comp4v416"
                   }
                 ]
               }
               EOF
 
-              # Create data file with targetIndex that returns bundles structure
-              # Mock returns: sha256:bun111 and sha256:bun222 in bundles[].related_images[]
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.18-bundles",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:{{ OCP_VERSION }}"
                 }
               }
               EOF
@@ -128,8 +126,8 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pyxisSecret
-          value: "pyxis"
+        - name: releaseName
+          value: "test-ns/current-release-multi-partial"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -189,41 +187,40 @@ spec:
 
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
 
-              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
-                exit 1
-              fi
-
-              echo "Filtered snapshot contents:"
+              echo "Filtered snapshot:"
               jq . "${FILTERED_SNAPSHOT}"
 
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
 
-              # Expected: 1 component (bundle3-new only)
-              # bundle1 and bundle2 are in bundles field and should be filtered out
-              if [ "${COUNT}" -ne 1 ]; then
-                echo "ERROR: Expected 1 component, got ${COUNT}"
+              # comp1 (v4.14, sha256:P1) in prior release → filtered
+              # comp2 (v4.14, sha256:N2) not in any release → kept
+              # comp3 (v4.16, sha256:N3) not in any release → kept
+              # comp4 (v4.16, sha256:N4) not in any release → kept
+              if [ "${COUNT}" -ne 3 ]; then
+                echo "ERROR: Expected 3 components (comp1 filtered, comp2/3/4 kept), got ${COUNT}"
                 exit 1
               fi
 
-              # Verify bundle1 is NOT in filtered snapshot (in bundles field)
-              if jq -e '.components[] | select(.name == "bundle1-published")' \
+              if jq -e '.components[] | select(.name == "comp1-published-v414")' \
                   "${FILTERED_SNAPSHOT}" > /dev/null; then
-                echo "ERROR: bundle1-published should have been filtered out"
+                echo "ERROR: comp1 (sha256:P1, v4.14) should have been filtered out"
                 exit 1
               fi
 
-              # Verify bundle2 is NOT in filtered snapshot (in bundles field)
-              if jq -e '.components[] | select(.name == "bundle2-published")' \
-                  "${FILTERED_SNAPSHOT}" > /dev/null; then
-                echo "ERROR: bundle2-published should have been filtered out"
-                exit 1
-              fi
+              for name in comp2-new-v414 comp3-new-v416 comp4-new-v416; do
+                if ! jq -e --arg n "$name" '.components[] | select(.name == $n)' \
+                    "${FILTERED_SNAPSHOT}" > /dev/null; then
+                  echo "ERROR: $name should be in filtered snapshot (not in any release)"
+                  exit 1
+                fi
+                ocp=$(jq -r --arg n "$name" \
+                    '.components[] | select(.name==$n) | .ocpVersion // empty' \
+                    "${FILTERED_SNAPSHOT}")
+                if [ -z "$ocp" ]; then
+                  echo "ERROR: ocpVersion missing on $name"
+                  exit 1
+                fi
+                echo "✓ $name: ocpVersion=$ocp"
+              done
 
-              # Verify bundle3 IS in filtered snapshot (not in bundles field)
-              if ! jq -e '.components[] | select(.name == "bundle3-new")' \
-                  "${FILTERED_SNAPSHOT}" > /dev/null; then
-                echo "ERROR: bundle3-new should be in filtered snapshot"
-                exit 1
-              fi
+              echo "✓ Multi-OCP + partial filter: comp1 removed (v4.14 release), comp2/3/4 kept"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-ocp-versions.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-ocp-versions.yaml
@@ -7,7 +7,7 @@ spec:
   description: |
     Test: Verify that filter-published-fbc-images correctly handles multiple components
     with different OCP versions, grouping them by resolved targetIndex and querying
-    Pyxis separately for each catalog version.
+    Release CRs separately for each catalog version.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -107,10 +107,6 @@ spec:
               # This will resolve to different catalogs based on component's base image
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
                   "targetIndex": "quay.io/redhat-pending/catalog:{{ OCP_VERSION }}",
                   "publishingCredentials": "test-publishing-creds"
@@ -137,8 +133,8 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pyxisSecret
-          value: "pyxis"
+        - name: releaseName
+          value: "test-ns/current-release-multi"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-release-history.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-release-history.yaml
@@ -2,33 +2,34 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-empty-input
+  name: test-filter-published-fbc-multi-release-history
 spec:
   description: |
-    Negative test: Verify that filter-published-fbc-images correctly handles an empty input snapshot
-    (no components), resulting in an empty filtered snapshot without errors.
+    Verify that published fragments are accumulated across MULTIPLE prior Release CRs
+    targeting the same index (union semantics).
+
+    Two prior successful Release CRs exist for the same target index:
+      - Release A recorded sha256:F1 (comp1)
+      - Release B recorded sha256:F3 (comp3)
+
+    The new snapshot has four components: comp1 (F1), comp2 (F2), comp3 (F3), comp4 (F4).
+    Expected: F1 and F3 are filtered (from different prior Releases); F2 and F4 are kept.
+
+    This tests the .items[] iteration in the jq query — if only the last Release's
+    fragments were used, comp1 would incorrectly survive the filter.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -69,22 +70,34 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test snapshot with NO components
-              # Should result in empty filtered snapshot (passthrough)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
-                "components": []
+                "components": [
+                  {
+                    "name": "comp1-from-release-A",
+                    "containerImage": "quay.io/test/comp1@sha256:F1"
+                  },
+                  {
+                    "name": "comp2-new",
+                    "containerImage": "quay.io/test/comp2@sha256:F2"
+                  },
+                  {
+                    "name": "comp3-from-release-B",
+                    "containerImage": "quay.io/test/comp3@sha256:F3"
+                  },
+                  {
+                    "name": "comp4-new",
+                    "containerImage": "quay.io/test/comp4@sha256:F4"
+                  }
+                ]
               }
               EOF
 
-              # Create data file with Pyxis configuration and targetIndex
-              # targetIndex required by task, but won't be queried (no components)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.17-empty",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -109,7 +122,7 @@ spec:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
         - name: releaseName
-          value: "test-ns/test-current"
+          value: "test-ns/current-release-history"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -169,20 +182,41 @@ spec:
 
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
 
-              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
-                exit 1
-              fi
-
-              echo "Filtered snapshot contents:"
+              echo "Filtered snapshot:"
               jq . "${FILTERED_SNAPSHOT}"
 
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
-              
-              # Expected: 0 components (input was empty)
-              if [ "${COUNT}" -ne 0 ]; then
-                echo "ERROR: Expected 0 components (empty input), got ${COUNT}"
+
+              # Expect exactly 2: comp2 and comp4 (comp1 from Release A, comp3 from Release B filtered)
+              if [ "${COUNT}" -ne 2 ]; then
+                echo "ERROR: Expected 2 components (union of Release A+B fragments), got ${COUNT}"
+                echo "  If count=3: Release A's sha256:F1 was not accumulated (only Release B used)"
                 exit 1
               fi
-              
+
+              # comp1 (sha256:F1) must be filtered — in Release A
+              if jq -e '.components[] | select(.name == "comp1-from-release-A")' \
+                  "${FILTERED_SNAPSHOT}" > /dev/null; then
+                echo "ERROR: comp1-from-release-A should have been filtered (sha256:F1 in Release A)"
+                exit 1
+              fi
+
+              # comp3 (sha256:F3) must be filtered — in Release B
+              if jq -e '.components[] | select(.name == "comp3-from-release-B")' \
+                  "${FILTERED_SNAPSHOT}" > /dev/null; then
+                echo "ERROR: comp3-from-release-B should have been filtered (sha256:F3 in Release B)"
+                exit 1
+              fi
+
+              # comp2 and comp4 must be kept
+              for name in comp2-new comp4-new; do
+                if ! jq -e --arg n "$name" '.components[] | select(.name == $n)' \
+                    "${FILTERED_SNAPSHOT}" > /dev/null; then
+                  echo "ERROR: $name should be present (not in any prior Release CR)"
+                  exit 1
+                fi
+              done
+
+              echo "✓ sha256:F1 (Release A) + sha256:F3 (Release B) both filtered via union"
+              echo "✓ comp2 and comp4 kept as expected"
+              echo "✓ Multi-release history accumulation: PASSED"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-no-app-label.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-no-app-label.yaml
@@ -2,33 +2,25 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-empty-input
+  name: test-filter-published-fbc-no-app-label
 spec:
   description: |
-    Negative test: Verify that filter-published-fbc-images correctly handles an empty input snapshot
-    (no components), resulting in an empty filtered snapshot without errors.
+    Verify safe fallback when the current Release CR exists but has no
+    appstudio.openshift.io/application label (kubectl get <name> returns empty string).
+    The task cannot determine the application name and must keep all components.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -69,22 +61,26 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test snapshot with NO components
-              # Should result in empty filtered snapshot (passthrough)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
-                "components": []
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:abc123"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "quay.io/test/comp2@sha256:def456"
+                  }
+                ]
               }
               EOF
 
-              # Create data file with Pyxis configuration and targetIndex
-              # targetIndex required by task, but won't be queried (no components)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.17-empty",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -109,7 +105,7 @@ spec:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
         - name: releaseName
-          value: "test-ns/test-current"
+          value: "test-ns/current-release-no-app-label"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -168,21 +164,22 @@ spec:
               set -eux
 
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
-
-              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
-                exit 1
-              fi
-
-              echo "Filtered snapshot contents:"
-              jq . "${FILTERED_SNAPSHOT}"
-
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
-              
-              # Expected: 0 components (input was empty)
-              if [ "${COUNT}" -ne 0 ]; then
-                echo "ERROR: Expected 0 components (empty input), got ${COUNT}"
+
+              # Application label missing → cannot look up releases → safe fallback
+              if [ "${COUNT}" -ne 2 ]; then
+                echo "ERROR: Expected 2 components (app label missing → safe fallback), got ${COUNT}"
                 exit 1
               fi
-              
+
+              for name in comp1 comp2; do
+                ocp=$(jq -r --arg n "$name" \
+                    '.components[] | select(.name==$n) | .ocpVersion // empty' \
+                    "${FILTERED_SNAPSHOT}")
+                if [ -z "$ocp" ]; then
+                  echo "ERROR: ocpVersion not attached to $name"
+                  exit 1
+                fi
+              done
+
+              echo "✓ Application label missing → safe fallback: all 2 components kept"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-no-prior-releases.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-no-prior-releases.yaml
@@ -2,33 +2,25 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-empty-input
+  name: test-filter-published-fbc-no-prior-releases
 spec:
   description: |
-    Negative test: Verify that filter-published-fbc-images correctly handles an empty input snapshot
-    (no components), resulting in an empty filtered snapshot without errors.
+    Verify that when Release CR list is empty (no prior releases for this application),
+    all snapshot components are kept and ocpVersion is attached to each.
+    This is the explicit first-release path exercised through the Release CR lookup.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -69,22 +61,26 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test snapshot with NO components
-              # Should result in empty filtered snapshot (passthrough)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
-                "components": []
+                "components": [
+                  {
+                    "name": "comp1-new",
+                    "containerImage": "quay.io/test/comp1@sha256:new111"
+                  },
+                  {
+                    "name": "comp2-new",
+                    "containerImage": "quay.io/test/comp2@sha256:new222"
+                  }
+                ]
               }
               EOF
 
-              # Create data file with Pyxis configuration and targetIndex
-              # targetIndex required by task, but won't be queried (no components)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.17-empty",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -109,7 +105,7 @@ spec:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
         - name: releaseName
-          value: "test-ns/test-current"
+          value: "test-ns/current-release-first"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -168,21 +164,22 @@ spec:
               set -eux
 
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
-
-              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
-                exit 1
-              fi
-
-              echo "Filtered snapshot contents:"
-              jq . "${FILTERED_SNAPSHOT}"
-
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
-              
-              # Expected: 0 components (input was empty)
-              if [ "${COUNT}" -ne 0 ]; then
-                echo "ERROR: Expected 0 components (empty input), got ${COUNT}"
+
+              if [ "${COUNT}" -ne 2 ]; then
+                echo "ERROR: Expected 2 components (no prior releases → keep all), got ${COUNT}"
                 exit 1
               fi
-              
+
+              for name in comp1-new comp2-new; do
+                ocp=$(jq -r --arg n "$name" \
+                    '.components[] | select(.name==$n) | .ocpVersion // empty' \
+                    "${FILTERED_SNAPSHOT}")
+                if [ -z "$ocp" ]; then
+                  echo "ERROR: ocpVersion missing on $name"
+                  exit 1
+                fi
+                echo "✓ $name: ocpVersion=$ocp"
+              done
+
+              echo "✓ All 2 components kept with ocpVersion: no prior releases found"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-no-release-name.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-no-release-name.yaml
@@ -2,33 +2,26 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-empty-input
+  name: test-filter-published-fbc-no-release-name
 spec:
   description: |
-    Negative test: Verify that filter-published-fbc-images correctly handles an empty input snapshot
-    (no components), resulting in an empty filtered snapshot without errors.
+    Verify safe fallback when releaseName parameter is empty.
+    The task must skip idempotence filtering and keep all components with ocpVersion attached.
+    This covers the case where the pipeline is triggered without a releaseName (e.g. manual
+    invocation or older pipeline versions that do not pass the parameter).
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -69,22 +62,26 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test snapshot with NO components
-              # Should result in empty filtered snapshot (passthrough)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
-                "components": []
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:abc123"
+                  },
+                  {
+                    "name": "comp2",
+                    "containerImage": "quay.io/test/comp2@sha256:def456"
+                  }
+                ]
               }
               EOF
 
-              # Create data file with Pyxis configuration and targetIndex
-              # targetIndex required by task, but won't be queried (no components)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.17-empty",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -109,7 +106,7 @@ spec:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
         - name: releaseName
-          value: "test-ns/test-current"
+          value: ""
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -169,20 +166,23 @@ spec:
 
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
 
-              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
-                exit 1
-              fi
-
-              echo "Filtered snapshot contents:"
-              jq . "${FILTERED_SNAPSHOT}"
-
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
-              
-              # Expected: 0 components (input was empty)
-              if [ "${COUNT}" -ne 0 ]; then
-                echo "ERROR: Expected 0 components (empty input), got ${COUNT}"
+
+              # releaseName="" → no lookup possible → all 2 components kept
+              if [ "${COUNT}" -ne 2 ]; then
+                echo "ERROR: Expected 2 components (releaseName empty → skip filtering), got ${COUNT}"
                 exit 1
               fi
-              
+
+              # ocpVersion must be attached even on the safe-fallback path
+              for name in comp1 comp2; do
+                ocp=$(jq -r --arg n "$name" \
+                    '.components[] | select(.name==$n) | .ocpVersion // empty' \
+                    "${FILTERED_SNAPSHOT}")
+                if [ -z "$ocp" ]; then
+                  echo "ERROR: ocpVersion not attached to $name"
+                  exit 1
+                fi
+              done
+
+              echo "✓ releaseName empty → safe fallback: all 2 components kept with ocpVersion"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-partial-published.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-partial-published.yaml
@@ -2,42 +2,36 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-index-no-fragments
+  name: test-filter-published-fbc-partial-published
 spec:
   description: |
-    Test: Verify safe fallback when Pyxis finds the index image but returns no fragment data.
+    TC-03: Partial-published scenario — some fragments already released, some new.
 
-    This reflects the realistic post-fix behavior: the corrected repositories.* filter
-    successfully finds the index image in Pyxis (HTTP 200, data non-empty), but the
-    Pyxis ContainerImage schema does not include related_images or bundles fields, so
-    fragment extraction yields an empty list. The task must fall back to keeping all
-    components for release (safe behavior).
+    Snapshot has two FBC fragments targeting the same index image (v4.15):
+      - comp1 (sha256:frag111): already published in a prior successful Release CR
+      - comp2 (sha256:frag222): new — not recorded in any prior Release CR
 
-    Assertions:
-    - All components are present in the filtered snapshot (no filtering happened)
-    - ocpVersion is attached to every component
+    Expected result:
+      - comp1 is filtered out (digest matches a released artifact)
+      - comp2 is kept (no prior Release records its digest)
+      - ocpVersion is attached to the kept component
+
+    This is the most production-representative idempotency scenario: a re-release of
+    a snapshot where only a subset of fragments are new. Previously blocked by the
+    Pyxis data gap; now testable because the Release CR stores exact fragment digests.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -78,36 +72,29 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Two components that share the same targetIndex.
-              # The mock returns an index image record that has NO related_images or
-              # bundles fields (empty ContainerImage - realistic Pyxis schema).
-              # Expected: both components are kept (safe fallback), each gets ocpVersion.
+              # Two components targeting the same index:
+              # comp1 (sha256:frag111) is recorded in a prior successful Release CR
+              # comp2 (sha256:frag222) is NOT recorded in any prior Release CR
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
                 "components": [
                   {
-                    "name": "comp1",
-                    "containerImage": "quay.io/test/comp1@sha256:frag001"
+                    "name": "comp1-published",
+                    "containerImage": "quay.io/test/comp1@sha256:frag111"
                   },
                   {
-                    "name": "comp2",
-                    "containerImage": "quay.io/test/comp2@sha256:frag002"
+                    "name": "comp2-new",
+                    "containerImage": "quay.io/test/comp2@sha256:frag222"
                   }
                 ]
               }
               EOF
 
-              # targetIndex mock returns an index record with no related_images/bundles
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.19-no-fragments",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -131,8 +118,8 @@ spec:
           value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
-        - name: pyxisSecret
-          value: "pyxis"
+        - name: releaseName
+          value: "test-ns/current-release-partial"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -192,45 +179,40 @@ spec:
 
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
 
-              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
-                exit 1
-              fi
-
-              echo "Filtered snapshot contents:"
+              echo "Filtered snapshot:"
               jq . "${FILTERED_SNAPSHOT}"
 
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
 
-              # Pyxis found the index image but returned no fragment data.
-              # The task must fall back to keeping ALL components (safe behavior).
-              if [ "${COUNT}" -ne 2 ]; then
-                echo "ERROR: Expected 2 components (safe fallback — index found but no fragments),"
-                echo "       got ${COUNT}"
+              # Expected: 1 component — only comp2-new survives
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected 1 component (partial filter), got ${COUNT}"
                 exit 1
               fi
 
-              # Verify both components are present
-              for comp in comp1 comp2; do
-                if ! jq -e --arg n "${comp}" '.components[] | select(.name == $n)' \
-                    "${FILTERED_SNAPSHOT}" > /dev/null; then
-                  echo "ERROR: ${comp} missing from filtered snapshot"
-                  exit 1
-                fi
-                echo "✓ ${comp} present in filtered snapshot (kept by safe fallback)"
-              done
+              # comp1 (sha256:frag111) must be filtered out — found in prior Release CR
+              if jq -e '.components[] | select(.name == "comp1-published")' \
+                  "${FILTERED_SNAPSHOT}" > /dev/null; then
+                echo "ERROR: comp1-published was in prior Release CR — should have been filtered"
+                exit 1
+              fi
 
-              # Verify ocpVersion is attached to each component
-              for comp in comp1 comp2; do
-                ocp=$(jq -r --arg n "${comp}" \
-                    '.components[] | select(.name == $n) | .ocpVersion // empty' \
-                    "${FILTERED_SNAPSHOT}")
-                if [ -z "${ocp}" ]; then
-                  echo "ERROR: ocpVersion not attached to ${comp}"
-                  exit 1
-                fi
-                echo "✓ ocpVersion attached to ${comp}: ${ocp}"
-              done
+              # comp2 (sha256:frag222) must be kept — not in any Release CR
+              if ! jq -e '.components[] | select(.name == "comp2-new")' \
+                  "${FILTERED_SNAPSHOT}" > /dev/null; then
+                echo "ERROR: comp2-new should be in filtered snapshot (not yet released)"
+                exit 1
+              fi
 
-              echo "✓ Test passed: index found in Pyxis but no fragment data → all components kept"
+              # ocpVersion must be attached to the kept component
+              ocp=$(jq -r '.components[] | select(.name == "comp2-new") | .ocpVersion // empty' \
+                  "${FILTERED_SNAPSHOT}")
+              if [ -z "$ocp" ]; then
+                echo "ERROR: ocpVersion not attached to comp2-new"
+                exit 1
+              fi
+
+              echo "✓ comp1-published filtered out (digest in prior Release CR)"
+              echo "✓ comp2-new kept (no prior Release records sha256:frag222)"
+              echo "✓ ocpVersion=$ocp attached to comp2-new"
+              echo "✓ TC-03 partial-published: PASSED"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-release-no-artifacts.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-release-no-artifacts.yaml
@@ -2,33 +2,28 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-empty-input
+  name: test-filter-published-fbc-release-no-artifacts
 spec:
   description: |
-    Negative test: Verify that filter-published-fbc-images correctly handles an empty input snapshot
-    (no components), resulting in an empty filtered snapshot without errors.
+    Verify that a prior Release CR with Released=True but no status.artifacts field
+    is handled safely. The jq expression (.status.artifacts.components // []) must
+    yield zero digests; all snapshot components must be kept.
+
+    This differs from release-not-completed (Released=False) — here the release
+    succeeded but wrote no artifact data (e.g. an older Release controller version).
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -69,22 +64,22 @@ spec:
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create test snapshot with NO components
-              # Should result in empty filtered snapshot (passthrough)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
-                "components": []
+                "components": [
+                  {
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:abc123"
+                  }
+                ]
               }
               EOF
 
-              # Create data file with Pyxis configuration and targetIndex
-              # targetIndex required by task, but won't be queried (no components)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "fbc": {
-                  "targetIndex": "quay.io/redhat-pending/catalog:v4.17-empty",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -109,7 +104,7 @@ spec:
         - name: dataPath
           value: "$(context.pipelineRun.uid)/data.json"
         - name: releaseName
-          value: "test-ns/test-current"
+          value: "test-ns/current-release-no-artifacts"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -168,21 +163,18 @@ spec:
               set -eux
 
               FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
-
-              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
-                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
-                exit 1
-              fi
-
-              echo "Filtered snapshot contents:"
-              jq . "${FILTERED_SNAPSHOT}"
-
               COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
-              echo "Component count: ${COUNT}"
-              
-              # Expected: 0 components (input was empty)
-              if [ "${COUNT}" -ne 0 ]; then
-                echo "ERROR: Expected 0 components (empty input), got ${COUNT}"
+
+              # Released=True but no artifacts → zero published digests → comp1 kept
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected 1 component (no artifacts in Release → kept), got ${COUNT}"
                 exit 1
               fi
-              
+
+              if ! jq -e '.components[] | select(.name == "comp1")' "${FILTERED_SNAPSHOT}" > /dev/null; then
+                echo "ERROR: comp1 should be present (prior Release had no artifact data)"
+                exit 1
+              fi
+
+              echo "✓ comp1 kept: prior Release had Released=True but no status.artifacts"
+              echo "✓ (.status.artifacts.components // []) null-safety works correctly"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-release-not-completed.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-release-not-completed.yaml
@@ -2,33 +2,28 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-filter-published-fbc-pyxis-500-error
+  name: test-filter-published-fbc-release-not-completed
 spec:
   description: |
-    Verify that filter-published-fbc-images handles Pyxis 500 errors gracefully with retries
-    and keeps all components (fail-safe behavior) after exhausting retry attempts.
+    Verify that a previous Release whose Released condition is False (failed/in-progress)
+    is NOT counted as published. All snapshot components must be kept.
+
+    This is the partial-delivery safety test: if a prior pipeline run failed mid-way
+    (e.g. advisory creation failed after IIB succeeded), the fragment must not be
+    treated as published — the re-release must run the full pipeline again.
   params:
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
     - name: ociArtifactExpiresAfter
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository.
-        An empty string means the artifacts do not expire.
       type: string
       default: "1d"
     - name: orasOptions
-      description: oras options to pass to Trusted Artifacts calls
       type: string
       default: "--insecure"
     - name: trustedArtifactsDebug
-      description: >-
-        Flag to enable debug logging in trusted artifacts.
-        Set to a non-empty string to enable.
       type: string
       default: ""
     - name: dataDir
-      description: The location where data will be stored
       type: string
   tasks:
     - name: setup
@@ -62,36 +57,31 @@ spec:
               value: $(params.orasOptions)
         steps:
           - name: create-test-data
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
             script: |
               #!/usr/bin/env bash
               set -eux
-              
+
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              
-              # Create test snapshot with components to be released
+
+              # comp1 digest (sha256:abc123) appears in a prior FAILED release.
+              # It must NOT be filtered — released=False means partial delivery.
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
               {
                 "application": "test-app",
                 "components": [
                   {
-                    "name": "comp1-test",
-                    "containerImage": "quay.io/test/comp1@sha256:test111"
+                    "name": "comp1",
+                    "containerImage": "quay.io/test/comp1@sha256:abc123"
                   }
                 ]
               }
               EOF
-              
-              # Create data file with Pyxis configuration and targetIndex that triggers 500 error
+
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
-                  "targetIndex": "quay.io/redhat/catalog-500-error:v1.0",
-                  "publishingCredentials": "test-publishing-creds"
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15"
                 }
               }
               EOF
@@ -105,23 +95,24 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(results.sourceDataArtifact.path)
-
-    - name: run-task
+    - name: run-filter
       runAfter:
         - setup
+      taskRef:
+        name: filter-published-fbc-images
       params:
         - name: snapshotPath
-          value: $(context.pipelineRun.uid)/snapshot.json
+          value: "$(context.pipelineRun.uid)/snapshot.json"
         - name: dataPath
-          value: $(context.pipelineRun.uid)/data.json
-        - name: pyxisSecret
-          value: pyxis
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: releaseName
+          value: "test-ns/current-release-incomplete"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
           value: $(params.orasOptions)
         - name: sourceDataArtifact
-          value: $(tasks.setup.results.sourceDataArtifact)
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -130,26 +121,23 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-      taskRef:
-        name: filter-published-fbc-images
-
-    - name: verify-components-kept
+    - name: verify-results
       runAfter:
-        - run-task
+        - run-filter
       params:
         - name: sourceDataArtifact
-          value: $(tasks.run-task.results.sourceDataArtifact)
-        - name: dataDir
-          value: $(params.dataDir)
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
         - name: orasOptions
           value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
       taskSpec:
         params:
           - name: sourceDataArtifact
             type: string
-          - name: dataDir
-            type: string
           - name: orasOptions
+            type: string
+          - name: dataDir
             type: string
         volumes:
           - name: workdir
@@ -170,45 +158,25 @@ spec:
                 value: $(params.dataDir)
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
-          - name: verify-all-components-kept
-            image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              # Task should succeed and keep all components when Pyxis fails
-              FILTERED_SNAPSHOT=$(cat "$(params.dataDir)/filtered-snapshot.json")
-              COMPONENT_COUNT=$(jq '.components | length' <<< "${FILTERED_SNAPSHOT}")
+              FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
 
-              if [ "${COMPONENT_COUNT}" != "1" ]; then
-                echo "ERROR: Expected 1 component (Pyxis error should keep all components), got ${COMPONENT_COUNT}"
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+
+              # comp1 is in a FAILED release — must NOT be filtered out
+              if [ "${COUNT}" -ne 1 ]; then
+                echo "ERROR: Expected 1 component (failed release not counted), got ${COUNT}"
                 exit 1
               fi
 
-              COMPONENT_NAME=$(jq -r '.components[0].name' <<< "${FILTERED_SNAPSHOT}")
-              if [ "${COMPONENT_NAME}" != "comp1-test" ]; then
-                echo "ERROR: Expected component 'comp1-test', got '${COMPONENT_NAME}'"
+              if ! jq -e '.components[] | select(.name == "comp1")' "${FILTERED_SNAPSHOT}" > /dev/null; then
+                echo "ERROR: comp1 should be present (prior release failed)"
                 exit 1
               fi
 
-              # Verify ocpVersion is attached even when Pyxis fails
-              expected_ocp_version="v4.15"
-
-              comp_ocp_version=$(jq -r '.components[0].ocpVersion //empty' <<< "${FILTERED_SNAPSHOT}")
-
-              if [ -z "${comp_ocp_version}" ]; then
-                echo "ERROR: ocpVersion not attached to comp1-test"
-                exit 1
-              fi
-
-              if [ "${comp_ocp_version}" != "${expected_ocp_version}" ]; then
-                echo "ERROR: ocpVersion mismatch for comp1-test"
-                echo "  Expected: ${expected_ocp_version}"
-                echo "  Got: ${comp_ocp_version}"
-                exit 1
-              fi
-
-              echo "✓ ocpVersion attached to comp1-test: ${comp_ocp_version}"
-              echo "✅ Test PASSED: Task succeeded with fail-safe behavior"
-              echo "   All components kept after Pyxis 500 errors and retries"
-              echo "   ocpVersion correctly attached to all components"
+              echo "✓ comp1 kept: prior Release had Released=False — not counted as published"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-staged-index.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-staged-index.yaml
@@ -89,10 +89,6 @@ spec:
               # Create data file with stagedIndex=true (stage build)
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
-                "pyxis": {
-                  "secret": "pyxis",
-                  "server": "production"
-                },
                 "fbc": {
                   "stagedIndex": true,
                   "targetIndex": "quay.io/redhat-pending/catalog:v4.14-stage",
@@ -119,8 +115,8 @@ spec:
           value: $(context.pipelineRun.uid)/snapshot.json
         - name: dataPath
           value: $(context.pipelineRun.uid)/data.json
-        - name: pyxisSecret
-          value: pyxis
+        - name: releaseName
+          value: "test-ns/test-current"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions

--- a/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
+++ b/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
@@ -216,8 +216,20 @@ spec:
         echo "INFO: Found ${component_count} components to process"
 
         if [ "${component_count}" -eq 0 ]; then
-            echo "ERROR: No components found in snapshot"
-            exit 1
+            echo "INFO: All components were filtered out by filter-published-fbc-images"
+            echo "INFO: Skipping FBC parameter collection — nothing to validate or publish"
+            if [ "${staged_index}" = "true" ]; then
+                empty_iib_secret="iib-service-account-stage"
+            else
+                empty_iib_secret="iib-service-account-prod"
+            fi
+            echo -n "true"              > "$(results.fbcOptIn.path)"
+            echo -n "true"              > "$(results.validationPassed.path)"
+            echo -n "false"             > "$(results.mustPublishIndexImage.path)"
+            echo -n "false"             > "$(results.mustSignIndexImage.path)"
+            echo -n "false"             > "$(results.mustOverwriteFromIndexImage.path)"
+            echo -n "${empty_iib_secret}" > "$(results.iibServiceAccountSecret.path)"
+            exit 0
         fi
 
         # Initialize result tracking arrays for comprehensive validation

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-empty-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-empty-snapshot.yaml
@@ -1,0 +1,178 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-fbc-parameters-empty-snapshot
+spec:
+  description: |
+    Run prepare-fbc-parameters with a snapshot that has zero components
+    (all components filtered out by filter-published-fbc-images).
+    The task must exit 0 and write mustPublishIndexImage=false,
+    mustSignIndexImage=false, and validationPassed=true to its results
+    so that downstream tasks (add-fbc-contribution, sign-index-image, etc.)
+    are correctly skipped via their when conditions.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+      taskSpec:
+        params:
+          - name: snapshotPath
+            type: string
+            description: Path to the JSON string of the mapped Snapshot spec in the data workspace
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        results:
+          - name: sourceDataArtifact
+            description: Location of trusted artifacts to be used to populate data directory
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Empty components array — simulates all fragments already published
+              cat > "$(params.dataDir)/$(params.snapshotPath)" << 'EOF'
+              {
+                "application": "foo-app",
+                "components": []
+              }
+              EOF
+
+              cat > "$(params.dataDir)/data.json" << 'EOF'
+              {
+                "fbc": {
+                  "allowedPackages": ["test-operator"],
+                  "hotfix": false,
+                  "preGA": false,
+                  "stagedIndex": false
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: prepare-fbc-parameters
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: pyxisSecret
+          value: test-pyxis-secret
+        - name: pyxisServer
+          value: production
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: https://github.com/konflux-ci/release-service-catalog.git
+        - name: taskGitRevision
+          value: development
+        - name: pipelineRunUid
+          value: "test-pipeline-run-uid"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: mustPublishIndexImage
+          value: "$(tasks.run-task.results.mustPublishIndexImage)"
+        - name: mustSignIndexImage
+          value: "$(tasks.run-task.results.mustSignIndexImage)"
+        - name: mustOverwriteFromIndexImage
+          value: "$(tasks.run-task.results.mustOverwriteFromIndexImage)"
+        - name: validationPassed
+          value: "$(tasks.run-task.results.validationPassed)"
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: mustPublishIndexImage
+            type: string
+          - name: mustSignIndexImage
+            type: string
+          - name: mustOverwriteFromIndexImage
+            type: string
+          - name: validationPassed
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -e
+
+              failures=0
+
+              check() {
+                local name="$1" expected="$2" actual="$3"
+                if [ "${actual}" = "${expected}" ]; then
+                  echo "PASS: ${name}=${actual}"
+                else
+                  echo "FAIL: ${name} expected=${expected} actual=${actual}"
+                  failures=$((failures + 1))
+                fi
+              }
+
+              check "mustPublishIndexImage"    "false" "$(params.mustPublishIndexImage)"
+              check "mustSignIndexImage"       "false" "$(params.mustSignIndexImage)"
+              check "mustOverwriteFromIndexImage" "false" "$(params.mustOverwriteFromIndexImage)"
+              check "validationPassed"         "true"  "$(params.validationPassed)"
+
+              if [ "${failures}" -gt 0 ]; then
+                echo "ERROR: ${failures} result assertion(s) failed"
+                exit 1
+              fi
+              echo "All result assertions passed for empty-snapshot path"

--- a/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
@@ -342,8 +342,9 @@ spec:
         echo "INFO: Found ${component_count} components to process"
 
         if [ "${component_count}" -eq 0 ]; then
-            echo "ERROR: No components found in snapshot"
-            exit 1
+            echo "INFO: All components were filtered out by filter-published-fbc-images"
+            echo "INFO: Nothing to prepare — skipping snapshot processing"
+            exit 0
         fi
 
         # Process each component

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-empty-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-empty-snapshot.yaml
@@ -1,0 +1,174 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-fbc-snapshot-empty-snapshot
+spec:
+  description: |
+    Run prepare-fbc-snapshot with a snapshot that has zero components
+    (all components filtered out by filter-published-fbc-images).
+    The task must exit 0 and log that nothing needs to be prepared.
+    The snapshot file must remain intact (empty components array) so the
+    downstream create-trusted-artifact step can still produce a valid artifact.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+      taskSpec:
+        params:
+          - name: snapshotPath
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: add-snapshot
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "fbc": {
+                  "fromIndex": "registry-proxy.engineering.redhat.com/rh-osbs/iib-preview-rhtap:v4.13",
+                  "targetIndex": "quay.io/redhat/redhat----preview-operator-index:v4.13"
+                }
+              }
+              EOF
+
+              # Empty components array — simulates all fragments already published
+              cat > "$(params.dataDir)/$(params.snapshotPath)" << EOF
+              {
+                "application": "foo-app",
+                "artifacts": {},
+                "components": []
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: prepare-fbc-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: snapshotPath
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+              - name: orasOptions
+                value: $(params.orasOptions)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+
+              component_count=$(jq '.components | length' "${SNAPSHOT_FILE}")
+              if [ "${component_count}" -ne 0 ]; then
+                echo "ERROR: Expected 0 components after empty-snapshot path, got ${component_count}"
+                exit 1
+              fi
+              echo "PASS: snapshot still has 0 components — task exited cleanly without modification"


### PR DESCRIPTION
## Describe your changes

- Replaced the docker_image_id=={full_image_ref} Pyxis filter with the repositories.registry, repositories.repository, and repositories.tags.name fields. For quay.io/redhat/redhat----preview-operator-index:4.13 this now produces:
   `repositories.registry==quay.io;repositories.repository==redhat/redhat----preview-operator-index;repositories.tags.name==4.13`
- Removed the date_filter (was an optimization on top of a broken query)

## Relevant Jira
[RELEASE-2379](https://redhat.atlassian.net/browse/RELEASE-2379)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`

Assisted-by: Cursor

[RELEASE-2379]: https://redhat.atlassian.net/browse/RELEASE-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ