### PR TITLE
feat(CALUNGA-231): add advisory creation for Python wheel releases

### DIFF
--- a/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
@@ -216,6 +216,8 @@ spec:
         # when running as non-root.
         - name: dataDir
           value: /var/workdir/content
+        - name: dataPath
+          value: $(tasks.collect-data.results.data)
       runAfter:
         - verify-enterprise-contract
 
@@ -281,5 +283,56 @@ spec:
           value: $(params.taskGitUrl)
         - name: taskGitRevision
           value: $(params.taskGitRevision)
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
       runAfter:
         - rh-sign-python-wheels
+
+    - name: create-advisory
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/create-advisory/create-advisory.yaml
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: sourceDataArtifact
+          value: "$(tasks.push-py-pulp.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: dataDir
+          value: /var/workdir/content
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      runAfter:
+        - push-py-pulp
+
+  finally:
+    - name: cleanup-internal-requests
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -209,6 +209,17 @@ spec:
 
         echo "Processing $content_type artifacts for PURL updates..."
 
+        # If all artifacts already have real (non-placeholder) PURLs, skip update-purl entirely.
+        # This handles content types (e.g. Python wheels) where PURLs are populated upstream
+        # and no checksum_map is needed.
+        ARTIFACT_COUNT=$(jq '$(params.jsonKey).content.artifacts // [] | length' "$DATA_FILE")
+        POPULATED_COUNT=$(jq '$(params.jsonKey).content.artifacts // []
+          | map(select(.purl != null and .purl != "" and .purl != "placeholder")) | length' "$DATA_FILE")
+        if [[ "$ARTIFACT_COUNT" -gt 0 && "$ARTIFACT_COUNT" -eq "$POPULATED_COUNT" ]]; then
+          echo "All $ARTIFACT_COUNT artifacts already have PURLs populated. Skipping update-purl."
+          exit 0
+        fi
+
         # Determine environment and set base URLs accordingly
         CDN_ENV=$(jq -r '.cdn.env // "production"' "$DATA_FILE")
         if [ "$CDN_ENV" = "stage" ] || [ "$CDN_ENV" = "qa" ]; then

--- a/tasks/managed/create-advisory/tests/test-create-advisory-skip-purl-prepopulated.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-skip-purl-prepopulated.yaml
@@ -1,0 +1,262 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-skip-purl-prepopulated
+spec:
+  description: |
+    Assert that the update-purl step is skipped when all artifacts
+    already have real (non-placeholder) PURLs populated upstream,
+    such as Python wheel releases.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << 'EOF'
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "calunga-push-to-pulp-prod",
+                  "namespace": "rhtap-releng-tenant"
+                },
+                "spec": {
+                  "applications": ["my-python-app"],
+                  "policy": "calunga-policy",
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "https://github.com/konflux-ci/release-service-catalog.git"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "production"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml"
+                        }
+                      ]
+                    }
+                  },
+                  "serviceAccountName": "release-calunga",
+                  "origin": "calunga-tenant"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << 'EOF'
+              {
+                "application": "my-python-app",
+                "components": [
+                  {
+                    "name": "my-package",
+                    "repository": "quay.io/redhat-prod/my-package"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "my-package",
+                      "contentType": "generic"
+                    }
+                  ]
+                },
+                "releaseNotes": {
+                  "product_name": "My Python Package",
+                  "product_version": "1.2.3",
+                  "product_id": [100],
+                  "type": "RHBA",
+                  "synopsis": "My Python Package 1.2.3 Release",
+                  "topic": "Python wheel release",
+                  "description": "This release provides my-package 1.2.3",
+                  "solution": "Install via pip",
+                  "references": [],
+                  "content": {
+                    "artifacts": [
+                      {
+                        "architecture": "noarch",
+                        "os": "any",
+                        "purl": "pkg:pypi/my-package@1.2.3",
+                        "component": "my-package"
+                      }
+                    ]
+                  }
+                },
+                "sign": {
+                  "configMapName": "cm"
+                },
+                "intention": "production"
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: request
+          value: "test-request"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # Verify the PURL was NOT updated by create-advisory.
+              # When all artifacts already have real PURLs, update-purl should
+              # skip entirely and leave them unchanged.
+              PURL=$(jq -r '.releaseNotes.content.artifacts[0].purl' "$DATA_FILE")
+              EXPECTED_PURL="pkg:pypi/my-package@1.2.3"
+
+              if [ "$PURL" != "$EXPECTED_PURL" ]; then
+                echo "Error: PURL was modified when it should have been skipped"
+                echo "Expected: $EXPECTED_PURL"
+                echo "Got: $PURL"
+                exit 1
+              fi
+
+              echo "Success: PURL was correctly left unchanged for pre-populated artifacts"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/managed/extract-py-artifacts/README.md
+++ b/tasks/managed/extract-py-artifacts/README.md
@@ -19,3 +19,4 @@ The pipeline service account must have get access to this secret
 | trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                | Yes      | ""            |
 | taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | No       | -             |
 | taskGitRevision         | The revision in the taskGitUrl repo to be used                                                        | No       | -             |
+| dataPath                | Path to data.json relative to dataDir                                                                 | No       | -             |

--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -45,6 +45,9 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: dataPath
+      type: string
+      description: Path to data.json relative to dataDir
   results:
     - name: sourceDataArtifact
       description: Produced trusted data artifact
@@ -143,6 +146,127 @@ spec:
 
         echo "Extracted files:"
         ls -la "${FILES_DIR}"
+
+    - name: populate-release-notes
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        DATA_FILE="$(params.dataDir)/$(params.dataPath)"
+
+        parse_wheel_platform() {
+          local platform="$1"
+
+          if [[ "$platform" == "any" || "$platform" == "none" ]]; then
+            echo "noarch any"
+            return
+          fi
+
+          # Extract arch from platform tag (last underscore-separated segment)
+          local arch="${platform##*_}"
+
+          # Derive OS from platform prefix
+          local os="any"
+          if [[ "$platform" == manylinux* || "$platform" == musllinux* || "$platform" == linux* ]]; then
+            os="linux"
+          elif [[ "$platform" == macosx* ]]; then
+            os="macos"
+          elif [[ "$platform" == win* ]]; then
+            os="windows"
+          fi
+
+          echo "$arch $os"
+        }
+
+        # Collect artifact entries as JSON lines for later deduplication
+        ARTIFACTS_JSONL=$(mktemp)
+
+        for whl in "${FILES_DIR}"/*.whl; do
+          [ -f "$whl" ] || continue
+          filename=$(basename "$whl")
+          echo "Processing wheel: $filename"
+
+          # Parse PEP 427 filename: {name}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+          stem="${filename%.whl}"
+          IFS='-' read -ra parts <<< "$stem"
+          num_parts=${#parts[@]}
+
+          if [[ $num_parts -lt 5 || $num_parts -gt 6 ]]; then
+            echo "ERROR: Cannot parse wheel filename: $filename"
+            exit 1
+          fi
+
+          name="${parts[0]}"
+          version="${parts[1]}"
+          platform="${parts[$((num_parts - 1))]}"
+
+          # Extract SBOM from wheel zip
+          dist_info="${name}-${version}.dist-info"
+          sbom_path="${dist_info}/sboms/redhat.spdx.json"
+          echo "  Extracting SBOM: $sbom_path"
+          sbom_json=$(unzip -p "$whl" "$sbom_path" 2>/dev/null) || {
+            echo "ERROR: SBOM not found in wheel: $sbom_path"
+            exit 1
+          }
+
+          # Find pkg:pypi PURL from SPDX SBOM
+          purl=$(jq -r '
+            [.packages[]?.externalRefs[]?
+              | select(.referenceType == "purl")
+              | .referenceLocator
+              | select(startswith("pkg:pypi/"))] | first // empty
+          ' <<< "$sbom_json")
+
+          if [[ -z "$purl" ]]; then
+            echo "ERROR: No pkg:pypi PURL found in SBOM for wheel: $filename"
+            exit 1
+          fi
+          echo "  Found PURL: $purl"
+
+          # Parse platform tag
+          read -r arch os <<< "$(parse_wheel_platform "$platform")"
+          echo "  Platform: $platform -> arch=$arch, os=$os"
+
+          # Build artifact entry as JSON line
+          jq -nc \
+            --arg component "$name" \
+            --arg purl "$purl" \
+            --arg architecture "$arch" \
+            --arg os "$os" \
+            '{component: $component, purl: $purl, architecture: $architecture, os: $os}' \
+            >> "$ARTIFACTS_JSONL"
+        done
+
+        # Deduplicate by (name, version, architecture, os).
+        # Since purl encodes name@version, deduplicating by (component, purl, arch, os) is equivalent.
+        DEDUPED=$(jq -sc '
+          group_by(.component + "|" + .purl + "|" + .architecture + "|" + .os)
+          | map(.[0])
+        ' "$ARTIFACTS_JSONL")
+        rm -f "$ARTIFACTS_JSONL"
+
+        ARTIFACT_COUNT=$(jq 'length' <<< "$DEDUPED")
+        if [[ "$ARTIFACT_COUNT" -eq 0 ]]; then
+          echo "ERROR: No .whl files found in ${FILES_DIR}"
+          exit 1
+        fi
+        echo "Adding $ARTIFACT_COUNT artifact(s) to releaseNotes.content.artifacts"
+
+        # Append entries to .releaseNotes.content.artifacts[] in data.json
+        TMP_DATA=$(mktemp)
+        jq --argjson artifacts "$DEDUPED" '
+          .releaseNotes.content.artifacts = (.releaseNotes.content.artifacts // []) + $artifacts
+        ' "$DATA_FILE" > "$TMP_DATA" && mv "$TMP_DATA" "$DATA_FILE"
+
+        echo "Done. Updated artifacts:"
+        jq '.releaseNotes.content.artifacts' "$DATA_FILE"
 
     - name: fetch-chains-provenance
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3

--- a/tasks/managed/extract-py-artifacts/tests/mocks.sh
+++ b/tasks/managed/extract-py-artifacts/tests/mocks.sh
@@ -33,13 +33,45 @@ function oras() {
 
     if [[ -n "$output_dir" ]]; then
       # Create mock Python package files
-      echo "mock wheel content" > "${output_dir}/test_package-1.0.0-py3-none-any.whl"
-      echo "mock sdist content" > "${output_dir}/test_package-1.0.0.tar.gz"
-      echo "Created mock files in ${output_dir}"
+      # If the .mock_no_wheels marker exists, only create sdist (no wheels)
+      if [[ -f "${TRUSTED_ARTIFACTS_EXTRACT_DIR}/.mock_no_wheels" ]]; then
+        echo "mock sdist content" > "${output_dir}/test_package-1.0.0.tar.gz"
+        echo "Created mock files (no wheels) in ${output_dir}"
+      else
+        echo "mock wheel content" > "${output_dir}/test_package-1.0.0-py3-none-any.whl"
+        echo "mock sdist content" > "${output_dir}/test_package-1.0.0.tar.gz"
+        echo "Created mock files in ${output_dir}"
+      fi
     fi
     return 0
   fi
 
+  return 0
+}
+
+function unzip() {
+  echo "Mock unzip called with: $*" >&2
+  if [[ "$1" == "-p" ]]; then
+    # Return a mock SPDX SBOM with a pkg:pypi PURL
+    cat << 'SBOM_EOF'
+{
+  "spdxVersion": "SPDX-2.3",
+  "packages": [
+    {
+      "name": "test-package",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/test_package@1.0.0"
+        }
+      ]
+    }
+  ]
+}
+SBOM_EOF
+    return 0
+  fi
   return 0
 }
 

--- a/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/extract-py-artifacts/tests/pre-apply-task-hook.sh
@@ -6,8 +6,9 @@
 #   [1] use-trusted-artifact (StepAction ref - no mock needed)
 #   [2] get-image-urls (script - inject mocks)
 #   [3] extract-artifacts (script - inject mocks)
-#   [4] fetch-chains-provenance (script - inject mocks)
-#   [5] create-trusted-artifact (StepAction ref - no mock needed)
+#   [4] populate-release-notes (script - inject mocks)
+#   [5] fetch-chains-provenance (script - inject mocks)
+#   [6] create-trusted-artifact (StepAction ref - no mock needed)
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -17,5 +18,8 @@ yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[
 # Inject mocks into the extract-artifacts step (step index 3)
 yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"
 
-# Inject mocks into the fetch-chains-provenance step (step index 4)
+# Inject mocks into the populate-release-notes step (step index 4)
 yq -i '.spec.steps[4].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[4].script' "$TASK_PATH"
+
+# Inject mocks into the fetch-chains-provenance step (step index 5)
+yq -i '.spec.steps[5].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[5].script' "$TASK_PATH"

--- a/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts-fail-no-wheels.yaml
+++ b/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts-fail-no-wheels.yaml
@@ -2,9 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-upload-py-pulp
+  name: test-extract-py-artifacts-fail-no-wheels
+  annotations:
+    test/assert-task-failure: "run-task"
 spec:
-  description: Test uploading Python packages to Pulp
+  description: |
+    Assert that extract-py-artifacts fails when no .whl files are found
+    in the extracted artifacts directory.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -25,6 +29,7 @@ spec:
     - name: dataDir
       description: The location where data will be stored
       type: string
+      default: /var/workdir/content
   tasks:
     - name: setup
       taskSpec:
@@ -52,14 +57,36 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              mkdir -p "$(params.dataDir)/files"
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
 
-              # Create mock wheel, sdist, and attestation files
-              FILES="$(params.dataDir)/files"
-              echo "mock wheel content" > "${FILES}/my_package-1.0.0-py3-none-any.whl"
-              echo "mock sdist content" > "${FILES}/my_package-1.0.0.tar.gz"
-              echo '{"version": 1, "envelope": {}}' > "${FILES}/my_package-1.0.0-py3-none-any.whl.attestation"
-              echo '{"version": 1, "envelope": {}}' > "${FILES}/my_package-1.0.0.tar.gz.attestation"
+              # Create marker to tell the oras mock not to create .whl files
+              touch "$(params.dataDir)/.mock_no_wheels"
+
+              # Create a mock snapshot spec with container images
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << 'EOF'
+              {
+                "application": "test-app",
+                "components": [
+                  {
+                    "name": "test-component",
+                    "containerImage": "quay.io/test/test-package@sha256:abc123"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "releaseNotes": {
+                  "product_id": [123],
+                  "type": "RHBA",
+                  "synopsis": "Test advisory",
+                  "content": {
+                    "artifacts": []
+                  }
+                }
+              }
+              EOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -72,24 +99,20 @@ spec:
                 value: $(results.sourceDataArtifact.path)
     - name: run-task
       taskRef:
-        name: upload-py-pulp
+        name: extract-py-artifacts
       params:
-        - name: SERVICE_ACCOUNT_SECRET_NAME
-          value: rhtl-pulp-credentials-secret
-        - name: PULP_BASE_URL
-          value: https://test.packages.redhat.com
-        - name: PULP_API_ROOT
-          value: /api/
-        - name: PULP_DOMAIN
-          value: test-domain
-        - name: PULP_REPOSITORY
-          value: test-repo
+        - name: SNAPSHOT_PATH
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
         - name: sourceDataArtifact
           value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
         - name: filesDir
           value: files
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
         - name: orasOptions
           value: $(params.orasOptions)
         - name: trustedArtifactsDebug
@@ -98,36 +121,7 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
-        - name: ociStorage
-          value: $(params.ociStorage)
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
       runAfter:
         - setup
-    - name: check-result
-      params:
-        - name: dataDir
-          value: $(params.dataDir)
-      taskSpec:
-        params:
-          - name: dataDir
-            type: string
-        volumes:
-          - name: workdir
-            emptyDir: {}
-        stepTemplate:
-          volumeMounts:
-            - mountPath: /var/workdir
-              name: workdir
-        steps:
-          - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:2f9e6863e82bbc9ddce5a290f3fd0e87657c475e3de8a832b2ef7f8d0671e7d3
-            script: |
-              #!/usr/bin/env bash
-              set -eux
-
-              # The upload task doesn't produce a trusted artifact output,
-              # so we just verify the task completed successfully.
-              # In a real scenario, the upload would have been done.
-              echo "Upload task completed successfully!"
-              echo "All checks passed!"
-      runAfter:
-        - run-task

--- a/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
@@ -67,6 +67,19 @@ spec:
                 ]
               }
               EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "releaseNotes": {
+                  "product_id": [123],
+                  "type": "RHBA",
+                  "synopsis": "Test advisory",
+                  "content": {
+                    "artifacts": []
+                  }
+                }
+              }
+              EOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -101,6 +114,8 @@ spec:
           value: "http://localhost"
         - name: taskGitRevision
           value: "main"
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
       runAfter:
         - setup
     - name: check-result
@@ -182,10 +197,28 @@ spec:
                 fi
               done
 
+              # Check that releaseNotes artifacts were populated in data.json
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+              ARTIFACT_COUNT=$(jq '[.releaseNotes.content.artifacts[] ] | length' "$DATA_FILE")
+              if [ "$ARTIFACT_COUNT" -eq 0 ]; then
+                echo "ERROR: No artifacts populated in releaseNotes"
+                jq . "$DATA_FILE"
+                exit 1
+              fi
+
+              # Verify the artifact has expected fields
+              PURL=$(jq -r '.releaseNotes.content.artifacts[0].purl' "$DATA_FILE")
+              if [[ "$PURL" != pkg:pypi/* ]]; then
+                echo "ERROR: Expected pkg:pypi PURL, got: $PURL"
+                exit 1
+              fi
+
               echo "Files extracted:"
               ls -la "${FILES_DIR}"
               echo "Chains provenance:"
               ls -la "${FILES_DIR}/chains-provenance"
+              echo "Release notes artifacts:"
+              jq '.releaseNotes.content.artifacts' "$DATA_FILE"
 
               echo "All checks passed!"
       runAfter:

--- a/tasks/managed/upload-py-pulp/README.md
+++ b/tasks/managed/upload-py-pulp/README.md
@@ -19,3 +19,4 @@ Upload Python packages (with attestations) to a Pulp repository.
 | trustedArtifactsDebug       | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                | Yes      | ""                           |
 | taskGitUrl                  | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | No       | -                            |
 | taskGitRevision             | The revision in the taskGitUrl repo to be used                                                        | No       | -                            |
+| ociStorage                  | The OCI repository where the Trusted Artifacts are stored                                             | No       | -                            |

--- a/tasks/managed/upload-py-pulp/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/upload-py-pulp/tests/pre-apply-task-hook.sh
@@ -11,6 +11,7 @@ kubectl create secret generic rhtl-pulp-credentials-secret \
 #   [0] prepare-workdir (command - no mock needed)
 #   [1] use-trusted-artifact (StepAction ref - no mock needed)
 #   [2] upload (command - replace with mock script)
+#   [3] create-trusted-artifact (StepAction ref - no mock needed)
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
+++ b/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
@@ -54,6 +54,13 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored
+  results:
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
   volumes:
     - name: service-account-secret
       secret:
@@ -133,3 +140,26 @@ spec:
         requests:
           memory: 256Mi
           cpu: 100m
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)


### PR DESCRIPTION
## Describe your changes
Add populate-release-notes step to extract-py-artifacts that extracts pkg:pypi PURLs from wheel SBOMs and populates releaseNotes artifacts. Add early exit in create-advisory update-purl for pre-populated PURLs. Wire create-advisory into the calunga-push-to-pulp pipeline.
## Relevant Jira
https://redhat.atlassian.net/browse/CALUNGA-231
## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
