### PR TITLE
fix(RELEASE-2397): custom CA support for self-hosted registries

### DIFF
--- a/stepactions/create-trusted-artifact-array/create-trusted-artifact-array.yaml
+++ b/stepactions/create-trusted-artifact-array/create-trusted-artifact-array.yaml
@@ -7,7 +7,7 @@ spec:
   description: >-
     This stepaction creates trusted artifacts. It does nothing if a .skip-trusted-artifacts file exists
     in root folder.
-  image: quay.io/konflux-ci/build-trusted-artifacts:653578444c73afc32b3a865fee9869a09f96c1a2
+  image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME
@@ -23,8 +23,8 @@ spec:
       default: []
     - name: caCertPath
       type: string
-      default: "/etc/pki/tls/certs/ca-bundle.crt"
-      description: Path to CA certificate bundle for TLS verification with self-signed certificates
+      default: "/mnt/trusted-ca/ca-bundle.crt"
+      description: Path to CA certificate bundle for TLS verification with self-hosted certificates
   args:
     - create
     - --store

--- a/stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+++ b/stepactions/create-trusted-artifact/create-trusted-artifact.yaml
@@ -7,7 +7,7 @@ spec:
   description: >-
     This stepaction creates a trusted artifact. It does nothing if a .skip-trusted-artifacts file exists
     in root folder.
-  image: quay.io/konflux-ci/build-trusted-artifacts:8b09217702ec665d4fae6d09f6a7910421f15b69
+  image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME
@@ -31,8 +31,8 @@ spec:
       description: oras options to pass to Trusted Artifacts calls
     - name: caCertPath
       type: string
-      default: "/etc/pki/tls/certs/ca-bundle.crt"
-      description: Path to CA certificate bundle for TLS verification with self-signed certificates
+      default: "/mnt/trusted-ca/ca-bundle.crt"
+      description: Path to CA certificate bundle for TLS verification with self-hosted certificates
   args:
     - create
     - --store

--- a/stepactions/use-trusted-artifact-array/use-trusted-artifact-array.yaml
+++ b/stepactions/use-trusted-artifact-array/use-trusted-artifact-array.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: >-
     This stepaction extracts an array of Trusted Artifacts into a folder.
-  image: quay.io/konflux-ci/build-trusted-artifacts:8b09217702ec665d4fae6d09f6a7910421f15b69
+  image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME
@@ -20,8 +20,8 @@ spec:
       default: []
     - name: caCertPath
       type: string
-      default: "/etc/pki/tls/certs/ca-bundle.crt"
-      description: Path to CA certificate bundle for TLS verification with self-signed certificates
+      default: "/mnt/trusted-ca/ca-bundle.crt"
+      description: Path to CA certificate bundle for TLS verification with self-hosted certificates
   args:
     - use
     - "$(params.sourceDataArtifacts[*])"

--- a/stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+++ b/stepactions/use-trusted-artifact/use-trusted-artifact.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: >-
     This stepaction extracts a Trusted Artifact into a folder.
-  image: quay.io/konflux-ci/build-trusted-artifacts:8b09217702ec665d4fae6d09f6a7910421f15b69
+  image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
   env:
     # Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
     - name: HOME
@@ -27,8 +27,8 @@ spec:
       description: oras options to pass to Trusted Artifacts calls
     - name: caCertPath
       type: string
-      default: "/etc/pki/tls/certs/ca-bundle.crt"
-      description: Path to CA certificate bundle for TLS verification with self-signed certificates
+      default: "/mnt/trusted-ca/ca-bundle.crt"
+      description: Path to CA certificate bundle for TLS verification with self-hosted certificates
   args:
     - use
     - $(params.sourceDataArtifact)=$(params.workDir)

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -163,6 +163,10 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
+        if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
+            export SSL_CERT_FILE="/mnt/trusted-ca/ca-bundle.crt"
+        fi
+
         SNAPSHOT_SPEC_FILE="$(params.dataDir)/$(params.snapshotPath)"
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         SNAPSHOT_SPEC_FILE_ORIG="${SNAPSHOT_SPEC_FILE}.orig"

--- a/tasks/managed/check-data-keys/check-data-keys.yaml
+++ b/tasks/managed/check-data-keys/check-data-keys.yaml
@@ -141,6 +141,10 @@ spec:
         #!/usr/bin/env bash
         set -ex
 
+        if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
+            export SSL_CERT_FILE="/mnt/trusted-ca/ca-bundle.crt"
+        fi
+
         if [ ! -f "$(params.dataDir)/$(params.dataPath)" ] ; then
             echo "No data JSON was provided."
             exit 1

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -174,6 +174,10 @@ spec:
         #!/usr/bin/env bash
         set -eo pipefail
 
+        if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
+            export SSL_CERT_FILE="/mnt/trusted-ca/ca-bundle.crt"
+        fi
+
         set -x
         echo -n "$(params.subdirectory)" > "$(results.subdirectory.path)"
 

--- a/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
+++ b/tasks/managed/filter-already-released-images/filter-already-released-images.yaml
@@ -138,6 +138,10 @@ spec:
         #!/usr/bin/env bash
         set -eux
 
+        if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
+            export SSL_CERT_FILE="/mnt/trusted-ca/ca-bundle.crt"
+        fi
+
         SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
 
         if [ ! -f "${SNAPSHOT_FILE}" ]; then

--- a/tasks/managed/make-repo-public/make-repo-public.yaml
+++ b/tasks/managed/make-repo-public/make-repo-public.yaml
@@ -136,6 +136,12 @@ spec:
         #!/usr/bin/env bash
         set -eu
 
+        if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
+            COMBINED_CA="/tmp/combined-ca-bundle.crt"
+            { cat /etc/pki/tls/certs/ca-bundle.crt; echo; cat /mnt/trusted-ca/ca-bundle.crt; } > "$COMBINED_CA"
+            export SSL_CERT_FILE="$COMBINED_CA"
+        fi
+
         REGISTRY_TOKEN="$(cat /etc/secrets/token)"
 
         set -x

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -140,6 +140,10 @@ spec:
         #!/usr/bin/env bash
         set -eux
 
+        if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
+            export SSL_CERT_FILE="/mnt/trusted-ca/ca-bundle.crt"
+        fi
+
         push_image () { # Expected arguments are [origin_digest, name, containerImage, repository, tag, platform]
           # note: Inspection might fail on empty repos, hence `|| true`
 

--- a/tasks/managed/sign-image-cosign-keyless/README.md
+++ b/tasks/managed/sign-image-cosign-keyless/README.md
@@ -4,23 +4,23 @@ Tekton task to sign container images in snapshot by cosign in keyless mode
 
 ## Parameters
 
-| Name                    | Description                                                                                                                | Optional | Default value                    |
-|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------------------|
-| snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                                |
-| retries                 | Retry cosign N times                                                                                                       | Yes      | 3                                |
-| concurrentLimit         | The maximum number of concurrent cosign signing jobs                                                                       | Yes      | 90                               |
-| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                            |
-| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                               |
-| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                               |
-| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                               |
-| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                               |
-| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release             |
-| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                                |
-| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                                |
-| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca                       |
-| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt                    |
-| caCertPath              | Path to CA certificate bundle for TLS verification with self-signed certificates                                           | Yes      | /etc/pki/tls/certs/ca-bundle.crt |
-| keylessOIDCIssuer       | OIDC issuer for keyless signing                                                                                            | No       | -                                |
-| keylessFulcioURL        | Fulcio URL for keyless signing                                                                                             | No       | -                                |
-| keylessRekorURL         | rekor URL for keyless signing                                                                                              | No       | -                                |
-| keylessTufURL           | TUF URL for keyless signing                                                                                                | No       | -                                |
+| Name                    | Description                                                                                                                | Optional | Default value                 |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|-------------------------------|
+| snapshotPath            | Path to the JSON string of the mapped Snapshot spec in the data workspace                                                  | No       | -                             |
+| retries                 | Retry cosign N times                                                                                                       | Yes      | 3                             |
+| concurrentLimit         | The maximum number of concurrent cosign signing jobs                                                                       | Yes      | 90                            |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                         |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                            |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes      | ""                            |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                                            | Yes      | ""                            |
+| sourceDataArtifact      | Location of trusted artifacts to be used to populate data directory                                                        | Yes      | ""                            |
+| dataDir                 | The location where data will be stored                                                                                     | Yes      | /var/workdir/release          |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored                      | No       | -                             |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                                             | No       | -                             |
+| caTrustConfigMapName    | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca                    |
+| caTrustConfigMapKey     | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt                 |
+| caCertPath              | Path to CA certificate bundle for TLS verification with self-hosted certificates                                           | Yes      | /mnt/trusted-ca/ca-bundle.crt |
+| keylessOIDCIssuer       | OIDC issuer for keyless signing                                                                                            | No       | -                             |
+| keylessFulcioURL        | Fulcio URL for keyless signing                                                                                             | No       | -                             |
+| keylessRekorURL         | rekor URL for keyless signing                                                                                              | No       | -                             |
+| keylessTufURL           | TUF URL for keyless signing                                                                                                | No       | -                             |

--- a/tasks/managed/sign-image-cosign-keyless/sign-image-cosign-keyless.yaml
+++ b/tasks/managed/sign-image-cosign-keyless/sign-image-cosign-keyless.yaml
@@ -62,8 +62,8 @@ spec:
       default: ca-bundle.crt
     - name: caCertPath
       type: string
-      description: Path to CA certificate bundle for TLS verification with self-signed certificates
-      default: /etc/pki/tls/certs/ca-bundle.crt
+      description: Path to CA certificate bundle for TLS verification with self-hosted certificates
+      default: /mnt/trusted-ca/ca-bundle.crt
     - name: keylessOIDCIssuer
       type: string
       description: OIDC issuer for keyless signing
@@ -154,6 +154,10 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -eu
+
+        if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
+            export SSL_CERT_FILE="/mnt/trusted-ca/ca-bundle.crt"
+        fi
 
         REKOR_URL="$(params.keylessRekorURL)"
         FULCIO_URL="$(params.keylessFulcioURL)"


### PR DESCRIPTION
## Describe your changes

Export SSL_CERT_FILE in tasks using cosign, skopeo, oras, and curl to support custom CA certificates for self-hosted registries in the push-to-external-registry pipeline.

Changes:
- Update stepactions to use new build-trusted-artifacts image
- Change default caCertPath from /etc/pki/tls/certs/ca-bundle.crt to /mnt/trusted-ca/ca-bundle.crt across all stepactions
- Export SSL_CERT_FILE=/mnt/trusted-ca/ca-bundle.crt in tasks: apply-mapping, check-data-keys, collect-data, filter-already-released-images, push-snapshot, sign-image-cosign-keyless
- Use combined CA file for make-repo-public (curl requires it)
- Streamline sign-image-cosign-keyless to match other tasks

The SSL_CERT_FILE approach is additive for cosign/skopeo/oras (system CA still used), but combined for curl in make-repo-public.

Related build-trusted-artifacts PR: https://github.com/konflux-ci/build-trusted-artifacts/pull/315

## Relevant Jira

RELEASE-2397

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
