### PR TITLE
feat(RELEASE-2386): add jira 404 retry in embargo-check

### DIFF
--- a/tasks/managed/embargo-check/embargo-check.yaml
+++ b/tasks/managed/embargo-check/embargo-check.yaml
@@ -129,7 +129,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: check-issues
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
       computeResources:
         limits:
           memory: 64Mi
@@ -190,8 +190,11 @@ spec:
             set +x # We don't want to leak the ACCESS_TOKEN
             if [ "$server" = "redhat.atlassian.net" ] ; then
                 AUTH_ARGS=(-u "${EMAIL}:${ACCESS_TOKEN}")
+                # Retry flaky 404s from Jira Cloud (same response as permission denied); opt-in via utils script.
+                OUTPUT=$(CURL_WITH_RETRY_RETRY_404=1 curl-with-retry --retry 3 "${AUTH_ARGS[@]}" "${API_URL}")
+            else
+                OUTPUT=$(curl-with-retry --retry 3 "${AUTH_ARGS[@]}" "${API_URL}")
             fi
-            OUTPUT=$(curl-with-retry --retry 3 "${AUTH_ARGS[@]}" "${API_URL}")
             CURL_RC=$?
             set -x
             if [ "$CURL_RC" -ne 0 ] ; then
@@ -260,7 +263,7 @@ spec:
         fi
         exit $RC
     - name: check-cves
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/embargo-check/tests/mocks.sh
+++ b/tasks/managed/embargo-check/tests/mocks.sh
@@ -6,6 +6,7 @@ function curl-with-retry() {
   echo Mock curl called with: $* >&2
   mkdir -p "$(params.dataDir)"
   echo $* >> "$(params.dataDir)/mock_curl.txt"
+  echo "${CURL_WITH_RETRY_RETRY_404:-}" >> "$(params.dataDir)/mock_curl_retry404.txt"
 
   if [[ "$*" == "--retry 3 https://jira.atlassian.com/rest/api/2/issue/ISSUE-123" ]]
   then

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-cve.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-embargoed-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-fail-no-data-json.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-ir-failure.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-jira-conversion.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-jira-conversion.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-no-release-notes.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-non-vuln-rh-issue.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -141,7 +141,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-nonexistent-rh-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-cves.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-issues.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -141,7 +141,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-public-key-added.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -174,7 +174,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -177,5 +177,8 @@ spec:
 
               [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"VULN-123"* ]]
               [[ $(tail -n 1 "$(params.dataDir)/mock_curl.txt") == *"12345"* ]]
+
+              [[ $(head -n 1 "$(params.dataDir)/mock_curl_retry404.txt") == "1" ]]
+              [[ $(grep -c . "$(params.dataDir)/mock_curl_retry404.txt") -eq 1 ]]
       runAfter:
         - run-task

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue-missing-cve.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
+++ b/tasks/managed/embargo-check/tests/test-embargo-check-rh-issue.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:0e30ef7b9cf668e8691ae55d04766ae9b8ca2be7e0fa9233227689c1d60a1b96
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -177,5 +177,10 @@ spec:
 
               [[ $(head -n 1 "$(params.dataDir)/mock_curl.txt") == *"VULN-123"* ]]
               [[ $(tail -n 1 "$(params.dataDir)/mock_curl.txt") == *"12345"* ]]
+
+              # Authenticated redhat.atlassian.net issue fetch should enable 404 retry; unauthenticated
+              # checks (and non-Cloud Jira) should not leave the flag set.
+              [[ $(head -n 1 "$(params.dataDir)/mock_curl_retry404.txt") == "1" ]]
+              [[ $(grep -c . "$(params.dataDir)/mock_curl_retry404.txt") -eq 1 ]]
       runAfter:
         - run-task


### PR DESCRIPTION
## Describe your changes

Jira issue GET can intermittently return 404 on Atlassian Cloud even when the issue exists and the token is valid. Add retry via CURL_WITH_RETRY_RETRY_404

## Relevant Jira

RELEASE-2386

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
