### PR TITLE
feat: add SBOM upload to Atlas/TPA in calunga release pipeline

### DIFF
--- a/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
@@ -125,6 +125,30 @@ spec:
         - name: ociStorage
           value: $(tasks.config.results.ociStorage)
 
+    - name: collect-atlas-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-tpa-params/collect-tpa-params.yaml
+      params:
+        - name: dataPath
+          value: $(tasks.collect-data.results.data)
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      runAfter:
+        - collect-data
+
     # TODO: We probably don't need to support single component mode.
     - name: reduce-snapshot
       taskRef:
@@ -220,6 +244,37 @@ spec:
           value: $(tasks.collect-data.results.data)
       runAfter:
         - verify-enterprise-contract
+
+    - name: upload-sboms-to-atlas
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/extract-and-upload-python-wheel-sboms-to-atlas.yaml
+      params:
+        - name: atlasApiUrl
+          value: "$(tasks.collect-atlas-params.results.atlasApiUrl)"
+        - name: ssoTokenUrl
+          value: "$(tasks.collect-atlas-params.results.ssoTokenUrl)"
+        - name: atlasSecretName
+          value: "$(tasks.collect-atlas-params.results.secretName)"
+        - name: sourceDataArtifact
+          value: "$(tasks.extract-py-artifacts.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: dataDir
+          value: /var/workdir/content
+      runAfter:
+        - extract-py-artifacts
+        - collect-atlas-params
 
     - name: rh-sign-python-wheels
       timeout: "2h00m0s"

--- a/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/README.md
+++ b/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/README.md
@@ -1,0 +1,21 @@
+# extract-and-upload-python-wheel-sboms-to-atlas
+
+Extract Fromager-generated SBOMs from Python wheels and upload them to
+Atlas (TPA) using the Mobster CLI
+
+## Parameters
+
+| Name                    | Description                                                                                           | Optional | Default value        |
+|-------------------------|-------------------------------------------------------------------------------------------------------|----------|----------------------|
+| atlasApiUrl             | URL of the Atlas/TPA API server                                                                       | No       | -                    |
+| ssoTokenUrl             | URL of the SSO token issuer for TPA authentication                                                    | No       | -                    |
+| atlasSecretName         | Name of the K8s secret containing TPA SSO credentials (keys sso_account, sso_token)                   | No       | -                    |
+| sourceDataArtifact      | Trusted Artifact containing the extracted wheels and release data                                     | No       | -                    |
+| dataDir                 | The location where data will be stored                                                                | Yes      | /var/workdir/content |
+| filesDir                | The relative path within dataDir where wheel files are located                                        | Yes      | files                |
+| taskGitUrl              | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | No       | -                    |
+| taskGitRevision         | The revision in the taskGitUrl repo to be used                                                        | No       | -                    |
+| ociStorage              | The OCI repository where the Trusted Artifacts are stored                                             | No       | -                    |
+| ociArtifactExpiresAfter | Expiration date for the trusted artifacts created                                                     | Yes      | 1d                   |
+| orasOptions             | oras options to pass to Trusted Artifacts calls                                                       | Yes      | ""                   |
+| trustedArtifactsDebug   | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                | Yes      | ""                   |

--- a/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/extract-and-upload-python-wheel-sboms-to-atlas.yaml
+++ b/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/extract-and-upload-python-wheel-sboms-to-atlas.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: extract-and-upload-python-wheel-sboms-to-atlas
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+    Extract Fromager-generated SBOMs from Python wheels and upload them to
+    Atlas (TPA) using the Mobster CLI
+  params:
+    - name: atlasApiUrl
+      type: string
+      description: URL of the Atlas/TPA API server
+    - name: ssoTokenUrl
+      type: string
+      description: URL of the SSO token issuer for TPA authentication
+    - name: atlasSecretName
+      type: string
+      description: Name of the K8s secret containing TPA SSO credentials (keys sso_account, sso_token)
+    - name: sourceDataArtifact
+      type: string
+      description: Trusted Artifact containing the extracted wheels and release data
+    - name: dataDir
+      type: string
+      description: The location where data will be stored
+      default: /var/workdir/content
+    - name: filesDir
+      type: string
+      description: The relative path within dataDir where wheel files are located
+      default: files
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored
+    - name: ociArtifactExpiresAfter
+      type: string
+      description: Expiration date for the trusted artifacts created
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: atlas-secret
+      secret:
+        secretName: $(params.atlasSecretName)
+        defaultMode: 0444
+  stepTemplate:
+    securityContext:
+      runAsUser: 1001
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+    volumeMounts:
+      - name: workdir
+        mountPath: /var/workdir
+  steps:
+    - name: prepare-workdir
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 32Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
+      command:
+        - mkdir
+        - -p
+        - $(params.dataDir)
+
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 10m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+
+    - name: extract-sboms-from-wheels
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      env:
+        - name: WHEELS_DIR
+          value: $(params.dataDir)/$(params.filesDir)
+        - name: SBOMS_DIR
+          value: $(params.dataDir)/sboms
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        mkdir -p "${SBOMS_DIR}"
+        found=0
+
+        for wheel in "${WHEELS_DIR}"/*.whl; do
+          [ -f "$wheel" ] || continue
+          wheel_name=$(basename "$wheel" .whl)
+
+          # Wheels are zip archives; list SBOM files inside .dist-info/sboms/
+          sbom_paths=$(unzip -l "$wheel" 2>/dev/null \
+            | grep -o '[^ ]*\.dist-info/sboms/[^ ]*[^/]' || true)
+
+          if [ -z "$sbom_paths" ]; then
+            echo "  No SBOMs found in ${wheel_name}"
+            continue
+          fi
+
+          while IFS= read -r sbom_path; do
+            sbom_filename=$(basename "$sbom_path")
+            output_name="${wheel_name}-${sbom_filename}"
+            unzip -p "$wheel" "$sbom_path" > "${SBOMS_DIR}/${output_name}"
+            echo "  Extracted ${sbom_path} -> ${output_name}"
+            found=$((found + 1))
+          done <<< "$sbom_paths"
+        done
+
+        if [ "$found" -eq 0 ]; then
+          echo "ERROR: No SBOMs found in any wheel"
+          exit 1
+        fi
+
+        echo ""
+        echo "Extracted ${found} SBOM(s):"
+        ls -la "${SBOMS_DIR}"
+
+    - name: upload-sboms-to-atlas
+      image: quay.io/konflux-ci/mobster@sha256:3584f2cbcfee9d9eec0c6d34309d6c436a347f303e697f888b7bdf693b515908
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      volumeMounts:
+        - name: atlas-secret
+          mountPath: /etc/atlas-secret
+          readOnly: true
+      env:
+        - name: MOBSTER_TPA_SSO_TOKEN_URL
+          value: $(params.ssoTokenUrl)
+        - name: SBOMS_DIR
+          value: $(params.dataDir)/sboms
+        - name: ATLAS_API_URL
+          value: $(params.atlasApiUrl)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [ ! -f /etc/atlas-secret/sso_account ] || [ ! -f /etc/atlas-secret/sso_token ]; then
+          echo "ERROR: Atlas secret not found or missing keys (sso_account, sso_token)"
+          exit 1
+        fi
+        MOBSTER_TPA_SSO_ACCOUNT="$(cat /etc/atlas-secret/sso_account)"
+        MOBSTER_TPA_SSO_TOKEN="$(cat /etc/atlas-secret/sso_token)"
+        export MOBSTER_TPA_SSO_ACCOUNT MOBSTER_TPA_SSO_TOKEN
+
+        sbom_count=$(find "${SBOMS_DIR}" -name '*.json' | wc -l)
+        if [ "$sbom_count" -eq 0 ]; then
+          echo "ERROR: No SBOMs found in ${SBOMS_DIR}"
+          exit 1
+        fi
+
+        echo "Uploading ${sbom_count} SBOM(s) to Atlas at ${ATLAS_API_URL}..."
+        mobster upload tpa \
+          --tpa-base-url "${ATLAS_API_URL}" \
+          --from-dir "${SBOMS_DIR}" \
+          --report \
+          --retries 3
+
+        echo "SBOM upload complete."

--- a/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/tests/mocks.sh
+++ b/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/tests/mocks.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -eux
+
+MOCK_LOG="${MOCK_LOG:-/tmp/mock_calls.txt}"
+
+function unzip() {
+  echo "Mock unzip called with: $*" >&2
+  echo "unzip $*" >> "${MOCK_LOG}"
+
+  if [[ "$1" == "-l" ]]; then
+    local wheel="$2"
+    local wheel_base
+    wheel_base=$(basename "$wheel" .whl)
+    cat <<LISTING
+Archive:  $wheel
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+     2048  2026-04-13 10:00   ${wheel_base}.dist-info/sboms/sbom.spdx.json
+---------                     -------
+     2048                     1 file
+LISTING
+    return 0
+  fi
+
+  if [[ "$1" == "-p" ]]; then
+    cat <<'SBOM'
+{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"test-sbom","documentNamespace":"https://example.com/test","creationInfo":{"creators":["Organization: Red Hat"]}}
+SBOM
+    return 0
+  fi
+
+  echo "ERROR: unexpected unzip command: $*" >&2
+  exit 1
+}
+
+function mobster() {
+  echo "Mock mobster called with: $*" >&2
+  echo "mobster $*" >> "${MOCK_LOG}"
+
+  if [[ "$1" == "upload" && "$2" == "tpa" ]]; then
+    echo "Mock upload to TPA successful" >&2
+    return 0
+  fi
+
+  echo "ERROR: unexpected mobster command: $*" >&2
+  exit 1
+}

--- a/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/tests/pre-apply-task-hook.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Create mock Atlas secret so the volume mount doesn't fail
+kubectl create secret generic mock-atlas-secret \
+    --from-literal=sso_account=mock-sso-account \
+    --from-literal=sso_token=mock-sso-token \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# Steps layout:
+#   [0] prepare-workdir (command - no mock needed)
+#   [1] use-trusted-artifact (StepAction ref - no mock needed)
+#   [2] extract-sboms-from-wheels (script - needs unzip mock)
+#   [3] upload-sboms-to-atlas (script - needs mobster mock)
+
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"
+yq -i '.spec.steps[3].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[3].script' "$TASK_PATH"

--- a/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/tests/test-upload-sboms-to-atlas.yaml
+++ b/tasks/managed/extract-and-upload-python-wheel-sboms-to-atlas/tests/test-upload-sboms-to-atlas.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-upload-sboms-to-atlas
+spec:
+  description: Test extracting SBOMs from wheels and uploading to Atlas
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: /var/workdir/content
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:2f9e6863e82bbc9ddce5a290f3fd0e87657c475e3de8a832b2ef7f8d0671e7d3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              mkdir -p "$(params.dataDir)/files"
+
+              # Create a mock snapshot spec
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << 'EOF'
+              {
+                "application": "calunga-v2-index-main",
+                "components": [
+                  {
+                    "name": "test-wheel-component",
+                    "containerImage": "quay.io/test/test-package@sha256:abc123"
+                  }
+                ]
+              }
+              EOF
+
+              # Create mock release data
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "releaseNotes": {
+                  "product_id": [1054],
+                  "product_name": "trusted libraries",
+                  "product_version": "1.0"
+                },
+                "atlas": {
+                  "server": "production"
+                }
+              }
+              EOF
+
+              # Create a mock wheel file (just needs to exist for the glob;
+              # unzip is mocked to return SBOM contents)
+              echo "mock-wheel-content" > "$(params.dataDir)/files/test_package-1.0.0-py3-none-any.whl"
+
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+
+    - name: run-task
+      taskRef:
+        name: extract-and-upload-python-wheel-sboms-to-atlas
+      params:
+        - name: atlasApiUrl
+          value: "https://mock-atlas.example.com"
+        - name: ssoTokenUrl
+          value: "https://mock-sso.example.com/token"
+        - name: atlasSecretName
+          value: "mock-atlas-secret"
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: filesDir
+          value: files
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup


### PR DESCRIPTION
## Describe your changes
Integrate Mobster CLI into the calunga-push-to-pulp pipeline to extract Fromager-generated SBOMs from Python wheels & upload them to the Atlas release instance, as required by Product Security.

## Relevant Jira
CALUNGA-232

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
