### PR TITLE
test(RELEASE-2308): mult-arch scenario for push-rpms-to-pulp e2e

### DIFF
--- a/integration-tests/push-rpms-to-pulp/README.md
+++ b/integration-tests/push-rpms-to-pulp/README.md
@@ -1,6 +1,6 @@
 # push-rpms-to-pulp Test
 
-This test validates the pushing of rpms to pulp pipeline. When the release includes noarch RPMs, the integration test asserts they are published to all default arch repos (x86_64, aarch64, s390x, ppc64le). Task-level test `tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-noarch-all-default-arches.yaml` covers the same noarch fanout behavior in isolation.
+This test validates the pushing of rpms to pulp pipeline. It builds binary RPMs for all supported architectures (x86_64, aarch64, s390x, ppc64le) plus a source RPM, and verifies each is pushed to its matching Pulp repository. It also validates noarch RPM fanout to all default arch repos. Task-level test `tasks/managed/push-rpms-to-pulp/tests/test-push-rpms-to-pulp-noarch-all-default-arches.yaml` covers noarch fanout behavior in isolation.
 
 ## Test-Specific Dependencies
 

--- a/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
@@ -16,29 +16,32 @@ spec:
       domain: konflux-release-integration-tests
       secretName: pulp-credentials-${component_name}
     mapping:
-      "rpm-repositories": [
-        {
-          "name": "rpm-x86_64",
-          "arch": "x86_64",
-          "repository_id": "rpm-x86_64",
-          "repository_name": "x86_64",
-          "distro": "testdistro"
-        },
-        {
-          "name": "rpm-aarch64",
-          "arch": "aarch64",
-          "repository_id": "rpm-aarch64",
-          "repository_name": "aarch64",
-          "distro": "testdistro"
-        },
-        {
-          "name": "rpm-source",
-          "arch": "src",
-          "repository_id": "rpm-source",
-          "repository_name": "source",
-          "distro": "testdistro"
-        }
-      ]
+      rpm-repositories:
+        - name: rpm-x86_64
+          arch: x86_64
+          repository_id: rpm-x86_64
+          repository_name: x86_64
+          distro: testdistro
+        - name: rpm-aarch64
+          arch: aarch64
+          repository_id: rpm-aarch64
+          repository_name: aarch64
+          distro: testdistro
+        - name: rpm-s390x
+          arch: s390x
+          repository_id: rpm-s390x
+          repository_name: s390x
+          distro: testdistro
+        - name: rpm-ppc64le
+          arch: ppc64le
+          repository_id: rpm-ppc64le
+          repository_name: ppc64le
+          distro: testdistro
+        - name: rpm-source
+          arch: src
+          repository_id: rpm-source
+          repository_name: source
+          distro: testdistro
       components:
         - name: ${component_name}
           contentType: rpm

--- a/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/pull-request-template.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/pull-request-template.yaml
@@ -30,9 +30,9 @@ spec:
     - name: target-branch
       value: "{{ target_branch }}"
     - name: build-architectures
-      value: ["x86_64"]
+      value: ["x86_64", "aarch64", "s390x", "ppc64le"]
     - name: build-platforms
-      value: ["linux/amd64", "localhost"]
+      value: ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le", "localhost"]
   pipelineRef:
     resolver: git
     params:

--- a/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/push-template.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/push-template.yaml
@@ -28,9 +28,9 @@ spec:
     - name: target-branch
       value: "{{ target_branch }}"
     - name: build-architectures
-      value: ["x86_64"]
+      value: ["x86_64", "aarch64", "s390x", "ppc64le"]
     - name: build-platforms
-      value: ["linux/amd64", "localhost"]
+      value: ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le", "localhost"]
   pipelineRef:
     resolver: git
     params:

--- a/integration-tests/push-rpms-to-pulp/test.sh
+++ b/integration-tests/push-rpms-to-pulp/test.sh
@@ -76,9 +76,9 @@ verify_release_contents() {
     advisory_url=$(jq -r '.status.artifacts.advisory.url // ""' <<< "${release_json}")
     advisory_internal_url=$(jq -r '.status.artifacts.advisory.internal_url // ""' <<< "${release_json}")
 
-    # first 2 arches are specified in the pipelinerun templates, the last one is src.
-    # When the release includes noarch RPMs, fanout adds extra rpmfiles (one per default arch).
-    arches=("x86_64" "src")
+    # All 4 binary arches are built by rpmbuild-pipeline, plus src.
+    # Noarch RPMs (hello-data) are fanned out to all default arch repos, adding extra rpmfiles.
+    arches=("x86_64" "aarch64" "s390x" "ppc64le" "src")
     echo "Checking RPM files count..."
     local rpmfiles=$(jq -c '.status.artifacts.rpmfiles // []' <<< "${release_json}")
     local rpmfiles_count=$(jq -r '. | length' <<< "${rpmfiles}")
@@ -96,6 +96,19 @@ verify_release_contents() {
         echo "✅️ rpmfiles for ${arch}: ${arch_rpmfiles}"
       else
         echo "🔴 rpmfiles for ${arch} was empty"
+        failures=$((failures+1))
+      fi
+      local expected_repo="${arch}"
+      if [ "${arch}" == "src" ]; then
+        expected_repo="source"
+      fi
+      local expected_pulprepo="konflux-release-integration-tests/${expected_repo}"
+      local actual_pulprepo
+      actual_pulprepo=$(jq -r '.[]? | select(.arch == "'"${arch}"'") | .pulprepo // ""' <<< "${rpmfiles}")
+      if [ "${actual_pulprepo}" == "${expected_pulprepo}" ]; then
+        echo "✅️ pulprepo for ${arch}: ${actual_pulprepo}"
+      else
+        echo "🔴 pulprepo for ${arch} was '${actual_pulprepo}', expected '${expected_pulprepo}'"
         failures=$((failures+1))
       fi
     done
@@ -240,14 +253,15 @@ verify_release_contents() {
               failures=$((failures+1))
             fi
 
-            # Check for binary RPM entry with arch (e.g., "hello-2.12.1-xxx (x86_64)")
-            # Use pattern that doesn't match the .src entry
-            if echo "${description}" | grep -E "hello-[0-9].*\(.*x86_64" | grep -qv "\.src"; then
-              echo "✅️ Found binary RPM entry with x86_64 arch in description"
-            else
-              echo "🔴 Missing binary RPM entry with x86_64 arch in description"
-              failures=$((failures+1))
-            fi
+            # Check for binary RPM entries for all architectures
+            for binary_arch in x86_64 aarch64 s390x ppc64le; do
+              if echo "${description}" | grep -E "hello-[0-9].*\(.*${binary_arch}" | grep -qv "\.src"; then
+                echo "✅️ Found binary RPM entry with ${binary_arch} arch in description"
+              else
+                echo "🔴 Missing binary RPM entry with ${binary_arch} arch in description"
+                failures=$((failures+1))
+              fi
+            done
 
             # Check for noarch RPM entry (e.g., "hello-data-2.12.1-xxx (noarch)")
             if echo "${description}" | grep -q "hello-data-.* (noarch)"; then


### PR DESCRIPTION
## Describe your changes

For the e2e test, now we build RPMs for all four architectures (x86_64, aarch64, s390x, ppc64le) instead of just x86_64.

Assisted-by: Claude Code

## Relevant Jira

https://redhat.atlassian.net/browse/RELEASE-2308

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
