### PR TITLE
fix(CALUNGA-215): decode DSSE envelope when extracting provenance

### DIFF
--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -180,7 +180,7 @@ spec:
             --insecure-ignore-tlog=true \
             --insecure-ignore-sct=true \
             --key k8s://openshift-pipelines/public-key \
-            "${IMAGE}" 2>"${COSIGN_STDERR}" | head -1 | jq . > "${PROVENANCE_FILE}"; then
+            "${IMAGE}" 2>"${COSIGN_STDERR}" | head -1 | jq '.payload | @base64d | fromjson' > "${PROVENANCE_FILE}"; then
             echo "  Saved Chains provenance to ${PROVENANCE_FILE}"
           else
             echo "ERROR: Failed to fetch Chains provenance for ${IMAGE}"

--- a/tasks/managed/extract-py-artifacts/tests/mocks.sh
+++ b/tasks/managed/extract-py-artifacts/tests/mocks.sh
@@ -47,8 +47,12 @@ function cosign() {
   echo "Mock cosign called with: $*" >&2
 
   if [[ "$1" == "verify-attestation" ]]; then
-    # Output on a single line, matching real cosign verify-attestation behavior
-    echo '{"predicateType":"https://slsa.dev/provenance/v1","predicate":{"buildDefinition":{"buildType":"https://tekton.dev/chains/v2/slsa","externalParameters":{"runSpec":{"pipelineRef":{"name":"build-python-wheels-oci-ta"},"params":[{"name":"PACKAGES","value":["test_package==1.0.0"]}]}},"internalParameters":{},"resolvedDependencies":[{"uri":"git+https://github.com/calungaproject/index.git","digest":{"sha1":"abc123def456"}}]},"runDetails":{"builder":{"id":"https://konflux-ci.dev/chains/v2"},"metadata":{"invocationId":"calunga-tenant/build-run-mock","startedOn":"2026-02-19T21:40:00Z","finishedOn":"2026-02-19T21:51:09Z"}}}}'
+    # Real cosign verify-attestation outputs a DSSE envelope with a base64-encoded payload.
+    # The payload decodes to the in-toto Statement containing predicateType and predicate
+    local statement='{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v1","subject":[{"name":"test","digest":{"sha256":"abc123"}}],"predicate":{"buildDefinition":{"buildType":"https://tekton.dev/chains/v2/slsa","externalParameters":{"runSpec":{"pipelineRef":{"name":"build-python-wheels-oci-ta"},"params":[{"name":"PACKAGES","value":["test_package==1.0.0"]}]}},"internalParameters":{},"resolvedDependencies":[{"uri":"git+https://github.com/calungaproject/index.git","digest":{"sha1":"abc123def456"}}]},"runDetails":{"builder":{"id":"https://konflux-ci.dev/chains/v2"},"metadata":{"invocationId":"calunga-tenant/build-run-mock","startedOn":"2026-02-19T21:40:00Z","finishedOn":"2026-02-19T21:51:09Z"}}}}'
+    local payload
+    payload=$(echo -n "${statement}" | base64 -w0)
+    echo "{\"payloadType\":\"application/vnd.in-toto+json\",\"payload\":\"${payload}\",\"signatures\":[{\"keyid\":\"\",\"sig\":\"mock-signature\"}]}"
     return 0
   fi
 

--- a/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
+++ b/tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
@@ -178,8 +178,9 @@ spec:
             shopt -u nullglob
         fi
 
-        if [ -z "${CHAINS_PREDICATE}" ]; then
+        if [ -z "${CHAINS_PREDICATE}" ] || [ "${CHAINS_PREDICATE}" = "null" ]; then
             echo "WARNING: No Chains provenance found, falling back to minimal predicate"
+            CHAINS_PREDICATE=""
         fi
 
         # Function to run cosign with retries


### PR DESCRIPTION
cosign verify-attestation outputs a DSSE envelope with the in-toto Statement base64-encoded in the payload field. The extract-py-artifacts task was saving the raw envelope, so rh-sign-python-wheels could not find .predicate and fell back to a minimal attestation with empty build parameters. Now, we decode the payload in extract-py-artifacts to harden the null check in rh-sign-python-wheels.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
