### PR TITLE
test(RELEASE-2328): verify pyxis image IDs and RPM manifests

### DIFF
--- a/integration-tests/rh-push-to-external-registry/test.sh
+++ b/integration-tests/rh-push-to-external-registry/test.sh
@@ -70,6 +70,18 @@ verify_release_contents() {
             echo "🔴 imageId: ${result_image_id} did not match expected imageId: ${imageId}"
             failures=$((failures+1))
         fi
+
+        # Verify RPM manifest was pushed to Pyxis for this image (validates push-rpm-data-to-pyxis ran)
+        result_rpm_json="$(curl --cert /tmp/cert --key /tmp/key \
+            "${pyxis_url}v1/images/id/${imageId}/rpm-manifest")"
+        rpm_manifest_id=$(jq -r '._id // ""' <<< "${result_rpm_json}")
+        if [ -n "${rpm_manifest_id}" ]; then
+            echo "✅️ Found RPM manifest for imageId: ${imageId} in pyxis"
+        else
+            echo "🔴 No RPM manifest found for imageId: ${imageId}"
+            failures=$((failures+1))
+        fi
+
         imageIdsFound=true
     done
 


### PR DESCRIPTION
## Describe your changes
create-pyxis-image and push-rpm-data-to-pyxis both run in the rh-push-to-external-registry pipeline, but neither was asserted in the integration test. A regression in Pyxis registration, which is required for Red Hat CVE tracking, would be completely invisible.
push-rpm-data-to-pyxis also has an anomaly in this pipeline: it lacks the mapped == "true" when-guard that create-pyxis-image carries, and its runAfter does not list create-pyxis-image.

**Changes done:**
Extended verify_release_contents() in integration-tests/rh-push-to-external-registry/test.sh:

- Existing check: each pyxis image ID from pyxis.json is queryable at the staging Pyxis REST API (GET /v1/images/id/{id}) — covers create-pyxis-image.
- New check: for every image ID, also query GET /v1/images/id/{id}/rpm-manifest and assert the manifest _id is present — covers push-rpm-data-to-pyxis. A missing RPM manifest now explicitly fails the test.

## Relevant Jira
[RELEASE-2328](https://redhat.atlassian.net/browse/RELEASE-2328)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


[RELEASE-2328]: https://redhat.atlassian.net/browse/RELEASE-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ