### PR TITLE
fix(RELEASE-2407): populate advisory URL on idempotent re-release

### DIFF
--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -5,6 +5,19 @@ This is a copy of v3.0.0 of the rh-push-to-registry-redhat-io pipeline, but with
 tasks added in. The plan is for this pipeline to eventually be deleted and take the place of
 the rh-push-to-registry-redhat-io pipeline.
 
+## Idempotent re-release behavior
+
+When the same snapshot is released a second time, the filter-already-released-advisory-images
+task detects that all images are already published in an existing advisory and sets
+skip_release=true. In this case all normal release tasks (signing, pushing, advisory creation,
+etc.) are skipped.
+
+To ensure release.status.artifacts.advisory.url is still populated after an idempotent
+re-release, the pipeline includes a dedicated update-cr-status-skipped task that runs only
+when skip_release=true. It reads the advisory URL written to the results directory by
+filter-already-released-advisory-images and patches the Release CR status in the same way
+the normal update-cr-status task does on the first release.
+
 ## Parameters
 
 | Name                            | Description                                                                                                                        | Optional | Default value                                             |

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -12,6 +12,19 @@ spec:
     This is a copy of v3.0.0 of the rh-push-to-registry-redhat-io pipeline, but with the advisory
     tasks added in. The plan is for this pipeline to eventually be deleted and take the place of
     the rh-push-to-registry-redhat-io pipeline.
+
+    ## Idempotent re-release behavior
+
+    When the same snapshot is released a second time, the filter-already-released-advisory-images
+    task detects that all images are already published in an existing advisory and sets
+    skip_release=true. In this case all normal release tasks (signing, pushing, advisory creation,
+    etc.) are skipped.
+
+    To ensure release.status.artifacts.advisory.url is still populated after an idempotent
+    re-release, the pipeline includes a dedicated update-cr-status-skipped task that runs only
+    when skip_release=true. It reads the advisory URL written to the results directory by
+    filter-already-released-advisory-images and patches the Release CR status in the same way
+    the normal update-cr-status task does on the first release.
   params:
     - name: release
       type: string
@@ -1120,6 +1133,41 @@ spec:
             value: tasks/managed/update-cr-status/update-cr-status.yaml
       runAfter:
         - create-advisory
+    - name: update-cr-status-skipped
+      when:
+        - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
+          operator: in
+          values: ["true"]
+      params:
+        - name: resource
+          value: $(params.release)
+        - name: resultsDirPath
+          value: $(tasks.collect-data.results.resultsDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: resultArtifacts
+          value:
+            - "$(tasks.filter-already-released-advisory-images.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/update-cr-status/update-cr-status.yaml
+      runAfter:
+        - filter-already-released-advisory-images
+        - collect-data
   finally:
     - name: cleanup-internal-requests
       taskRef:

--- a/tasks/managed/update-cr-status/tests/test-update-cr-status-advisory-from-filter.yaml
+++ b/tasks/managed/update-cr-status/tests/test-update-cr-status-advisory-from-filter.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-cr-status-advisory-from-filter
+spec:
+  description: |
+    Run the update-cr-status task with a single resultArtifact that contains only
+    the filter-already-released-advisory-images results file — the same setup used
+    by the update-cr-status-skipped pipeline task on the idempotent re-release path
+    (skip_release=true). The task should patch the Release CR status with
+    advisory.url and advisory.internal_url.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              RESULTS_DIR="$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              mkdir -p "$RESULTS_DIR"
+
+              # Simulate the results file written by filter-already-released-advisory-images
+              # when all snapshot images are already published in an existing advisory
+              FILTER_RESULTS="$RESULTS_DIR/filter-already-released-advisory-images-results.json"
+              cat > "$FILTER_RESULTS" << EOF
+              {
+                  "advisory": {
+                      "url": "https://access.redhat.com/errata/RHSA-2024:12345",
+                      "internal_url": "https://errata.devel.redhat.com/advisory/12345"
+                  }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release" << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-cr-status-advisory
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f "$(params.dataDir)/$(context.pipelineRun.uid)/release"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: update-cr-status
+      params:
+        - name: resource
+          value: default/release-cr-status-advisory
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: resultArtifacts
+          value:
+            - "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that Release.Status contains advisory.url from the filter task results
+              test "$(kubectl get release release-cr-status-advisory -n default \
+                -o jsonpath='{.status.artifacts.advisory.url}')" \
+                == "https://access.redhat.com/errata/RHSA-2024:12345"
+
+              echo Test that Release.Status contains advisory.internal_url from the filter task results
+              test "$(kubectl get release release-cr-status-advisory -n default \
+                -o jsonpath='{.status.artifacts.advisory.internal_url}')" \
+                == "https://errata.devel.redhat.com/advisory/12345"
+      runAfter:
+        - run-task
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete release release-cr-status-advisory


### PR DESCRIPTION
## Describe your changes
When all snapshot images are already published in an advisory (skip_release=true), the update-cr-status task was skipped, leaving release.status.artifacts.advisory.url unpopulated on the second release.

This fix adds an update-cr-status-skipped task to the rh-advisories pipeline that runs only when skip_release=true, reading the advisory URL resolved by filter-already-released-advisory-images and patching the release CR status accordingly. 

## Relevant Jira
[RELEASE-2407](https://redhat.atlassian.net/browse/RELEASE-2407)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`

Assisted-by: Claude

[RELEASE-2407]: https://redhat.atlassian.net/browse/RELEASE-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ