### PR TITLE
chore: restrict CODEOWNERS to specific directories only

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
-# Global code owners — these users can approve changes to any file in the repo
-* @gbenhaim @arewm @ralphbean
+# Code owners for specific directories only
+# Other directories follow default repo PR approval settings
+
+/pipelines/ @gbenhaim @arewm @ralphbean
+/tasks/ @gbenhaim @arewm @ralphbean
+/schema/ @gbenhaim @arewm @ralphbean
+/stepactions/ @gbenhaim @arewm @ralphbean


### PR DESCRIPTION
## Describe your changes

Limit code owner approval requirements to /pipelines/, /tasks/, /schema/, and /stepactions/ directories. That is, only changes directly affecting Konflux users will require architect approval.

As discussed with the architects here: https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1775663755633449?thread_ts=1775658767.038399&cid=C02CTEB3MMF

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
