### PR TITLE
feat(CLOUDDST-32151): add support for multiple OCP versions per FBC

### DIFF
--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -214,9 +214,11 @@ spec:
         timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' "${DATA_FILE}")
         timestamp=$(date "+${timestamp_format}")
 
-        # Extract OCP versions from snapshot
-        ocp_versions=$(jq -r '.components[].ocpVersion' "$SNAPSHOT_PATH" | sort -u)
-        echo "INFO: Found OCP versions: $(echo "$ocp_versions" | tr '\n' ' ')"
+        # Extract OCP versions from snapshot (ocpVersion is JSON array)
+        # Components can have multiple versions: ["v4.17", "v4.18", "v4.19"]
+        # Fallback to empty array if ocpVersion is absent or null for backward compatibility
+        ocp_versions=$(jq -r '.components[] | (.ocpVersion // []) | .[]' "$SNAPSHOT_PATH" | sort -u | tr '\n' ' ')
+        echo "INFO: Found OCP versions: ${ocp_versions}"
 
         echo "INFO: Using pre-determined values from prepare-fbc-parameters:"
         echo "  - mustPublishIndexImage: ${mustPublishIndexImage}"
@@ -277,20 +279,43 @@ spec:
         task_timeout=$(date -u "+%Hh%Mm%Ss" -d @$(( request_timeout_seconds )))
 
         # Group components by OCP version for isolated processing
+        # Expands multi-version components into separate instances per version
         group_components_by_ocp_version() {
             local snapshot_file="$1"
             local ocp_versions="$2"
 
-            # Group components by OCP version
+            # For each OCP version, extract/expand matching components
             for ocp_version in $ocp_versions; do
                 local group_file="${groups_dir}/${ocp_version}.json"
-                jq --arg ocp_version "$ocp_version" \
-                    '.components | map(select(.ocpVersion == $ocp_version))' \
-                    "$snapshot_file" > "$group_file"
+
+                # Build group by expanding multi-version components
+                # Uses ocpVersionMetadata to get resolved indexes for this specific version
+                jq --arg ocp_version "$ocp_version" '
+                  .components | map(
+                    # Check if component supports this OCP version (ocpVersion is JSON array)
+                    if (.ocpVersion | index($ocp_version)) then
+                      # Find metadata for this specific version
+                      (.ocpVersionMetadata | map(select(.version == $ocp_version)) | .[0]) as $version_metadata |
+
+                      # Create instance for this version with resolved indexes
+                      . + {
+                        ocpVersion: $ocp_version,
+                        updatedFromIndex: $version_metadata.updatedFromIndex,
+                        targetIndex: $version_metadata.targetIndex,
+                        originalName: .name,
+                        name: (if (.ocpVersion | length) > 1
+                               then .name + "-" + $ocp_version
+                               else .name end)
+                      }
+                    else
+                      empty
+                    end
+                  )
+                ' "$snapshot_file" > "$group_file"
 
                 local group_count
                 group_count=$(jq 'length' "$group_file")
-                echo "INFO: OCP version $ocp_version has $group_count components" >&2
+                echo "INFO: OCP version $ocp_version has $group_count component instance(s)" >&2
             done
         }
 

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-backward-compatibility.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-backward-compatibility.yaml
@@ -106,9 +106,14 @@ spec:
                     "name": "test-component-1",
                     "containerImage": "registry.redhat.io/ubi8/ubi:latest",
                     "repository": "prod-registry.io/prod-location0",
-                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
-                    "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
-                    "ocpVersion": "4.12"
+                    "ocpVersion": ["4.12"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "4.12",
+                        "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
+                        "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-invalid-product-characters.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-invalid-product-characters.yaml
@@ -91,9 +91,14 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
-                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
-                    "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
-                    "ocpVersion": "4.12"
+                    "ocpVersion": ["4.12"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "4.12",
+                        "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
+                        "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-ir-failure.yaml
@@ -89,9 +89,14 @@ spec:
                     "name": "comp0",
                     "containerImage": "fail.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
-                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
-                    "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
-                    "ocpVersion": "4.12"
+                    "ocpVersion": ["4.12"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "4.12",
+                        "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
+                        "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-ocp-intersecting.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-multi-ocp-intersecting.yaml
@@ -1,0 +1,337 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-add-fbc-contribution-multi-ocp-intersecting
+spec:
+  description: |
+    Test add-fbc-contribution with multiple components targeting multiple OCP versions with intersecting support.
+    Scenario:
+    - Component 1: supports v4.17, v4.18, v4.19
+    - Component 2: supports v4.18, v4.19 (intersecting with comp1)
+    - Component 3: supports v4.19, v4.20 (intersecting with comp2)
+    This validates proper grouping and processing across intersecting OCP version sets.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-test-data
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/results"
+
+              # Create snapshot with multiple components, each supporting multiple OCP versions
+              # Component 1: v4.17, v4.18, v4.19
+              # Component 2: v4.18, v4.19 (intersects with comp1)
+              # Component 3: v4.19, v4.20 (intersects with comp2)
+              cat > "$(params.dataDir)/snapshot_spec.json" << 'EOF'
+              {
+                "application": "multi-ocp-intersecting-test",
+                "components": [
+                  {
+                    "name": "comp1-multi-ocp",
+                    "containerImage": "registry.io/comp1@sha256:0001",
+                    "repository": "prod-registry.io/prod-comp1",
+                    "ocpVersion": ["v4.17", "v4.18", "v4.19"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.17",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.17",
+                        "targetIndex": "quay.io/test/target-index:v4.17"
+                      },
+                      {
+                        "version": "v4.18",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.18",
+                        "targetIndex": "quay.io/test/target-index:v4.18"
+                      },
+                      {
+                        "version": "v4.19",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.19",
+                        "targetIndex": "quay.io/test/target-index:v4.19"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "comp2-intersecting",
+                    "containerImage": "registry.io/comp2@sha256:0002",
+                    "repository": "prod-registry.io/prod-comp2",
+                    "ocpVersion": ["v4.18", "v4.19"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.18",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.18",
+                        "targetIndex": "quay.io/test/target-index:v4.18"
+                      },
+                      {
+                        "version": "v4.19",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.19",
+                        "targetIndex": "quay.io/test/target-index:v4.19"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "comp3-intersecting",
+                    "containerImage": "registry.io/comp3@sha256:0003",
+                    "repository": "prod-registry.io/prod-comp3",
+                    "ocpVersion": ["v4.19", "v4.20"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.19",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.19",
+                        "targetIndex": "quay.io/test/target-index:v4.19"
+                      },
+                      {
+                        "version": "v4.20",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.20",
+                        "targetIndex": "quay.io/test/target-index:v4.20"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              # Create data.json with FBC configuration
+              cat > "$(params.dataDir)/data.json" << 'EOF'
+              {
+                "fbc": {
+                  "fromIndex": "quay.io/redhat/redhat-operator-index:{{ OCP_VERSION }}",
+                  "targetIndex": "quay.io/test/target-index:{{ OCP_VERSION }}",
+                  "fbcPublishingCredentials": "test-fbc-publishing-credentials",
+                  "buildTimeoutSeconds": 420,
+                  "requestTimeoutSeconds": 120,
+                  "buildTags": ["latest"],
+                  "addArches": []
+                }
+              }
+              EOF
+
+              echo "Multi-OCP intersecting test data created"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+
+    - name: run-task
+      taskRef:
+        name: add-fbc-contribution
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: snapshotPath
+          value: snapshot_spec.json
+        - name: dataPath
+          value: data.json
+        - name: resultsDirPath
+          value: results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: mustPublishIndexImage
+          value: "true"
+        - name: mustOverwriteFromIndexImage
+          value: "false"
+        - name: iibServiceAccountSecret
+          value: "test-iib-secret"
+      runAfter:
+        - setup
+
+    - name: check-result
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: internalRequestResultsFile
+          value: $(tasks.run-task.results.internalRequestResultsFile)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: pipelineRunUid
+            type: string
+          - name: internalRequestResultsFile
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              RESULTS_FILE="$(params.dataDir)/$(params.internalRequestResultsFile)"
+              PIPELINE_UID="$(params.pipelineRunUid)"
+
+              echo "Checking results for multi-OCP intersecting test..."
+
+              # Verify results file exists
+              if [ ! -f "$RESULTS_FILE" ]; then
+                echo "ERROR: Results file not found at $RESULTS_FILE"
+                exit 1
+              fi
+
+              echo "Results file contents:"
+              jq . "$RESULTS_FILE"
+
+              # Expected OCP versions: v4.17, v4.18, v4.19, v4.20
+              # Expected components after deduplication (one per unique target_index):
+              # - v4.17: 1 component (comp1)
+              # - v4.18: 2 components (comp1, comp2)
+              # - v4.19: 3 components (comp1, comp2, comp3)
+              # - v4.20: 1 component (comp3)
+              # Total component instances before deduplication: 7
+              # After deduplication (keeping last per target_index): 4 (one per OCP version)
+
+              # Verify we have results for all 4 OCP versions (after deduplication)
+              component_count=$(jq '.components | length' "$RESULTS_FILE")
+              expected_count=4
+              if [ "$component_count" != "$expected_count" ]; then
+                echo "ERROR: Expected $expected_count components (after deduplication), got $component_count"
+                jq . "$RESULTS_FILE"
+                exit 1
+              fi
+
+              # Verify OCP versions are present in results
+              for ocp_version in "v4.17" "v4.18" "v4.19" "v4.20"; do
+                version_count=$(jq --arg v "$ocp_version" \
+                  '[.components[] | select(.ocp_version == $v)] | length' "$RESULTS_FILE")
+                if [ "$version_count" != "1" ]; then
+                  echo "ERROR: Expected 1 result for OCP version $ocp_version (after dedup), got $version_count"
+                  exit 1
+                fi
+                echo "SUCCESS: Found result for OCP version $ocp_version"
+              done
+
+              # Verify target indexes match expected pattern
+              for ocp_version in "v4.17" "v4.18" "v4.19" "v4.20"; do
+                target_index=$(jq -r --arg v "$ocp_version" \
+                  '.components[] | select(.ocp_version == $v) | .target_index' "$RESULTS_FILE")
+                expected_target="quay.io/test/target-index:$ocp_version"
+                if [ "$target_index" != "$expected_target" ]; then
+                  echo "ERROR: Target index mismatch for $ocp_version. Expected: $expected_target, Got: $target_index"
+                  exit 1
+                fi
+                echo "SUCCESS: Target index verified for OCP version $ocp_version: $target_index"
+              done
+
+              # Verify InternalRequests were created for each OCP version group
+              echo "Checking InternalRequests created for pipeline $PIPELINE_UID..."
+              ir_count=$(kubectl get internalrequest \
+                -l "internal-services.appstudio.openshift.io/pipelinerun-uid=${PIPELINE_UID}" \
+                --no-headers | wc -l | tr -d ' ')
+
+              # Expected: 4 InternalRequests (one batch per OCP version since we have <= maxBatchSize per group)
+              if [ "$ir_count" -lt "4" ]; then
+                echo "ERROR: Expected at least 4 InternalRequests (one per OCP version), got $ir_count"
+                kubectl get internalrequest \
+                  -l "internal-services.appstudio.openshift.io/pipelinerun-uid=${PIPELINE_UID}"
+                exit 1
+              fi
+
+              echo "SUCCESS: Multi-OCP intersecting test validation passed!"
+              echo "  - Processed 3 components across 4 OCP versions"
+              echo "  - v4.17: 1 instance (comp1)"
+              echo "  - v4.18: 2 instances (comp1, comp2)"
+              echo "  - v4.19: 3 instances (comp1, comp2, comp3)"
+              echo "  - v4.20: 1 instance (comp3)"
+              echo "  - Results deduplicated to 4 final components (one per OCP version)"
+      runAfter:
+        - run-task
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests -l \
+                "internal-services.appstudio.openshift.io/pipelinerun-uid=$(context.pipelineRun.uid)" || true
+
+              echo "Multi-OCP intersecting test cleanup completed"

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-multi-components.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged-multi-components.yaml
@@ -80,25 +80,40 @@ spec:
                     "name": "test-fbc-component-staged-4.13-1",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-first-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                     "repository": "quay.io/test/test-fbc-component-staged",
-                    "ocpVersion": "v4.13",
-                    "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
-                    "targetIndex": ""
+                    "ocpVersion": ["v4.13"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.13",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
+                        "targetIndex": ""
+                      }
+                    ]
                   },
                   {
                     "name": "test-fbc-component-staged-4.13-2",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-last-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                     "repository": "quay.io/test/test-fbc-component-staged",
-                    "ocpVersion": "v4.13",
-                    "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
-                    "targetIndex": ""
+                    "ocpVersion": ["v4.13"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.13",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
+                        "targetIndex": ""
+                      }
+                    ]
                   },
                   {
                     "name": "test-fbc-component-staged-4.14-1",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                     "repository": "quay.io/test/test-fbc-component-staged",
-                    "ocpVersion": "v4.14",
-                    "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.14",
-                    "targetIndex": ""
+                    "ocpVersion": ["v4.14"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.14",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.14",
+                        "targetIndex": ""
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-staged.yaml
@@ -79,9 +79,14 @@ spec:
                     "name": "test-fbc-component-staged",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                     "repository": "quay.io/test/test-fbc-component-staged",
-                    "ocpVersion": "v4.13",
-                    "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
-                    "targetIndex": ""
+                    "ocpVersion": ["v4.13"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.13",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.13",
+                        "targetIndex": ""
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-with-validation-results.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-with-validation-results.yaml
@@ -88,9 +88,14 @@ spec:
                     "name": "test-component-1",
                     "containerImage": "registry.redhat.io/ubi8/ubi:latest",
                     "repository": "prod-registry.io/prod-location0",
-                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
-                    "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
-                    "ocpVersion": "4.12"
+                    "ocpVersion": ["4.12"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "4.12",
+                        "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
+                        "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution.yaml
@@ -87,9 +87,14 @@ spec:
                     "name": "comp0",
                     "containerImage": "registry.io/image0@sha256:0000",
                     "repository": "prod-registry.io/prod-location0",
-                    "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
-                    "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12",
-                    "ocpVersion": "4.12"
+                    "ocpVersion": ["4.12"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "4.12",
+                        "updatedFromIndex": "quay.io/scoheb/fbc-index-testing:latest",
+                        "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12"
+                      }
+                    ]
                   }
                 ]
               }

--- a/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
+++ b/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
@@ -303,14 +303,9 @@ spec:
           # For multi-version components, resolve targetIndex for each version
           # and track all unique targetIndex values
           for ocp_version in $ocp_versions; do
-            # Resolve {{ OCP_VERSION }} if present in template
-            if [[ "$target_index_template" == *"{{ OCP_VERSION }}"* ]]; then
-              # Resolve {{ OCP_VERSION }} placeholder using bash parameter expansion
-              target_index="${target_index_template//\{\{ OCP_VERSION \}\}/$ocp_version}"
-            else
-              # No placeholder, use template as-is
-              target_index="$target_index_template"
-            fi
+            # Resolve {{ OCP_VERSION }} placeholder (tolerant of spacing variants)
+            target_index=$(sed -E "s/\{\{(\s+)?OCP_VERSION(\s+)?\}\}/${ocp_version}/g" \
+              <<< "$target_index_template")
 
             echo "    → Resolved targetIndex for ${ocp_version}: ${target_index}"
 

--- a/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
+++ b/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
@@ -217,17 +217,26 @@ spec:
           fi
           echo "    ✓ OCP version validated: ${ocp_version}"
 
-          # Store OCP version for this component
-          component_ocp_versions[$i]="$ocp_version"
+          # Store OCP version as JSON array for this component
+          # Handles both string and array formats for backward compatibility
+          component_ocp_versions[$i]=$(jq -cn --arg v "$ocp_version" '($v | fromjson? // $v) | [.] | flatten')
+
+          # Validate result is a proper JSON array
+          if ! jq -e 'type == "array"' <<< "${component_ocp_versions[$i]}" > /dev/null; then
+            echo "    ❌ ERROR: Failed to convert OCP version to array format"
+            echo "       Got: ${component_ocp_versions[$i]}"
+            exit 1
+          fi
         done
 
         echo "✓ OCP versions extracted and validated for all ${component_count} component(s)"
         echo ""
 
         # Build OCP versions JSON for jq (used by both early exits and main filtering)
+        # Each value is already a JSON array
         ocp_args=()
         for idx in "${!component_ocp_versions[@]}"; do
-          ocp_args+=(--arg "$idx" "${component_ocp_versions[$idx]}")
+          ocp_args+=(--argjson "$idx" "${component_ocp_versions[$idx]}")
         done
         ocp_versions_json=$(jq -n '$ARGS.named' "${ocp_args[@]}")
 
@@ -274,37 +283,51 @@ spec:
         echo ""
 
         # Resolve {{ OCP_VERSION }} for each component and group by resolved targetIndex
-        # OCP versions were already extracted upfront
-        declare -A target_index_to_components  # resolved targetIndex -> space-separated component indices
-        declare -a unique_target_indices       # Array of unique resolved targetIndex values
+        # OCP versions were already extracted upfront (stored as JSON arrays)
+        declare -A target_index_to_components     # resolved targetIndex -> space-separated component indices
+        declare -a unique_target_indices          # Array of unique resolved targetIndex values
+        declare -A component_version_to_target_index  # "component_idx:ocp_version" -> resolved targetIndex (for reuse)
 
         echo "Resolving targetIndex for each component..."
         for ((i=0; i<component_count; i++)); do
           component=$(jq -c ".components[$i]" "${SNAPSHOT_FILE}")
           component_name=$(jq -r '.name' <<< "$component")
-          ocp_version="${component_ocp_versions[$i]}"  # Use already-extracted OCP version
+          component_ocp_json="${component_ocp_versions[$i]}"  # JSON array
 
           echo "  Component $((i+1))/${component_count}: ${component_name}"
-          echo "    → OCP version: ${ocp_version}"
+          echo "    → OCP version(s): ${component_ocp_json}"
 
-          # Resolve {{ OCP_VERSION }} if present in template
-          if [[ "$target_index_template" == *"{{ OCP_VERSION }}"* ]]; then
-            # Resolve {{ OCP_VERSION }} placeholder using bash parameter expansion
-            target_index="${target_index_template//\{\{ OCP_VERSION \}\}/$ocp_version}"
-          else
-            # No placeholder, use template as-is
-            target_index="$target_index_template"
-          fi
+          # Convert JSON array to space-separated for iteration
+          ocp_versions=$(jq -r '.[]' <<< "$component_ocp_json" | tr '\n' ' ')
 
-          echo "    → Resolved targetIndex: ${target_index}"
+          # For multi-version components, resolve targetIndex for each version
+          # and track all unique targetIndex values
+          for ocp_version in $ocp_versions; do
+            # Resolve {{ OCP_VERSION }} if present in template
+            if [[ "$target_index_template" == *"{{ OCP_VERSION }}"* ]]; then
+              # Resolve {{ OCP_VERSION }} placeholder using bash parameter expansion
+              target_index="${target_index_template//\{\{ OCP_VERSION \}\}/$ocp_version}"
+            else
+              # No placeholder, use template as-is
+              target_index="$target_index_template"
+            fi
 
-          # Group component by its resolved targetIndex
-          if [ -z "${target_index_to_components[$target_index]:-}" ]; then
-            target_index_to_components[$target_index]="$i"
-            unique_target_indices+=("$target_index")
-          else
-            target_index_to_components[$target_index]+=" $i"
-          fi
+            echo "    → Resolved targetIndex for ${ocp_version}: ${target_index}"
+
+            # Store resolved targetIndex for later reuse during filtering
+            component_version_to_target_index["$i:$ocp_version"]="$target_index"
+
+            # Group component by its resolved targetIndex
+            if [ -z "${target_index_to_components[$target_index]:-}" ]; then
+              target_index_to_components[$target_index]="$i"
+              unique_target_indices+=("$target_index")
+            else
+              # Only add component index if not already in the list (avoid duplicates)
+              if [[ " ${target_index_to_components[$target_index]} " != *" $i "* ]]; then
+                target_index_to_components[$target_index]+=" $i"
+              fi
+            fi
+          done
         done
         
         unique_count=${#unique_target_indices[@]}
@@ -497,8 +520,9 @@ spec:
         echo "Filtering Components Based on Published Fragments"
         echo "================================================================"
         echo ""
-        
-        declare -A components_to_keep
+
+        declare -A components_to_keep          # component index -> "keep" if any version needs publishing
+        declare -A component_kept_versions     # component index -> space-separated versions to keep
         components_kept=0
         filtered_out_count=0
 
@@ -506,49 +530,74 @@ spec:
           component=$(jq -c ".components[$i]" "${SNAPSHOT_FILE}")
           component_name=$(jq -r '.name' <<< "$component")
           container_image=$(jq -r '.containerImage' <<< "$component")
-          
+          ocp_versions_json="${component_ocp_versions[$i]}"  # JSON array
+
           fragment_digest="${container_image##*@}"
-          
-          # Determine which resolved targetIndex this component belongs to
-          resolved_target_index=""
-          for target_idx in "${unique_target_indices[@]}"; do
-            component_indices="${target_index_to_components[$target_idx]}"
-            # Check if index i is in the space-separated list using bash pattern matching
-            if [[ " $component_indices " == *" $i "* ]]; then
-              resolved_target_index="$target_idx"
-              break
-            fi
-          done
-          
+
           echo "=== Component $((i+1))/${component_count}: ${component_name} ==="
           echo "  containerImage: ${container_image}"
           echo "  fragment digest: ${fragment_digest}"
-          echo "  Resolved targetIndex: ${resolved_target_index}"
-          
-          published_fragments="${target_index_fragments[$resolved_target_index]}"
+          echo "  OCP version(s): ${ocp_versions_json}"
 
-          # Check if fragment digest is in the newline-separated list using bash pattern matching
-          fragment_found=false
-          if [ -n "$published_fragments" ]; then
-            while IFS= read -r published_digest; do
-              if [ "$published_digest" = "$fragment_digest" ]; then
-                fragment_found=true
-                break
-              fi
-            done <<< "$published_fragments"
-          fi
+          # Convert JSON array to space-separated for iteration
+          ocp_versions=$(jq -r '.[]' <<< "$ocp_versions_json" | tr '\n' ' ')
 
-          if [ "$fragment_found" = "true" ]; then
-            echo "  Status: ✓ FOUND in published index"
-            echo "  Action: FILTER OUT (already published)"
-            filtered_out_count=$((filtered_out_count + 1))
-          else
-            echo "  Status: ✗ NOT in published index"
-            echo "  Action: KEEP (needs publishing)"
+          # Track which versions to keep for this component
+          versions_to_keep=""
+          versions_filtered=""
+
+          # Check each OCP version independently
+          for ocp_version in $ocp_versions; do
+            # Get pre-resolved targetIndex for this component and version
+            target_index="${component_version_to_target_index["$i:$ocp_version"]}"
+
+            echo "  Checking version ${ocp_version}:"
+            echo "    → targetIndex: ${target_index}"
+
+            # Get published fragments for this targetIndex
+            published_fragments="${target_index_fragments[$target_index]}"
+
+            # Check if fragment is published for this version
+            fragment_found=false
+            if [ -n "$published_fragments" ]; then
+              while IFS= read -r published_digest; do
+                if [ "$published_digest" = "$fragment_digest" ]; then
+                  fragment_found=true
+                  break
+                fi
+              done <<< "$published_fragments"
+            fi
+
+            if [ "$fragment_found" = "true" ]; then
+              echo "    Status: ✓ FOUND in ${ocp_version} catalog"
+              echo "    Action: FILTER OUT for this version"
+              versions_filtered="${versions_filtered}${ocp_version} "
+            else
+              echo "    Status: ✗ NOT in ${ocp_version} catalog"
+              echo "    Action: KEEP for this version"
+              versions_to_keep="${versions_to_keep}${ocp_version} "
+            fi
+          done
+
+          # Trim trailing spaces using parameter expansion
+          versions_to_keep="${versions_to_keep% }"
+          versions_filtered="${versions_filtered% }"
+
+          # Decision: keep component if ANY version needs publishing
+          if [ -n "$versions_to_keep" ]; then
+            echo "  Decision: KEEP component (versions: ${versions_to_keep})"
             components_to_keep[$i]="keep"
+            component_kept_versions[$i]="$versions_to_keep"
             components_kept=$((components_kept + 1))
+          else
+            echo "  Decision: FILTER OUT (all versions published)"
+            filtered_out_count=$((filtered_out_count + 1))
           fi
-          
+
+          if [ -n "$versions_filtered" ]; then
+            echo "  Filtered versions: ${versions_filtered}"
+          fi
+
           echo ""
         done
 
@@ -556,8 +605,8 @@ spec:
         echo "Filtering Summary:"
         echo "  Total components: ${component_count}"
         echo "  Unique targetIndex values: ${unique_count}"
-        echo "  New (to publish): ${components_kept}"
-        echo "  Already published: ${filtered_out_count}"
+        echo "  Components to publish: ${components_kept}"
+        echo "  Components filtered out: ${filtered_out_count}"
         echo "================================================================"
         echo ""
 
@@ -569,6 +618,7 @@ spec:
           echo "Building filtered snapshot with ${components_kept} component(s)..."
 
           # Build jq filter to keep only non-published components and attach ocpVersion
+          # For multi-version components, ocpVersion contains only versions that need publishing
           # shellcheck disable=SC2016  # jq variables, not bash - single quotes are correct
           jq_filter='def processComponents:
             [
@@ -577,7 +627,7 @@ spec:
               $indices[] |
               . as $idx |
               if $keep_indices[$idx | tostring] == "keep" then
-                $comps[$idx] | .ocpVersion |= $ocp_versions[$idx | tostring]
+                $comps[$idx] | .ocpVersion |= $kept_versions[$idx | tostring]
               else
                 empty
               end
@@ -590,15 +640,25 @@ spec:
           done
           keep_indices_json=$(jq -n '$ARGS.named' "${keep_args[@]}")
 
-          # Use pre-built ocp_versions_json (built earlier after OCP version extraction)
+          # Build kept_versions JSON (contains only unpublished versions for each component as JSON arrays)
+          # Convert space-separated strings to JSON arrays
+          version_args=()
+          for idx in "${!component_kept_versions[@]}"; do
+            # Convert space-separated to JSON array: "v4.17 v4.18" -> ["v4.17", "v4.18"]
+            versions_array=$(echo "${component_kept_versions[$idx]}" | tr ' ' '\n' | jq -R . | jq -s .)
+            version_args+=(--argjson "$idx" "$versions_array")
+          done
+          kept_versions_json=$(jq -n '$ARGS.named' "${version_args[@]}")
+
           jq --argjson keep_indices "$keep_indices_json" \
-             --argjson ocp_versions "$ocp_versions_json" \
+             --argjson kept_versions "$kept_versions_json" \
              "$jq_filter" \
             "${SNAPSHOT_FILE}" > "${FILTERED_SNAPSHOT_FILE}"
 
           kept_count=$(jq '.components | length' "${FILTERED_SNAPSHOT_FILE}")
           echo "✓ Filtered snapshot created with ${kept_count} component(s)"
           echo "✓ Attached ocpVersion to all ${kept_count} component(s)"
+          echo "  (only unpublished versions included in ocpVersion)"
         fi
 
         echo -n "filtered-snapshot.json" > "$(results.filteredSnapshotPath.path)"

--- a/tasks/managed/filter-published-fbc-images/tests/mocks.sh
+++ b/tasks/managed/filter-published-fbc-images/tests/mocks.sh
@@ -252,6 +252,28 @@ curl() {
         ]
       }]
     }'
+  # Same targetIndex test: v4.15 catalog with pub001 and pub002 published
+  elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.15%3Blast_update_date"* ]] && [[ "$*" != *"-unpublished"* ]]; then
+    echo "✅ Matched v4.15 catalog pattern - returning pub001 and pub002 as published" >&2
+    json_response='{
+      "data": [{
+        "_id": "index-v4.15-same",
+        "docker_image_digest": "sha256:index-v4.15-same-digest",
+        "docker_image_id": "quay.io/redhat-pending/catalog:v4.15",
+        "related_images": [
+          {
+            "image": "quay.io/test/bundle1@sha256:pub001",
+            "name": "bundle1",
+            "digest": "sha256:pub001"
+          },
+          {
+            "image": "quay.io/test/bundle2@sha256:pub002",
+            "name": "bundle2",
+            "digest": "sha256:pub002"
+          }
+        ]
+      }]
+    }'
   else
     # Default: return empty data (no published index)
     echo "⚠️  No curl pattern matched - returning empty data. Query was: $*" >&2
@@ -310,6 +332,11 @@ if [[ "$*" == *"inspect"* ]]; then
     ocp_version="4.14"
   elif [[ "$image" == *"@sha256:comp3v416"* ]] || [[ "$image" == *"@sha256:comp4v416"* ]]; then
     ocp_version="4.16"
+  elif [[ "$image" == *"@sha256:partial123"* ]]; then
+    # Partial filtering test: component supports BOTH v4.17 and v4.18
+    # Return as JSON array since this component has multi-version support
+    # The label should be: '["v4.17","v4.18"]'
+    ocp_version="4.17"  # Base image shows v4.17, but component supports both
   elif [[ "$image" == *"@sha256:invalidocp"* ]]; then
     # Invalid OCP version format for testing validation (three parts instead of two)
     ocp_version="4.14.1"
@@ -380,6 +407,32 @@ elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.1
       "docker_image_id": "quay.io/redhat-pending/catalog:v4.16",
       "related_images": [
         {"image": "quay.io/test/comp3@sha256:comp3v416", "digest": "sha256:comp3v416"}
+      ]
+    }]
+  }'
+elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.17%3Blast_update_date"* ]]; then
+  echo "✅ Matched v4.17 catalog - returning partial123 as published" >&2
+  json_response='{
+    "data": [{
+      "_id": "index-v4.17-partial",
+      "docker_image_id": "quay.io/redhat-pending/catalog:v4.17",
+      "related_images": [
+        {"image": "quay.io/test/multi-version-op@sha256:partial123", "digest": "sha256:partial123"}
+      ]
+    }]
+  }'
+elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.18%3Blast_update_date"* ]] && [[ "$*" != *"-bundles"* ]]; then
+  echo "✅ Matched v4.18 catalog - returning empty (partial123 NOT published)" >&2
+  json_response='{"data": []}'
+elif [[ "$*" == *"docker_image_id%3D%3Dquay.io%2Fredhat-pending%2Fcatalog%3Av4.15%3Blast_update_date"* ]] && [[ "$*" != *"-unpublished"* ]]; then
+  echo "✅ Matched v4.15 catalog - returning pub001 and pub002 as published" >&2
+  json_response='{
+    "data": [{
+      "_id": "index-v4.15-same",
+      "docker_image_id": "quay.io/redhat-pending/catalog:v4.15",
+      "related_images": [
+        {"image": "quay.io/test/bundle1@sha256:pub001", "digest": "sha256:pub001"},
+        {"image": "quay.io/test/bundle2@sha256:pub002", "digest": "sha256:pub002"}
       ]
     }]
   }'

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-basic.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-basic.yaml
@@ -228,10 +228,10 @@ spec:
                 exit 1
               fi
 
-              # Verify ocpVersion is attached to the kept component
-              expected_ocp_version="v4.15"
+              # Verify ocpVersion is attached to the kept component (now as array)
+              expected_ocp_version='["v4.15"]'
 
-              comp2_ocp_version=$(jq -r '.components[] | select(.name == "comp2-new") | .ocpVersion //empty' \
+              comp2_ocp_version=$(jq -c '.components[] | select(.name == "comp2-new") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
 
               if [ -z "${comp2_ocp_version}" ]; then

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-first-release.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-first-release.yaml
@@ -214,9 +214,9 @@ spec:
               fi
 
               # Verify ocpVersion is attached to all components
-              expected_ocp_version="v4.15"
+              expected_ocp_version='["v4.15"]'
 
-              comp1_ocp_version=$(jq -r '.components[] | select(.name == "comp1-new") | .ocpVersion //empty' \
+              comp1_ocp_version=$(jq -c '.components[] | select(.name == "comp1-new") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
 
               if [ -z "${comp1_ocp_version}" ]; then
@@ -231,7 +231,7 @@ spec:
                 exit 1
               fi
 
-              comp2_ocp_version=$(jq -r '.components[] | select(.name == "comp2-new") | .ocpVersion //empty' \
+              comp2_ocp_version=$(jq -c '.components[] | select(.name == "comp2-new") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
 
               if [ -z "${comp2_ocp_version}" ]; then

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-invalid-target-index.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-invalid-target-index.yaml
@@ -201,9 +201,9 @@ spec:
               fi
 
               # Verify ocpVersion is attached
-              expected_ocp_version="v4.15"
+              expected_ocp_version='["v4.15"]'
 
-              comp1_ocp_version=$(jq -r '.components[] | select(.name == "comp1-test") | .ocpVersion //empty' \
+              comp1_ocp_version=$(jq -c '.components[] | select(.name == "comp1-test") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
 
               if [ -z "${comp1_ocp_version}" ]; then

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-ocp-versions.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-multi-ocp-versions.yaml
@@ -267,7 +267,7 @@ spec:
               echo "=========================================="
 
               # Verify ocpVersion is attached to comp2-v414-new
-              comp2_ocp=$(jq -r '.components[] | select(.name == "comp2-v414-new") | .ocpVersion //empty' \
+              comp2_ocp=$(jq -c '.components[] | select(.name == "comp2-v414-new") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
               if [ -z "${comp2_ocp}" ]; then
                 echo "❌ ERROR: ocpVersion not attached to comp2-v414-new"
@@ -276,7 +276,7 @@ spec:
               echo "✅ comp2-v414-new has ocpVersion: ${comp2_ocp}"
 
               # Verify ocpVersion is attached to comp4-v416-new
-              comp4_ocp=$(jq -r '.components[] | select(.name == "comp4-v416-new") | .ocpVersion //empty' \
+              comp4_ocp=$(jq -c '.components[] | select(.name == "comp4-v416-new") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
               if [ -z "${comp4_ocp}" ]; then
                 echo "❌ ERROR: ocpVersion not attached to comp4-v416-new"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-pyxis-500-error.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-pyxis-500-error.yaml
@@ -192,9 +192,9 @@ spec:
               fi
 
               # Verify ocpVersion is attached even when Pyxis fails
-              expected_ocp_version="v4.15"
+              expected_ocp_version='["v4.15"]'
 
-              comp_ocp_version=$(jq -r '.components[0].ocpVersion //empty' <<< "${FILTERED_SNAPSHOT}")
+              comp_ocp_version=$(jq -c '.components[0].ocpVersion //empty' <<< "${FILTERED_SNAPSHOT}")
 
               if [ -z "${comp_ocp_version}" ]; then
                 echo "ERROR: ocpVersion not attached to comp1-test"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-staged-index.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-staged-index.yaml
@@ -214,9 +214,9 @@ spec:
               fi
 
               # Verify ocpVersion is attached to all components
-              expected_ocp_version="v4.15"
+              expected_ocp_version='["v4.15"]'
 
-              comp1_ocp_version=$(jq -r '.components[] | select(.name == "comp1-stage") | .ocpVersion //empty' \
+              comp1_ocp_version=$(jq -c '.components[] | select(.name == "comp1-stage") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
 
               if [ -z "${comp1_ocp_version}" ]; then
@@ -231,7 +231,7 @@ spec:
                 exit 1
               fi
 
-              comp2_ocp_version=$(jq -r '.components[] | select(.name == "comp2-stage") | .ocpVersion //empty' \
+              comp2_ocp_version=$(jq -c '.components[] | select(.name == "comp2-stage") | .ocpVersion //empty' \
                   "${FILTERED_SNAPSHOT}")
 
               if [ -z "${comp2_ocp_version}" ]; then

--- a/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
+++ b/tasks/managed/prepare-fbc-parameters/prepare-fbc-parameters.yaml
@@ -283,25 +283,31 @@ spec:
               --argjson result "$package_result" <<< "$package_validation_results")
 
             # === OCP VERSION READING ===
-            # Read OCP version from snapshot (attached by filter-published-fbc-images)
-            echo "  INFO: Reading OCP version from snapshot..."
-            ocp_version=$(jq -cr --argjson i "$i" '.components[$i].ocpVersion' "${SNAPSHOT_PATH}")
+            # Read OCP version(s) from snapshot (attached by filter-published-fbc-images)
+            # Expected format: JSON array ["v4.12"] or ["v4.12", "v4.13"]
+            echo "  INFO: Reading OCP version(s) from snapshot..."
+            ocp_versions_json=$(jq -c --argjson i "$i" '.components[$i].ocpVersion' "${SNAPSHOT_PATH}")
 
-            if [ -z "$ocp_version" ] || [ "$ocp_version" = "null" ]; then
+            if [ -z "$ocp_versions_json" ] || [ "$ocp_versions_json" = "null" ]; then
                 echo "    ERROR: ocpVersion not found for component $i"
                 echo "    This field should be attached by filter-published-fbc-images task"
                 validation_failed=true
-                ocp_version="invalid"
+                ocp_versions_json="null"  # Reset to prevent state leakage across iterations
             else
-                echo "    SUCCESS: Using OCP version from snapshot: ${ocp_version}"
-                target_versions=$(jq --arg version "$ocp_version" '. += [$version]' <<< "$target_versions")
+                echo "    SUCCESS: Component supports: ${ocp_versions_json}"
+
+                # Add each version to target_versions array (merge JSON arrays, keeping unique values)
+                target_versions=$(jq -s --argjson new_versions "$ocp_versions_json" \
+                  '.[0] + $new_versions | unique' <<< "$target_versions")
 
                 # Group components by OCP version for duplicate package detection
-                if [ -z "${ocp_version_to_component_indices[$ocp_version]:-}" ]; then
-                    ocp_version_to_component_indices[$ocp_version]="$i"
-                else
-                    ocp_version_to_component_indices[$ocp_version]+=$'\n'"$i"
-                fi
+                for ocp_version in $(jq -r '.[]' <<< "$ocp_versions_json"); do
+                  if [ -z "${ocp_version_to_component_indices[$ocp_version]:-}" ]; then
+                      ocp_version_to_component_indices[$ocp_version]="$i"
+                  else
+                      ocp_version_to_component_indices[$ocp_version]+=$'\n'"$i"
+                  fi
+                done
             fi
         done
         # Ensure all bundle images are unique across fragments

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-duplicate-packages.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-duplicate-packages.yaml
@@ -72,19 +72,23 @@ spec:
                 "components": [
                   {
                     "name": "test-fbc-component-1",
-                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297"
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
+                    "ocpVersion": ["v4.16"]
                   },
                   {
                     "name": "test-fbc-component-2",
-                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a"
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a",
+                    "ocpVersion": ["v4.16"]
                   },
                   {
                     "name": "test-fbc-component-1-duplicate",
-                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297"
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
+                    "ocpVersion": ["v4.16"]
                   },
                   {
                     "name": "test-fbc-component-2-duplicate",
-                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a"
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a",
+                    "ocpVersion": ["v4.16"]
                   }
                 ]
               }

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-failure-propagation.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-failure-propagation.yaml
@@ -71,7 +71,7 @@ spec:
                   {
                     "name": "test-component-invalid-package",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
-                    "ocpVersion": "v4.14"
+                    "ocpVersion": ["v4.14"]
                   }
                 ]
               }

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-integration.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-integration.yaml
@@ -69,12 +69,12 @@ spec:
                   {
                     "name": "test-fbc-component-1",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
-                    "ocpVersion": "v4.14"
+                    "ocpVersion": ["v4.14"]
                   },
                   {
                     "name": "test-fbc-component-2",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a",
-                    "ocpVersion": "v4.14"
+                    "ocpVersion": ["v4.14"]
                   }
                 ]
               }

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-multi-ocp-intersecting.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-multi-ocp-intersecting.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-fbc-parameters-multi-ocp-intersecting
+spec:
+  description: |
+    Test prepare-fbc-parameters with multiple components targeting multiple OCP versions with intersecting support.
+    Scenario:
+    - Component 1: supports v4.17, v4.18
+    - Component 2: supports v4.18, v4.19 (intersecting with comp1 on v4.18)
+    Verifies package validation and opt-in checking across multi-OCP components.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+      taskSpec:
+        params:
+          - name: snapshotPath
+            type: string
+            description: Path to the JSON string of the mapped Snapshot spec in the data workspace
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        results:
+          - name: sourceDataArtifact
+            description: Location of trusted artifacts to be used to populate data directory
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Ensure data directory exists
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Create snapshot with multiple components, each supporting multiple OCP versions
+              # Using actual test FBC images that exist and are accessible
+              # comp1: sha256:f6e7... (has example-operator)
+              # comp2: sha256:4218... (has operator-foundry-e2e-example-operator)
+              # Note: Both images exist and can be pulled for opm render
+              cat > "$(params.dataDir)/$(params.snapshotPath)" << 'EOF'
+              {
+                "components": [
+                  {
+                    "name": "comp1-multi-ocp",
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
+                    "ocpVersion": ["v4.17", "v4.18"]
+                  },
+                  {
+                    "name": "comp2-intersecting",
+                    "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a",
+                    "ocpVersion": ["v4.18", "v4.19"]
+                  }
+                ]
+              }
+              EOF
+
+              # Create data.json with allowed packages
+              cat > "$(params.dataDir)/data.json" << 'EOF'
+              {
+                "fbc": {
+                  "allowedPackages": [
+                    "test-operator",
+                    "example-operator",
+                    "test-package",
+                    "test-package-1",
+                    "test-package-2",
+                    "operator-foundry-e2e-example-operator"
+                  ],
+                  "hotfix": false,
+                  "preGA": false,
+                  "stagedIndex": false
+                }
+              }
+              EOF
+
+              echo "Multi-OCP intersecting test data created for prepare-fbc-parameters"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+
+    - name: run-task
+      taskRef:
+        name: prepare-fbc-parameters
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: pyxisSecret
+          value: test-pyxis-secret
+        - name: pyxisServer
+          value: production
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: https://github.com/konflux-ci/release-service-catalog.git
+        - name: taskGitRevision
+          value: development
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+      runAfter:
+        - setup
+
+    - name: check-result
+      params:
+        - name: fbcOptIn
+          value: $(tasks.run-task.results.fbcOptIn)
+        - name: validationPassed
+          value: $(tasks.run-task.results.validationPassed)
+        - name: mustPublishIndexImage
+          value: $(tasks.run-task.results.mustPublishIndexImage)
+        - name: mustSignIndexImage
+          value: $(tasks.run-task.results.mustSignIndexImage)
+        - name: mustOverwriteFromIndexImage
+          value: $(tasks.run-task.results.mustOverwriteFromIndexImage)
+        - name: iibServiceAccountSecret
+          value: $(tasks.run-task.results.iibServiceAccountSecret)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: fbcOptIn
+            type: string
+          - name: validationPassed
+            type: string
+          - name: mustPublishIndexImage
+            type: string
+          - name: mustSignIndexImage
+            type: string
+          - name: mustOverwriteFromIndexImage
+            type: string
+          - name: iibServiceAccountSecret
+            type: string
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Checking multi-OCP intersecting test results..."
+
+              # Verify results
+              echo "Results:"
+              echo "  - fbcOptIn: $(params.fbcOptIn)"
+              echo "  - validationPassed: $(params.validationPassed)"
+              echo "  - mustPublishIndexImage: $(params.mustPublishIndexImage)"
+              echo "  - mustSignIndexImage: $(params.mustSignIndexImage)"
+              echo "  - mustOverwriteFromIndexImage: $(params.mustOverwriteFromIndexImage)"
+              echo "  - iibServiceAccountSecret: $(params.iibServiceAccountSecret)"
+
+              # Verify opt-in is true (all components opted in via mocks)
+              if [ "$(params.fbcOptIn)" != "true" ]; then
+                echo "ERROR: Expected fbcOptIn=true, got $(params.fbcOptIn)"
+                exit 1
+              fi
+
+              # Verify validation passed
+              if [ "$(params.validationPassed)" != "true" ]; then
+                echo "ERROR: Expected validationPassed=true, got $(params.validationPassed)"
+                exit 1
+              fi
+
+              # For standard production release (not hotfix/preGA/staged), should use opt-in status
+              if [ "$(params.mustPublishIndexImage)" != "true" ]; then
+                echo "ERROR: Expected mustPublishIndexImage=true (based on opt-in), got $(params.mustPublishIndexImage)"
+                exit 1
+              fi
+
+              if [ "$(params.mustSignIndexImage)" != "true" ]; then
+                echo "ERROR: Expected mustSignIndexImage=true (based on opt-in), got $(params.mustSignIndexImage)"
+                exit 1
+              fi
+
+              if [ "$(params.mustOverwriteFromIndexImage)" != "true" ]; then
+                echo "ERROR: Expected mustOverwriteFromIndexImage=true (based on opt-in)," \
+                  "got $(params.mustOverwriteFromIndexImage)"
+                exit 1
+              fi
+
+              # Verify production IIB service account (stagedIndex=false)
+              if [ "$(params.iibServiceAccountSecret)" != "iib-service-account-prod" ]; then
+                echo "ERROR: Expected production IIB service account, got $(params.iibServiceAccountSecret)"
+                exit 1
+              fi
+
+              echo "SUCCESS: Multi-OCP intersecting test validation passed!"
+              echo "  - Validated 2 components across 3 OCP versions (v4.17, v4.18, v4.19)"
+              echo "  - Component 1: v4.17, v4.18 (multi-OCP)"
+              echo "  - Component 2: v4.18, v4.19 (intersects with comp1 on v4.18)"
+              echo "  - All components passed package validation"
+              echo "  - All components opted in to FBC"
+              echo "  - Publishing decisions correctly applied"
+
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests -l \
+                "internal-services.appstudio.openshift.io/pipelinerun-uid=$(context.pipelineRun.uid)" || true
+
+              echo "Multi-OCP intersecting test cleanup completed"

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-multiple-modes.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-multiple-modes.yaml
@@ -71,7 +71,7 @@ spec:
                   {
                     "name": "test-fbc-component",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
-                    "ocpVersion": "v4.14"
+                    "ocpVersion": ["v4.14"]
                   }
                 ]
               }

--- a/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-stage-pyxis.yaml
+++ b/tasks/managed/prepare-fbc-parameters/tests/test-prepare-fbc-parameters-stage-pyxis.yaml
@@ -69,12 +69,12 @@ spec:
                   {
                     "name": "test-fbc-component-1",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
-                    "ocpVersion": "v4.14"
+                    "ocpVersion": ["v4.14"]
                   },
                   {
                     "name": "test-fbc-component-2",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:42183bc9716448d0c25dbe35bb1c61661449270c89576bed8b9d46ec8df08a4a",
-                    "ocpVersion": "v4.14"
+                    "ocpVersion": ["v4.14"]
                   }
                 ]
               }

--- a/tasks/managed/prepare-fbc-snapshot/README.md
+++ b/tasks/managed/prepare-fbc-snapshot/README.md
@@ -8,8 +8,10 @@ It extracts OCP versions from container image annotations, resolves index templa
 placeholders, and updates the original snapshot with component-specific resolved indexes. These resolved
 indexes take into account the OCP version targeted as well as the release strategy (i.e. hotfix and preGA).
 
-Expects each component in the snapshot to have an ocpVersion field (e.g., "v4.14"),
-which is automatically attached by the filter-published-fbc-images task.
+Expects each component in the snapshot to have an ocpVersion field as a JSON array
+(e.g., ["v4.14"] or ["v4.17", "v4.18"]), automatically attached by the
+filter-published-fbc-images task. For multi-version components, produces an
+ocpVersionMetadata array with per-version resolved indexes.
 
 ## Parameters
 

--- a/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
@@ -16,8 +16,10 @@ spec:
     placeholders, and updates the original snapshot with component-specific resolved indexes. These resolved
     indexes take into account the OCP version targeted as well as the release strategy (i.e. hotfix and preGA).
 
-    Expects each component in the snapshot to have an ocpVersion field (e.g., "v4.14"),
-    which is automatically attached by the filter-published-fbc-images task.
+    Expects each component in the snapshot to have an ocpVersion field as a JSON array
+    (e.g., ["v4.14"] or ["v4.17", "v4.18"]), automatically attached by the
+    filter-published-fbc-images task. For multi-version components, produces an
+    ocpVersionMetadata array with per-version resolved indexes.
   params:
     - name: snapshotPath
       description: Path to the JSON string of the mapped Snapshot spec in the data workspace

--- a/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
@@ -353,56 +353,73 @@ spec:
 
             echo "INFO: Processing component $((i+1))/${component_count}: ${component_name}"
 
-            # Read OCP version from snapshot (attached by filter-published-fbc-images)
-            echo "  INFO: Reading OCP version from snapshot..."
-            ocp_version=$(jq -r ".components[$i].ocpVersion" "${SNAPSHOT_PATH}")
+            # Read OCP version(s) from snapshot (attached by filter-published-fbc-images)
+            # Expected format: JSON array ["v4.12"] or ["v4.12", "v4.13", "v4.14"]
+            echo "  INFO: Reading OCP version(s) from snapshot..."
+            ocp_versions_json=$(jq -c ".components[$i].ocpVersion" "${SNAPSHOT_PATH}")
 
-            if [ -z "${ocp_version}" ] || [ "${ocp_version}" = "null" ]; then
+            if [ -z "${ocp_versions_json}" ] || [ "${ocp_versions_json}" = "null" ]; then
                 echo "    ERROR: ocpVersion not found for component ${component_name}"
                 echo "    This field should be attached by filter-published-fbc-images task"
                 exit 1
             fi
 
-            echo "    SUCCESS: Using OCP version from snapshot: ${ocp_version}"
+            # Count versions
+            version_count=$(jq 'length' <<< "$ocp_versions_json")
 
-            # Generate resolved indexes
-            updated_from_index=""
-            resolved_target_index=""
+            echo "    SUCCESS: Component supports ${version_count} OCP version(s): ${ocp_versions_json}"
 
-            # Generate updated fromIndex if template provided
-            updated_from_index=$(replace_tag "${raw_from_index}" "${ocp_version}")
-            echo "    INFO: Resolved fromIndex: ${updated_from_index}"
+            # Convert JSON array to space-separated for iteration
+            ocp_versions=$(jq -r '.[]' <<< "$ocp_versions_json" | tr '\n' ' ')
 
-            # Generate targetIndex with OCP version and common suffix
-            # The suffix should always be just the common suffix (e.g., RELEASE-1234-timestamp)
-            # The OCP version comes from either replacing {{ OCP_VERSION }} or being in the fixed version
+            # Generate metadata for each OCP version
+            ocp_metadata="[]"
 
-            resolved_target_index=$(generate_component_target_index \
-              "${ocp_version}" "${raw_target_index}" "${common_suffix}")
-            echo "    INFO: Resolved targetIndex: ${resolved_target_index}"
+            for ocp_version in $ocp_versions; do
+                echo "  INFO: Resolving indexes for ${ocp_version}..."
 
-            # Validate OCP version consistency between indexes and base image
-            # if {{OCP_VERSION}} is not set, the original Index will be kept but its ocp version should
-            # match base image version.
-            echo "    INFO: Validating OCP version consistency..."
-            validateOCPVersion "${updated_from_index}" "${ocp_version}"
-            if [ -n "${resolved_target_index}" ]; then
-                validateOCPVersion "${resolved_target_index}" "${ocp_version}"
-            fi
-            echo "    SUCCESS: OCP version validation passed"
+                # Generate resolved indexes for this version
+                updated_from_index=$(replace_tag "${raw_from_index}" "${ocp_version}")
 
-            # Update snapshot with resolved index data
-            # Note: ocpVersion is already attached by filter-published-fbc-images task
-            echo "  INFO: Updating snapshot with resolved index data..."
+                # Generate targetIndex with OCP version and common suffix
+                # The suffix should always be just the common suffix (e.g., RELEASE-1234-timestamp)
+                # The OCP version comes from either replacing {{ OCP_VERSION }} or being in the fixed version
+
+                resolved_target_index=$(generate_component_target_index \
+                  "${ocp_version}" "${raw_target_index}" "${common_suffix}")
+
+                echo "    → fromIndex: ${updated_from_index}"
+                echo "    → targetIndex: ${resolved_target_index}"
+
+                # Validate OCP version consistency between indexes and base image
+                # if {{OCP_VERSION}} is not set, the original Index will be kept but its ocp version should
+                # match base image version.
+                echo "    INFO: Validating OCP version consistency for ${ocp_version}..."
+                validateOCPVersion "${updated_from_index}" "${ocp_version}"
+                if [ -n "${resolved_target_index}" ]; then
+                    validateOCPVersion "${resolved_target_index}" "${ocp_version}"
+                fi
+                echo "    SUCCESS: OCP version validation passed for ${ocp_version}"
+
+                # Add to metadata array
+                ocp_metadata=$(jq --arg version "$ocp_version" \
+                                  --arg from_index "$updated_from_index" \
+                                  --arg target_index "$resolved_target_index" \
+                                  '. += [{
+                                    version: $version,
+                                    updatedFromIndex: $from_index,
+                                    targetIndex: $target_index
+                                  }]' <<< "$ocp_metadata")
+            done
+
+            # Update snapshot with ocpVersionMetadata array
+            echo "  INFO: Updating snapshot with ocpVersionMetadata..."
 
             TEMP="/tmp/temp.json"
-            # Apply each update directly
-            jq ".components[$i].updatedFromIndex |= \"$updated_from_index\"" \
-              "$SNAPSHOT_PATH" > "$TEMP" && mv "$TEMP" "$SNAPSHOT_PATH"
-            jq ".components[$i].targetIndex |= \"$resolved_target_index\"" \
+            jq --argjson metadata "$ocp_metadata" ".components[$i].ocpVersionMetadata = \$metadata" \
               "$SNAPSHOT_PATH" > "$TEMP" && mv "$TEMP" "$SNAPSHOT_PATH"
 
-            echo "  INFO: Successfully updated component with resolved indexes"
+            echo "  INFO: Successfully updated component with metadata for ${version_count} version(s)"
         done
 
         echo "INFO: Snapshot update completed successfully"

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-basic.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-basic.yaml
@@ -80,7 +80,7 @@ spec:
                       {
                           "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                           "name": "test-container-foo",
-                          "ocpVersion": "v4.12",
+                          "ocpVersion": ["v4.12"],
                           "source": {
                               "git": {
                                   "context": "./",
@@ -180,12 +180,14 @@ spec:
               SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
 
               # Fetch ocpVersion from the component itself
-              ocpVersion=$(jq -r '.components[].ocpVersion' "$SNAPSHOT_FILE")
+              ocpVersion=$(jq -r '.components[].ocpVersion[0]' "$SNAPSHOT_FILE")
 
-              # Read components and initial values
-              fromIndex=$(jq -r '.components[].updatedFromIndex' "$SNAPSHOT_FILE")
-              targetIndex=$(jq -r '.components[].targetIndex' "$SNAPSHOT_FILE")
+              # Read components and initial values from ocpVersionMetadata
+              fromIndex=$(jq -r '.components[].ocpVersionMetadata[].updatedFromIndex' "$SNAPSHOT_FILE")
+              targetIndex=$(jq -r '.components[].ocpVersionMetadata[].targetIndex' "$SNAPSHOT_FILE")
+              version=$(jq -r '.components[].ocpVersionMetadata[].version' "$SNAPSHOT_FILE")
 
               for index in "${fromIndex}" "${targetIndex}"; do
                 [ "${index#*:}" = "${ocpVersion}" ]
+                [ "${index#*:}" = "${version}" ]
               done

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-fail-ocp-version-mismatch.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-fail-ocp-version-mismatch.yaml
@@ -73,7 +73,7 @@ spec:
                       {
                           "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                           "name": "test-container-foo",
-                          "ocpVersion": "v4.12",
+                          "ocpVersion": ["v4.12"],
                           "source": {
                               "git": {
                                   "context": "./",

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-hotfix.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-hotfix.yaml
@@ -82,7 +82,7 @@ spec:
                 "components": [
                   {
                     "name": "test-fbc-component",
-                    "ocpVersion": "v4.12",
+                    "ocpVersion": ["v4.12"],
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                     "repository": "quay.io/test/test-fbc-component"
                   }
@@ -199,8 +199,8 @@ spec:
               echo "Updated snapshot contents:"
               jq . "$SNAPSHOT_PATH"
 
-              # Get the target index from the updated snapshot
-              TARGET_INDEX=$(jq -r '.components[0].targetIndex' "$SNAPSHOT_PATH")
+              # Get the target index from the updated snapshot (from ocpVersionMetadata)
+              TARGET_INDEX=$(jq -r '.components[0].ocpVersionMetadata[0].targetIndex' "$SNAPSHOT_PATH")
               echo "Target index: $TARGET_INDEX"
 
               # Verify hotfix suffix pattern: v4.12-RELEASE-1234-timestamp

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-multi-ocp-intersecting.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-multi-ocp-intersecting.yaml
@@ -1,0 +1,310 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-prepare-fbc-snapshot-multi-ocp-intersecting
+spec:
+  description: |
+    Test prepare-fbc-snapshot with multiple components targeting multiple OCP versions with intersecting support.
+    Scenario:
+    - Component 1: supports v4.12, v4.13, v4.14
+    - Component 2: supports v4.13, v4.14 (intersecting with comp1)
+    - Component 3: supports v4.14, v4.15 (intersecting with comp2)
+    Verifies that ocpVersionMetadata is correctly generated for each OCP version per component.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+      taskSpec:
+        params:
+          - name: snapshotPath
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: add-snapshot
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Create data.json with index templates using OCP_VERSION placeholder
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "fbc": {
+                  "fromIndex": "quay.io/redhat/redhat-operator-index:{{ OCP_VERSION }}",
+                  "targetIndex": "quay.io/test/target-index:{{ OCP_VERSION }}"
+                }
+              }
+              EOF
+
+              # Create snapshot with components having multiple OCP versions (from filter-published-fbc-images)
+              # Each component has ocpVersion as JSON array
+              cat > "$(params.dataDir)/$(params.snapshotPath)" << 'EOF'
+              {
+                "application": "multi-ocp-intersecting-app",
+                "components": [
+                  {
+                    "containerImage": "quay.io/test/comp1@sha256:0001",
+                    "name": "comp1-multi-ocp",
+                    "ocpVersion": ["v4.17", "v4.18", "v4.19"],
+                    "repository": "quay.io/test/comp1"
+                  },
+                  {
+                    "containerImage": "quay.io/test/comp2@sha256:0002",
+                    "name": "comp2-intersecting",
+                    "ocpVersion": ["v4.18", "v4.19"],
+                    "repository": "quay.io/test/comp2"
+                  },
+                  {
+                    "containerImage": "quay.io/test/comp3@sha256:0003",
+                    "name": "comp3-intersecting",
+                    "ocpVersion": ["v4.19", "v4.20"],
+                    "repository": "quay.io/test/comp3"
+                  }
+                ]
+              }
+              EOF
+
+              echo "Multi-OCP intersecting test data created for prepare-fbc-snapshot"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+
+    - name: run-task
+      taskRef:
+        name: prepare-fbc-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "development"
+      runAfter:
+        - setup
+
+    - name: check-result
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: snapshotPath
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+              - name: orasOptions
+                value: $(params.orasOptions)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+
+              echo "Checking multi-OCP intersecting snapshot results..."
+              echo "Snapshot contents:"
+              jq . "$SNAPSHOT_FILE"
+
+              # Verify component count
+              component_count=$(jq '.components | length' "$SNAPSHOT_FILE")
+              if [ "$component_count" != "3" ]; then
+                echo "ERROR: Expected 3 components, got $component_count"
+                exit 1
+              fi
+
+              # Component 1: should have metadata for v4.12, v4.13, v4.14
+              echo "Checking component 1 (comp1-multi-ocp)..."
+              comp1_versions=$(jq -r '.components[0].ocpVersion | length' "$SNAPSHOT_FILE")
+              if [ "$comp1_versions" != "3" ]; then
+                echo "ERROR: Component 1 should support 3 OCP versions, got $comp1_versions"
+                exit 1
+              fi
+
+              comp1_metadata_count=$(jq -r '.components[0].ocpVersionMetadata | length' "$SNAPSHOT_FILE")
+              if [ "$comp1_metadata_count" != "3" ]; then
+                echo "ERROR: Component 1 should have 3 metadata entries, got $comp1_metadata_count"
+                exit 1
+              fi
+
+              # Verify each version has correct resolved indexes
+              for version in "v4.17" "v4.18" "v4.19"; do
+                from_index=$(jq -r --arg v "$version" \
+                  '.components[0].ocpVersionMetadata[] | select(.version == $v) | .updatedFromIndex' "$SNAPSHOT_FILE")
+                target_index=$(jq -r --arg v "$version" \
+                  '.components[0].ocpVersionMetadata[] | select(.version == $v) | .targetIndex' "$SNAPSHOT_FILE")
+
+                expected_from="quay.io/redhat/redhat-operator-index:$version"
+                expected_target="quay.io/test/target-index:$version"
+
+                if [ "$from_index" != "$expected_from" ]; then
+                  echo "ERROR: Component 1 fromIndex mismatch for $version. Expected: $expected_from, Got: $from_index"
+                  exit 1
+                fi
+
+                if [ "$target_index" != "$expected_target" ]; then
+                  echo "ERROR: Component 1 targetIndex mismatch for $version." \
+                    "Expected: $expected_target, Got: $target_index"
+                  exit 1
+                fi
+
+                echo "SUCCESS: Component 1 has correct indexes for $version"
+              done
+
+              # Component 2: should have metadata for v4.13, v4.14
+              echo "Checking component 2 (comp2-intersecting)..."
+              comp2_versions=$(jq -r '.components[1].ocpVersion | length' "$SNAPSHOT_FILE")
+              if [ "$comp2_versions" != "2" ]; then
+                echo "ERROR: Component 2 should support 2 OCP versions, got $comp2_versions"
+                exit 1
+              fi
+
+              comp2_metadata_count=$(jq -r '.components[1].ocpVersionMetadata | length' "$SNAPSHOT_FILE")
+              if [ "$comp2_metadata_count" != "2" ]; then
+                echo "ERROR: Component 2 should have 2 metadata entries, got $comp2_metadata_count"
+                exit 1
+              fi
+
+              for version in "v4.18" "v4.19"; do
+                from_index=$(jq -r --arg v "$version" \
+                  '.components[1].ocpVersionMetadata[] | select(.version == $v) | .updatedFromIndex' "$SNAPSHOT_FILE")
+                target_index=$(jq -r --arg v "$version" \
+                  '.components[1].ocpVersionMetadata[] | select(.version == $v) | .targetIndex' "$SNAPSHOT_FILE")
+
+                expected_from="quay.io/redhat/redhat-operator-index:$version"
+                expected_target="quay.io/test/target-index:$version"
+
+                if [ "$from_index" != "$expected_from" ] || [ "$target_index" != "$expected_target" ]; then
+                  echo "ERROR: Component 2 index mismatch for $version"
+                  exit 1
+                fi
+
+                echo "SUCCESS: Component 2 has correct indexes for $version"
+              done
+
+              # Component 3: should have metadata for v4.14, v4.15
+              echo "Checking component 3 (comp3-intersecting)..."
+              comp3_versions=$(jq -r '.components[2].ocpVersion | length' "$SNAPSHOT_FILE")
+              if [ "$comp3_versions" != "2" ]; then
+                echo "ERROR: Component 3 should support 2 OCP versions, got $comp3_versions"
+                exit 1
+              fi
+
+              comp3_metadata_count=$(jq -r '.components[2].ocpVersionMetadata | length' "$SNAPSHOT_FILE")
+              if [ "$comp3_metadata_count" != "2" ]; then
+                echo "ERROR: Component 3 should have 2 metadata entries, got $comp3_metadata_count"
+                exit 1
+              fi
+
+              for version in "v4.19" "v4.20"; do
+                from_index=$(jq -r --arg v "$version" \
+                  '.components[2].ocpVersionMetadata[] | select(.version == $v) | .updatedFromIndex' "$SNAPSHOT_FILE")
+                target_index=$(jq -r --arg v "$version" \
+                  '.components[2].ocpVersionMetadata[] | select(.version == $v) | .targetIndex' "$SNAPSHOT_FILE")
+
+                expected_from="quay.io/redhat/redhat-operator-index:$version"
+                expected_target="quay.io/test/target-index:$version"
+
+                if [ "$from_index" != "$expected_from" ] || [ "$target_index" != "$expected_target" ]; then
+                  echo "ERROR: Component 3 index mismatch for $version"
+                  exit 1
+                fi
+
+                echo "SUCCESS: Component 3 has correct indexes for $version"
+              done
+
+              echo "SUCCESS: Multi-OCP intersecting snapshot test passed!"
+              echo "  - Component 1: 3 OCP versions (v4.17, v4.18, v4.19)"
+              echo "  - Component 2: 2 OCP versions (v4.18, v4.19) - intersects with comp1"
+              echo "  - Component 3: 2 OCP versions (v4.19, v4.20) - intersects with comp2"
+              echo "  - All components have correct ocpVersionMetadata with resolved indexes"

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-placeholder-replace.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-placeholder-replace.yaml
@@ -80,7 +80,7 @@ spec:
                       {
                           "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                           "name": "test-container-foo",
-                          "ocpVersion": "v4.12",
+                          "ocpVersion": ["v4.12"],
                           "source": {
                               "git": {
                                   "context": "./",
@@ -94,7 +94,7 @@ spec:
                       {
                        "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                           "name": "test-container-boo",
-                          "ocpVersion": "v4.12",
+                          "ocpVersion": ["v4.13"],
                           "source": {
                               "git": {
                                   "context": "./",
@@ -197,12 +197,14 @@ spec:
               num_components=$(jq -r '.components | length' "$SNAPSHOT_PATH")
               for ((i=0; i<num_components; i++)); do
                 # Fetch ocpVersion from the component itself
-                ocpVersion=$(jq -r ".components[$i].ocpVersion" "$SNAPSHOT_PATH")
+                ocpVersion=$(jq -r ".components[$i].ocpVersion[0]" "$SNAPSHOT_PATH")
 
-                fromIndex=$(jq -r ".components[$i].updatedFromIndex" "$SNAPSHOT_PATH")
-                targetIndex=$(jq -r ".components[$i].targetIndex" "$SNAPSHOT_PATH")
+                fromIndex=$(jq -r ".components[$i].ocpVersionMetadata[0].updatedFromIndex" "$SNAPSHOT_PATH")
+                targetIndex=$(jq -r ".components[$i].ocpVersionMetadata[0].targetIndex" "$SNAPSHOT_PATH")
+                version=$(jq -r ".components[$i].ocpVersionMetadata[0].version" "$SNAPSHOT_PATH")
 
                 for index in "${fromIndex}" "${targetIndex}"; do
                   [ "${index#*:}" = "${ocpVersion}" ]
+                  [ "${index#*:}" = "${version}" ]
                 done
               done

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-staged.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot-staged.yaml
@@ -82,7 +82,7 @@ spec:
                 "components": [
                   {
                     "name": "test-fbc-component-staged",
-                    "ocpVersion": "v4.12",
+                    "ocpVersion": ["v4.12"],
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                     "repository": "quay.io/test/test-fbc-component-staged"
                   }
@@ -214,9 +214,10 @@ spec:
                 exit 1
               fi
 
-              # Check for component-specific index resolution
+              # Check for component-specific index resolution (in ocpVersionMetadata)
               COMPONENTS_WITH_FROM_INDEX=$(jq \
-                '[.components[] | select(has("updatedFromIndex"))] | length' "$SNAPSHOT_PATH")
+                '[.components[] | select(has("ocpVersionMetadata") and
+                  (.ocpVersionMetadata | length > 0))] | length' "$SNAPSHOT_PATH")
 
               echo "Components with updatedFromIndex: $COMPONENTS_WITH_FROM_INDEX"
 
@@ -229,7 +230,7 @@ spec:
 
               # For staged releases, verify targetIndex is empty string (not missing)
               COMPONENTS_WITH_EMPTY_TARGET_INDEX=$(jq \
-                '[.components[] | select(has("targetIndex") and .targetIndex == "")] | length' "$SNAPSHOT_PATH")
+                '[.components[] | select(.ocpVersionMetadata[0].targetIndex == "")] | length' "$SNAPSHOT_PATH")
 
               echo "Components with empty targetIndex: $COMPONENTS_WITH_EMPTY_TARGET_INDEX"
 
@@ -241,7 +242,7 @@ spec:
               fi
 
               # Verify OCP version was resolved correctly
-              FIRST_COMPONENT_OCP=$(jq -r '.components[0].ocpVersion' "$SNAPSHOT_PATH")
+              FIRST_COMPONENT_OCP=$(jq -r '.components[0].ocpVersionMetadata[0].version' "$SNAPSHOT_PATH")
               if [[ "$FIRST_COMPONENT_OCP" =~ ^v[0-9]+\.[0-9]+$ ]]; then
                 echo "✅ OCP version format is correct: $FIRST_COMPONENT_OCP"
               else
@@ -249,8 +250,9 @@ spec:
                 exit 1
               fi
 
-              # Verify fromIndex was resolved with OCP version
-              FIRST_COMPONENT_FROM_INDEX=$(jq -r '.components[0].updatedFromIndex' "$SNAPSHOT_PATH")
+              # Verify fromIndex was resolved with OCP version (from ocpVersionMetadata)
+              FIRST_COMPONENT_FROM_INDEX=$(jq -r \
+                '.components[0].ocpVersionMetadata[0].updatedFromIndex' "$SNAPSHOT_PATH")
               if [[ "$FIRST_COMPONENT_FROM_INDEX" == *"$FIRST_COMPONENT_OCP"* ]]; then
                 echo "✅ FromIndex correctly resolved with OCP version: $FIRST_COMPONENT_FROM_INDEX"
               else

--- a/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/tests/test-prepare-fbc-snapshot.yaml
@@ -82,7 +82,7 @@ spec:
                 "components": [
                   {
                     "name": "test-fbc-component",
-                    "ocpVersion": "v4.12",
+                    "ocpVersion": ["v4.12"],
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
                     "repository": "quay.io/test/test-fbc-component"
                   }
@@ -214,39 +214,58 @@ spec:
                 exit 1
               fi
 
-              # Check for component-specific index resolution
-              COMPONENTS_WITH_FROM_INDEX=$(jq \
-                '[.components[] | select(has("updatedFromIndex"))] | length' "$SNAPSHOT_PATH")
-              COMPONENTS_WITH_TARGET_INDEX=$(jq \
-                '[.components[] | select(has("targetIndex"))] | length' "$SNAPSHOT_PATH")
+              # Check for ocpVersionMetadata structure
+              COMPONENTS_WITH_METADATA=$(jq \
+                '[.components[] | select(has("ocpVersionMetadata"))] | length' "$SNAPSHOT_PATH")
 
-              echo "Components with updatedFromIndex: $COMPONENTS_WITH_FROM_INDEX"
-              echo "Components with targetIndex: $COMPONENTS_WITH_TARGET_INDEX"
+              echo "Components with ocpVersionMetadata: $COMPONENTS_WITH_METADATA"
 
-              if [[ "$COMPONENTS_WITH_FROM_INDEX" -eq "$TOTAL_COMPONENTS" ]] && \
-                 [[ "$COMPONENTS_WITH_TARGET_INDEX" -eq "$TOTAL_COMPONENTS" ]]; then
-                echo "✅ All components have resolved indexes"
-              else
-                echo "❌ Not all components have resolved indexes"
+              if [[ "$COMPONENTS_WITH_METADATA" -ne "$TOTAL_COMPONENTS" ]]; then
+                echo "❌ Not all components have ocpVersionMetadata"
                 exit 1
               fi
 
-              # Verify OCP version replacement in indexes
-              echo "Verifying OCP version replacement..."
+              echo "✅ All components have ocpVersionMetadata"
+
+              # Verify ocpVersionMetadata structure and content
+              echo "Verifying ocpVersionMetadata structure..."
               for i in $(seq 0 $((TOTAL_COMPONENTS - 1))); do
-                OCP_VERSION=$(jq -r ".components[$i].ocpVersion" "$SNAPSHOT_PATH")
-                FROM_INDEX=$(jq -r ".components[$i].updatedFromIndex" "$SNAPSHOT_PATH")
-                TARGET_INDEX=$(jq -r ".components[$i].targetIndex" "$SNAPSHOT_PATH")
+                OCP_VERSIONS=$(jq -c ".components[$i].ocpVersion" "$SNAPSHOT_PATH")
+                METADATA_COUNT=$(jq ".components[$i].ocpVersionMetadata | length" "$SNAPSHOT_PATH")
 
-                echo "Component $i: OCP=$OCP_VERSION, fromIndex=$FROM_INDEX, targetIndex=$TARGET_INDEX"
+                # Count expected versions (using jq length)
+                EXPECTED_COUNT=$(jq ".components[$i].ocpVersion | length" "$SNAPSHOT_PATH")
 
-                # Check that OCP version is present in the resolved indexes
-                if [[ "$FROM_INDEX" == *"$OCP_VERSION"* ]] && [[ "$TARGET_INDEX" == *"$OCP_VERSION"* ]]; then
-                  echo "✅ Component $i has correct OCP version in indexes"
-                else
-                  echo "❌ Component $i missing OCP version in indexes"
+                echo "Component $i: ocpVersion=$OCP_VERSIONS"
+                echo "  Metadata entries: $METADATA_COUNT (expected: $EXPECTED_COUNT)"
+
+                if [[ "$METADATA_COUNT" -ne "$EXPECTED_COUNT" ]]; then
+                  echo "❌ Component $i metadata count mismatch"
                   exit 1
                 fi
+
+                # Verify each metadata entry
+                for j in $(seq 0 $((METADATA_COUNT - 1))); do
+                  VERSION=$(jq -r ".components[$i].ocpVersionMetadata[$j].version" "$SNAPSHOT_PATH")
+                  FROM_INDEX=$(jq -r ".components[$i].ocpVersionMetadata[$j].updatedFromIndex" "$SNAPSHOT_PATH")
+                  TARGET_INDEX=$(jq -r ".components[$i].ocpVersionMetadata[$j].targetIndex" "$SNAPSHOT_PATH")
+
+                  echo "  Metadata[$j]: version=$VERSION, fromIndex=$FROM_INDEX, targetIndex=$TARGET_INDEX"
+
+                  # Verify version is in ocpVersion field
+                  if [[ ! "$OCP_VERSIONS" =~ $VERSION ]]; then
+                    echo "❌ Version $VERSION not found in component's ocpVersion field"
+                    exit 1
+                  fi
+
+                  # Check that OCP version is present in the resolved indexes
+                  if [[ "$FROM_INDEX" == *"$VERSION"* ]] && [[ "$TARGET_INDEX" == *"$VERSION"* ]]; then
+                    echo "  ✅ Metadata[$j] has correct OCP version in indexes"
+                  else
+                    echo "❌ Metadata[$j] missing OCP version in indexes"
+                    exit 1
+                  fi
+                done
               done
 
               echo "✅ All snapshot update verifications passed"


### PR DESCRIPTION
The tasks are currently designed to handle one target OCP version per FBC component. With binaryless FBCs, a single FBC can now target multiple OCP versions. This commit adds support for it while maintaining backwards compatibility.

- filter-published-fbc-images:
  - ocpVersion will now be extracted and attached to the Snapshot component as a JSON array.
- prepare-fbc-parameters:
  - refactored to support ocpVersion as a JSON array
- prepare-fbc-snapshot:
  - Each component will now have an additional field ocpVersionMetadata
  - If ocpVersion is ["v4.17", "v4.18"], the ocpVersionMetadata field will be an array containing one object per supported OCP version.
  - Each object within ocpVersionMetadata will contain version, updatedFromIndex and targetIndex where version will be individual ocp version string.
- add-fbc-contribution:
  - refactored to read ocpVersion JSON array and handle the ocpVersionMetadata field when creating groups.

Additional tests have been added to test the multiple OCP verison path. Current tests pass with existing config and only formatting changes.


Assisted-By: Claude

