### PR TITLE
chore: add gitlint rule to block AI in Co-Authored-By

### DIFF
--- a/.github/gitlint/contrib_no_ai_coauthored_by.py
+++ b/.github/gitlint/contrib_no_ai_coauthored_by.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from gitlint.rules import CommitRule, RuleViolation
+import re
+
+
+class NoAICoAuthoredBy(CommitRule):
+    """This rule will enforce that Co-Authored-By trailers do not
+    reference AI tools. AI tools should be referenced using
+    the Assisted-by: trailer instead."""
+
+    id = "UC2"
+    name = "contrib-no-ai-coauthored-by"
+
+    # AI tool patterns to block in Co-Authored-By:
+    ai_tool_patterns = [
+        r"claude",
+        r"cursor",
+        r"copilot",
+        r"chatgpt",
+        r"gemini",
+    ]
+
+    def validate(self, commit):
+        """Validate that Co-Authored-By does not reference AI tools."""
+
+        pattern = re.compile("|".join(self.ai_tool_patterns), re.IGNORECASE)
+
+        for idx, line in enumerate(commit.message.body):
+            match = re.match(r"\s*co-authored-by:\s*(.*)", line, re.IGNORECASE)
+            if match:
+                value = match.group(1)
+                if pattern.search(value):
+                    return [
+                        RuleViolation(
+                            self.id,
+                            f"Co-Authored-By must not reference AI tools. "
+                            f"Use 'Assisted-by: <AI TOOL>' instead. "
+                            f"Found: {line.strip()}",
+                            line_nr=idx + 2,
+                        )
+                    ]
+
+        return []

--- a/.gitlint
+++ b/.gitlint
@@ -16,3 +16,5 @@ line-length=72
 [ignore-by-author-name]
 regex=(.*)\[bot\](.*)
 ignore=T1,B1
+
+[contrib-no-ai-coauthored-by]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,17 @@ Overall explanation of what this commit is achieving and the motivation behind i
 
 Signed-off-by: Your Name <your-name@your-email.com>
 ```
+
+### AI tools in commits
+
+If you used an AI tool to help with your contribution, add an `Assisted-by` trailer to your commit message
+
+```
+Assisted-by: Claude
+```
+
+Do not use `Co-Authored-By` for AI tools. This is enforced by gitlint and your commit will be rejected if it includes something like `Co-Authored-By: Claude <noreply@anthropic.com>`.
+
 ### Pull Request Title Prefixes
 
 The title prefix should be one of (`chore`|`docs`|`feat`|`fix`|`refactor`|`revert`|`style`|`test`) followed by a colon (`:`) and lowercase title. Optionally, you can include a Jira key.
@@ -144,7 +155,7 @@ Running `.github/scripts/check_readme.sh` locally is recommended to find these e
 If you wish to update a task, pipeline, or task/pipeline parameter description, do **not** manually change the README.md file.
 
 Instead, you should change the descriptions in the `yaml` file associated with the task/pipeline, and then run `.github/scripts/readme_generator.sh`
-with the changed task/pipeline directories as arguments. This is because the task/pipeline `yaml` file is considered the source of truth for each 
+with the changed task/pipeline directories as arguments. This is because the task/pipeline `yaml` file is considered the source of truth for each
 task/pipeline README.md file. If you manually change the README.md file without updating the yaml, `check_readme.sh` will fail and `readme_generator.sh`
 will overwrite your changes. You should never have to update the README.md file manually.
 
@@ -327,7 +338,7 @@ source .env.testing
 
 # Run tests
 ./scripts/run-local-tests.sh                              # Auto-detect changes
-./scripts/run-local-tests.sh --pr-mode                    # Test PR changes  
+./scripts/run-local-tests.sh --pr-mode                    # Test PR changes
 ./scripts/run-local-tests.sh tasks/managed/add-fbc-contribution  # Specific task
 ```
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,4 +7,5 @@
   - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
 - [ ] My commit message includes `Signed-off-by: My name <email>`
 - [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
+- [ ] If AI tools were used, I have added `Assisted-by: <tool>` ([details](CONTRIBUTING.md#ai-tools-in-commits))
 - [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`


### PR DESCRIPTION


## Describe your changes
Add rule to reject Co-Authored-By trailers that reference AI tools. Update CONTRIBUTING and PR template with guidance on using Assisted-by instead.

Assisted-by: Claude
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
