### PR TITLE
fix(KONFLUX-12767): set retry for check-data-keys

### DIFF
--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -152,7 +152,7 @@ spec:
         fi
 
         schema="${SCHEMA_FILE/\.git\///}"
-        if ! curl -sL --fail-with-body "$schema" -o /tmp/schema ; then
+        if ! curl -sL --fail-with-body --retry 3 --retry-delay 5 --retry-all-errors "$schema" -o /tmp/schema ; then
             echo "Failed to download schema file: $schema"
             exit 1
         fi

--- a/tasks/managed/check-data-keys/tests/mocks.sh
+++ b/tasks/managed/check-data-keys/tests/mocks.sh
@@ -10,6 +10,6 @@ function curl() {
         test -s "$file_path" || { echo "Schema file is empty from configMap"; exit 1; }
         jq empty "$file_path" || { echo "Schema file is not valid JSON from configMap"; exit 1; }
     else
-        command curl -Ls --fail-with-body "$@" -o "$file_path"
+        command curl -Ls --fail-with-body --retry 3 --retry-delay 5 --retry-all-errors "$@" -o "$file_path"
     fi
 }


### PR DESCRIPTION
## Describe your changes
Add curl retry to schema download to avoid pipeline failures from transient network issues.

## Relevant Jira
https://redhat.atlassian.net/browse/KONFLUX-12767

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
