### PR TITLE
test(RELEASE-2325): add idempotent retrigger e2e test for rh-advisories

### DIFF
--- a/.tekton/release-service-catalog-pull-request.yaml
+++ b/.tekton/release-service-catalog-pull-request.yaml
@@ -118,6 +118,7 @@ spec:
     - default: ""
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+      type: string
     - default: "false"
       description: Build a source image.
       name: build-source-image

--- a/.tekton/release-service-catalog-push.yaml
+++ b/.tekton/release-service-catalog-push.yaml
@@ -113,6 +113,7 @@ spec:
     - default: ""
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
+      type: string
     - default: "false"
       description: Build a source image.
       name: build-source-image

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -7,6 +7,8 @@ This directory contains end-to-end integration tests for the Release Service Cat
 The following integration test suites are available:
 
 - **[collectors](collectors/)** - Tests for advisory data collection and processing
+- **[collectors-no-cve](collectors-no-cve/)** - Tests for the no-CVE path of advisory data collection
+- **[rh-advisories-idempotent](rh-advisories-idempotent/)** - Tests idempotent re-release behavior for the rh-advisories pipeline: verifies that a second release with the same snapshot detects the existing advisory, skips all downstream tasks, and correctly populates `advisory.url` in the Release CR status
 - **[fbc-release](fbc-release/)** - Tests for File-Based Catalog (FBC) release pipeline
 - **[push-to-addons-registry](push-to-addons-registry/)** - Tests for pushing to addon registries
 - **[rh-push-helm-chart-to-registry-redhat-io](rh-push-helm-chart-to-registry-redhat-io/)** - Tests for Helm OCI chart release pipeline

--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -905,6 +905,60 @@ cleanup_old_resources() {
     set -e
 }
 
+# --- Release / PipelineRun Query Helpers ---
+# These helpers are available to all test suites via this shared library.
+
+# Return the short PipelineRun name (no namespace prefix) for the managed
+# pipeline associated with a Release CR.
+get_pipelinerun_name_from_release() {
+    local release_name=$1
+
+    local pipelinerun_full
+    pipelinerun_full=$(kubectl get release "${release_name}" -n "${tenant_namespace}" \
+        -o jsonpath='{.status.managedProcessing.pipelineRun}')
+
+    if [ -z "${pipelinerun_full}" ]; then
+        return 1
+    fi
+
+    basename "${pipelinerun_full}"
+}
+
+# Return the full Release CR as JSON.
+get_release_json() {
+    local release_name=$1
+    kubectl get release "${release_name}" -n "${tenant_namespace}" -o json
+}
+
+# Return 0 (true) if the named task appears in the PipelineRun's skippedTasks
+# list, 1 (false) otherwise.
+is_task_skipped() {
+    local release_name=$1
+    local task_name=$2
+
+    local pipelinerun_name
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || return 1
+
+    local skipped_task
+    skipped_task=$(kubectl get pipelinerun "${pipelinerun_name}" -n "${managed_namespace}" \
+        -o jsonpath="{.status.skippedTasks[?(@.name=='${task_name}')].name}")
+
+    [[ -n "${skipped_task}" ]]
+}
+
+# Return the value of a named pipeline-level result from the managed PipelineRun
+# associated with a Release CR.
+get_pipelinerun_result() {
+    local release_name=$1
+    local result_name=$2
+
+    local pipelinerun_name
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || return 1
+
+    kubectl get pipelinerun "${pipelinerun_name}" -n "${managed_namespace}" \
+        -o jsonpath="{.status.results[?(@.name=='${result_name}')].value}"
+}
+
 # Function to verify Release contents
 verify_release_contents() {
     echo "📝 Note: Test Suite may implement ${FUNCNAME[0]}" \

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -108,7 +108,7 @@ spec:
               success_test_cases=()
 
               ALL_TESTCASES=("collectors" "collectors-no-cve" "e2e" "fbc-release" "push-rpms-to-pulp" \
-                "push-to-addons-registry" "push-to-external-registry-idempotent" \
+                "push-to-addons-registry" "push-to-external-registry-idempotent" "rh-advisories-idempotent" \
                 "push-to-external-registry" "release-to-github" "rh-push-helm-chart-to-registry-redhat-io" \
                 "rh-push-to-external-registry" "rh-push-to-external-registry-multi-component" \
                 "rh-push-to-registry-redhat-io" "rhtap-service-push")

--- a/integration-tests/push-to-external-registry-idempotent/test.sh
+++ b/integration-tests/push-to-external-registry-idempotent/test.sh
@@ -13,55 +13,13 @@
 # --- Global Script Variables (Defaults) ---
 CLEANUP="true"
 
-# Helper: Get PipelineRun name from Release CR
-# Returns just the PipelineRun name (without namespace prefix)
-get_pipelinerun_name_from_release() {
-    local release_name=$1
-
-    # Get the actual PipelineRun name from the Release CR
-    # Format is: namespace/name, we need just the name part
-    local pipelinerun_full
-    pipelinerun_full=$(kubectl get release "${release_name}" -n "${tenant_namespace}" \
-        -o jsonpath='{.status.managedProcessing.pipelineRun}' 2>/dev/null)
-
-    if [ -z "${pipelinerun_full}" ]; then
-        return 1
-    fi
-
-    # Extract and return just the name part after the /
-    basename "${pipelinerun_full}"
-}
-
-# Helper: Get release as JSON
-get_release_json() {
-    local release_name=$1
-    kubectl get release "${release_name}" -n "${tenant_namespace}" -o json
-}
-
 # Check if all components were filtered (idempotency validation)
 # Returns 0 (true) if push-snapshot task was skipped, 1 (false) otherwise
 were_all_components_filtered() {
     local release_name=$1
 
     # Check if all components were filtered by seeing if push-snapshot was skipped
-    is_taskrun_skipped "${release_name}" "push-snapshot"
-}
-
-# Check if a specific task was skipped in the pipeline
-# Returns 0 (true) if task was skipped, 1 (false) otherwise
-is_taskrun_skipped() {
-    local release_name=$1
-    local task_name=$2
-
-    local pipelinerun_name
-    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || return 1
-
-    # Check if task appears in PipelineRun's skippedTasks list
-    local skipped_task
-    skipped_task=$(kubectl get pipelinerun "${pipelinerun_name}" -n "${managed_namespace}" \
-        -o jsonpath="{.status.skippedTasks[?(@.name=='${task_name}')].name}" 2>/dev/null)
-
-    [[ -n "${skipped_task}" ]]
+    is_task_skipped "${release_name}" "push-snapshot"
 }
 
 # Verify a single release has valid artifacts and image can be pulled

--- a/integration-tests/rh-advisories-idempotent/README.md
+++ b/integration-tests/rh-advisories-idempotent/README.md
@@ -1,0 +1,95 @@
+# rh-advisories-idempotent test
+
+## Overview
+
+This test validates idempotent re-release behavior for the `rh-advisories` pipeline:
+
+1. **First release**: all tasks run, advisory created (`skip_release=false`)
+2. **Second release** (same snapshot): `filter-already-released-advisory-images` detects the
+   existing advisory in Pyxis → `skip_release=true`
+3. All downstream tasks are skipped; release CR still reaches `Released=True`
+4. `advisory.url` is present in second release status (populated from filter result,
+   not from `create-advisory`)
+
+## Setup
+
+### Dependencies
+* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
+* GitHub personal access token (classic) for above repo with **admin:repo_hook**,
+  **delete_repo**, **repo** scopes.
+* The password to the vault files. (Contact a member of the Release team should you
+  want to run this test suite.)
+* Access to the target cluster and tenant and managed namespaces
+  * **Cluster:** stg-rh01 (staging cluster)
+  * **Tenant Namespace:** `dev-release-team-tenant` (local) or `rhtap-release-2-tenant` (PaC)
+  * **Managed Namespace:** `managed-release-team-tenant`
+
+### Required Environment Variables
+- `GITHUB_TOKEN` - GitHub personal access token
+- `VAULT_PASSWORD_FILE` - Path to file containing ansible vault password
+- `RELEASE_CATALOG_GIT_URL` - Release service catalog URL for the RPA
+- `RELEASE_CATALOG_GIT_REVISION` - Release service catalog revision for the RPA
+
+### Optional Environment Variables
+- `KUBECONFIG` - Kubeconfig file for cluster access
+- `LARGE_SNAPSHOT_COMPONENT_COUNT` - Number of components in snapshot (default: 1)
+- `LARGE_SNAPSHOT_TIMEOUT` - Pipeline timeout (default: 2h0m0s)
+
+### Test Properties
+#### [test.env](test.env)
+- Contains resource names and configuration values for testing.
+- Uses a single-component pre-built snapshot to minimize first release duration.
+
+#### [test.sh](test.sh)
+- Overrides standard build functions to skip builds and use pre-built images.
+- Implements the two-phase idempotent test: first release then second release.
+- Verifies all acceptance criteria post second release.
+
+### Test Functions
+#### [lib/test-functions.sh](../lib/test-functions.sh)
+- Reusable functions for tests.
+
+### Secrets
+- Secrets are stored in ansible vault files (symlinked from `rh-advisories-large-snapshot`):
+  - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
+  - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
+
+## Acceptance Criteria
+
+- Second release: all major tasks (`create-advisory`, `push-snapshot`, `verify-conforma`,
+  `rh-sign-image`, etc.) appear in `skippedTasks`
+- `advisory.url` present in second release `status.artifacts` (written by
+  `update-cr-status-skipped` from filter result, not `create-advisory`)
+
+## Running the test
+
+For local testing:
+
+```shell
+../run-test.sh rh-advisories-idempotent
+```
+
+**Note:** This test runs two full releases sequentially. The first release takes
+approximately 1-2 hours in staging; the second release completes quickly once the
+filter detects the existing advisory.
+
+### Debugging
+
+Use `--skip-cleanup` to preserve resources after the test:
+
+```shell
+../run-test.sh rh-advisories-idempotent --skip-cleanup
+```
+
+### Maintenance
+
+To update secrets:
+
+```shell
+ansible-vault decrypt vault/tenant-secrets.yaml --output "/tmp/tenant-secrets.yaml" \
+  --vault-password-file <vault password file>
+vi /tmp/tenant-secrets.yaml
+ansible-vault encrypt /tmp/tenant-secrets.yaml --output "vault/tenant-secrets.yaml" \
+  --vault-password-file <vault password file>
+rm /tmp/tenant-secrets.yaml
+```

--- a/integration-tests/rh-advisories-idempotent/resources/managed/ec-policy.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/managed/ec-policy.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/ec-policy.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/managed/kustomization.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/managed/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: ${managed_namespace}
+resources:
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rpa.yaml
+  - ec-policy.yaml
+  - secrets/managed-secrets.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/managed/rpa.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/managed/rpa.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: ${release_plan_admission_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  applications:
+    - ${application_name}
+  data:
+    jira:
+      jiraAdvisorySecret: advisory-jira-secret-${component_name}
+    cgw:
+      cgwSecret: publish-to-cgw-secret-${component_name}
+    atlas:
+      server: stage
+      atlas-sso-secret-name: atlas-staging-sso-secret-${component_name}
+      atlas-retry-aws-secret-name: atlas-retry-s3-staging-secret-${component_name}
+    pyxis:
+      server: stage
+      secret: pyxis-${component_name}
+    sign:
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e-pq"
+      cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
+    mapping:
+      defaults:
+        tags:
+          - latest
+        pushSourceContainer: true
+      components:
+        - name: ${component_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+    releaseNotes:
+      product_id:
+        - 999
+      product_name: Red Hat Comp2
+      product_version: '1.0.1'
+      cpe: 'cpe:/a:redhat:comp2:1::appstream'
+      product_stream: comp2-1.0
+  origin: ${tenant_namespace}
+  pipeline:
+    pipelineRef:
+      params:
+        - name: url
+          value: "${RELEASE_CATALOG_GIT_URL}"
+        - name: revision
+          value: "${RELEASE_CATALOG_GIT_REVISION}"
+        - name: pathInRepo
+          value: pipelines/managed/rh-advisories/rh-advisories.yaml
+      resolver: git
+    serviceAccountName: ${managed_sa_name}
+    timeouts:
+      pipeline: 4h0m0s
+      tasks: 4h0m0s
+  policy: standard-${component_name}

--- a/integration-tests/rh-advisories-idempotent/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/sa-rolebinding.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/managed/sa.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/managed/sa.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/sa.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/tenant/application.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/tenant/application.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/application.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/tenant/component.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/tenant/component.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/component.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/tenant/kustomization.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/tenant/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/tenant/rp.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/tenant/rp.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/rp.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/sa-rolebinding.yaml

--- a/integration-tests/rh-advisories-idempotent/resources/tenant/sa.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/tenant/sa.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/sa.yaml

--- a/integration-tests/rh-advisories-idempotent/test.env
+++ b/integration-tests/rh-advisories-idempotent/test.env
@@ -1,0 +1,33 @@
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
+
+export originating_tool="rh-advisories-idempotent-test"
+
+# Namespaces
+export tenant_namespace=dev-release-team-tenant
+#
+## Since this is a test that requires internal services,
+## this name should not change.
+#
+export managed_namespace=managed-release-team-tenant
+
+export application_name=rh-adv-idem-app-${uuid}
+export component_type=rh-adv-idem
+export component_name=${component_type}-${uuid}
+export component_branch=${component_name}
+## do not change this. it is a known branch created by Konflux
+export appstudio_component_branch="appstudio-${component_name}"
+
+export component_github_org=hacbs-release-tests
+export component_base_branch=collectors-base
+export component_repo_name=${component_github_org}/${component_name}
+export component_base_repo_name=${component_github_org}/e2e-base
+export component_git_url=https://github.com/$component_repo_name
+
+export tenant_collector_sa_name=${component_type}-collector-sa-${uuid}
+export tenant_sa_name=${component_type}-tenant-sa-${uuid}
+export release_plan_name=${component_type}-rp-${uuid}
+
+export managed_sa_name=${component_type}-sa-${uuid}
+export release_plan_admission_name=${component_type}-rpa-${uuid}

--- a/integration-tests/rh-advisories-idempotent/test.sh
+++ b/integration-tests/rh-advisories-idempotent/test.sh
@@ -1,0 +1,556 @@
+#!/usr/bin/env bash
+#
+# test.sh - Test-specific functions for rh-advisories-idempotent
+#
+# This test validates idempotent release behavior for the rh-advisories pipeline by:
+#   1. Building a real component via GitHub/PaC (same flow as collectors test)
+#   2. Waiting for the first release (auto-released after build): all tasks run,
+#      advisory created (skip_release=false)
+#   3. Creating a second release with the SAME snapshot (sequential retrigger)
+#   4. Verifying the second release detects the existing advisory via
+#      filter-already-released-advisory-images and sets skip_release=true
+#   5. Asserting all downstream tasks are skipped and advisory.url is present
+#      in the release status (populated by update-cr-status-skipped from filter result)
+#   6. Creating two additional releases (3rd and 4th) CONCURRENTLY with the same
+#      snapshot to verify no race condition causes duplicate advisory creation
+#   7. Verifying advisory URL stability: all filtered releases report the SAME URL
+#   8. Fetching the actual advisory content and verifying the component image
+#      digest is present (advisory references the correct images)
+#
+# Acceptance criteria:
+#   - Second release: all major tasks in skippedTasks
+#   - advisory.url present in second release status (from filter result, not create-advisory)
+#   - Concurrent 3rd and 4th releases: both get skip_release=true, no duplicate advisory
+#   - advisory.url identical across all filtered releases (no new advisory created)
+#   - Advisory content contains the component image digest from the first release
+#
+# This file is sourced by run-test.sh
+#
+
+# --- Global Script Variables (Defaults) ---
+CLEANUP="true"
+NO_CVE="true"
+
+# Exit via log_error when a GitHub API response is empty, non-JSON, or an error object.
+validate_github_api_json() {
+    local response=$1
+    local context=$2
+
+    if [ -z "${response}" ]; then
+        log_error "${context}: empty API response"
+    fi
+    if ! jq -e . >/dev/null 2>&1 <<< "${response}"; then
+        log_error "${context}: non-JSON API response"
+    fi
+    if jq -e '.message' >/dev/null 2>&1 <<< "${response}"; then
+        log_error "${context}: $(jq -r '.message' <<< "${response}")"
+    fi
+}
+
+# --- envsubst Variable Allowlist ---
+readonly ENVSUBST_ALLOWLIST='$application_name $component_branch $component_git_url $component_name $managed_namespace $managed_sa_name $originating_tool $release_plan_admission_name $release_plan_name $tenant_namespace $tenant_sa_name $tenant_collector_sa_name $RELEASE_CATALOG_GIT_REVISION $RELEASE_CATALOG_GIT_URL'
+
+# Patch component source BEFORE merge to add multi-arch and source image build support
+# This mirrors the collectors test to produce a multi-arch image for the advisory pipeline
+patch_component_source_before_merge() {
+    echo "Patching component source BEFORE MERGE to:"
+    echo "- Add multi-arch support to the PaC pipeline"
+    echo "- Add source image build to the PaC pipeline"
+
+    local xtrace_was_on=0 github_token
+    [[ $- == *x* ]] && xtrace_was_on=1
+    set +x
+    trap 'unset github_token; if [[ "${xtrace_was_on}" -eq 1 ]]; then set -x; fi; trap - RETURN' RETURN
+
+    github_token=$(yq '. | select(.metadata.name | contains("pipelines-as-code-secret-")) | .stringData.password' \
+        "${SUITE_DIR}/resources/tenant/secrets/tenant-secrets.yaml")
+
+    local file_names=(
+        ".tekton/${component_name}-pull-request.yaml"
+        ".tekton/${component_name}-push.yaml"
+    )
+    for file_name in "${file_names[@]}"; do
+        echo "Patching ${file_name}..."
+
+        local pr_response head_sha contents_response
+        if ! pr_response=$(curl -sS --retry 3 --fail-with-body -H "Authorization: token ${github_token}" \
+            "https://api.github.com/repos/${component_repo_name}/pulls/${pr_number}"); then
+            [ -n "${pr_response}" ] && validate_github_api_json "${pr_response}" "GitHub pull #${pr_number}"
+            log_error "GitHub pull #${pr_number}: HTTP request failed"
+        fi
+        validate_github_api_json "${pr_response}" "GitHub pull #${pr_number}"
+        head_sha=$(jq -er '.head.sha' <<< "${pr_response}")
+
+        if ! contents_response=$(curl -sS --retry 3 --fail-with-body -H "Authorization: token ${github_token}" \
+            "https://api.github.com/repos/${component_repo_name}/contents/${file_name}?ref=${head_sha}"); then
+            [ -n "${contents_response}" ] \
+                && validate_github_api_json "${contents_response}" "GitHub contents ${file_name} @ ${head_sha}"
+            log_error "GitHub contents ${file_name} @ ${head_sha}: HTTP request failed"
+        fi
+        validate_github_api_json "${contents_response}" "GitHub contents ${file_name} @ ${head_sha}"
+        local decoded_contents
+        decoded_contents=$(jq -er '.content' <<< "${contents_response}" | base64 -d)
+
+        local work_dir nopath_file_name encoded_contents
+        work_dir=$(mktemp -d)
+        nopath_file_name=$(basename "${file_name}")
+        echo "${decoded_contents}" > "${work_dir}/${nopath_file_name}"
+        yq -i '
+          .spec.params //= [] |
+          (.spec.params[] | select(.name == "build-platforms") | .value) |=
+            ((. // []) + ["linux/arm64"] | unique) |
+          if any(.spec.params[]; .name == "build-source-image") then
+            (.spec.params[] | select(.name == "build-source-image") | .value) = "true"
+          else
+            .spec.params += [{"name": "build-source-image", "value": "true"}]
+          end
+        ' "${work_dir}/${nopath_file_name}"
+        encoded_contents=$(base64 -w 0 < "${work_dir}/${nopath_file_name}")
+        rm -rf "${work_dir}"
+
+        GH_TOKEN="${github_token}" "${SCRIPT_DIR}/scripts/update-file-in-pull-request.sh" \
+            "${component_repo_name}" \
+            "${pr_number}" \
+            "${file_name}" \
+            "Update component source before merge" \
+            "${encoded_contents}"
+    done
+
+    echo "✅ Successfully patched component source!"
+}
+
+# Helper: Apply a Release CR and immediately return (non-blocking).
+# Used to create multiple releases concurrently before waiting for any.
+create_release_cr() {
+    local release_name=$1
+    local snapshot_name=$2
+    local test_type=$3
+
+    cat <<EOF | kubectl apply -f -
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: "${release_name}"
+  namespace: "${tenant_namespace}"
+  labels:
+    originating-tool: "${originating_tool}"
+    test-run-uuid: "${uuid}"
+    test-type: "${test_type}"
+spec:
+  snapshot: "${snapshot_name}"
+  releasePlan: "${release_plan_name}"
+EOF
+}
+
+# Helper: Wait for a release and capture its exit status into a named result variable.
+# Usage: wait_for_release <release_name> <result_var>
+# Sets result_var to 0 on success, 1 on failure.
+wait_for_release_async() {
+    local release_name=$1
+    local result_file=$2
+
+    (
+        RELEASE_NAME="${release_name}" RELEASE_NAMESPACE="${tenant_namespace}" \
+            "${SUITE_DIR}/../scripts/wait-for-release.sh" \
+            && echo "0" > "${result_file}" \
+            || echo "1" > "${result_file}"
+    ) &
+}
+
+# Helper: Get a field from release.status.artifacts.advisory (e.g. url, internal_url).
+get_advisory_artifact_field_from_release() {
+    local release_name=$1
+    local field_name=$2
+    local release_json
+
+    if ! release_json=$(get_release_json "${release_name}"); then
+        log_error "Could not retrieve Release JSON for ${release_name}"
+    fi
+    jq -r --arg field "${field_name}" '.status.artifacts.advisory[$field] // ""' \
+        <<< "${release_json}" 2>/dev/null || echo ""
+}
+
+# Helper: Get skip_release result value from filter task in the managed PipelineRun.
+# Prints the value and returns 0 on success; prints nothing and returns 1 on resolution failure.
+get_filter_skip_release_result() {
+    local release_name=$1
+    local pipelinerun_name plr_json taskrun_name taskrun_json result_value
+
+    pipelinerun_name=$(get_pipelinerun_name_from_release "${release_name}") || return 1
+    plr_json=$(kubectl get pipelinerun "${pipelinerun_name}" -n "${managed_namespace}" -o json) || return 1
+
+    taskrun_name=$(jq -er --arg task_name 'filter-already-released-advisory-images' '
+        [.status.childReferences[]? | select(.pipelineTaskName == $task_name) | .name] as $refs |
+        if ($refs | length) == 0 then
+            "no TaskRun for \($task_name)" | error
+        elif ($refs | length) > 1 then
+            "expected exactly 1 TaskRun for \($task_name), got \($refs | length)" | error
+        else
+            $refs[0]
+        end
+    ' <<< "${plr_json}") || return 1
+
+    taskrun_json=$(kubectl get taskrun "${taskrun_name}" -n "${managed_namespace}" -o json) || return 1
+
+    result_value=$(jq -er --arg result_name 'skip_release' '
+        [.status.results[]? | select(.name == $result_name) | .value] as $vals |
+        if ($vals | length) == 0 then
+            "no \($result_name) result on TaskRun" | error
+        elif ($vals | length) > 1 then
+            "expected exactly 1 \($result_name) result, got \($vals | length)" | error
+        else
+            $vals[0]
+        end
+    ' <<< "${taskrun_json}") || return 1
+
+    echo "${result_value}"
+    return 0
+}
+
+# Main verification: implements idempotent test logic
+# At this point RELEASE_NAMES contains the first release (auto-triggered after build)
+verify_release_contents() {
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  rh-advisories Idempotent Test - Phase 1: Verify First Release"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    local first_release_name
+    first_release_name=$(echo "${RELEASE_NAMES}" | awk '{print $1}')
+    echo "First release: ${first_release_name}"
+
+    # Verify create-advisory ran (not skipped) - images were unknown to Pyxis
+    echo "Checking first release ran create-advisory..."
+    if is_task_skipped "${first_release_name}" "create-advisory"; then
+        log_error "First release: create-advisory was skipped, but it should have run (skip_release should be false)"
+    fi
+    echo "✅ First release: create-advisory ran (advisory created, skip_release=false)"
+
+    # Get advisory URL from first release status
+    local first_advisory_url
+    first_advisory_url=$(get_advisory_artifact_field_from_release "${first_release_name}" url)
+    if [ -z "${first_advisory_url}" ]; then
+        log_error "First release: advisory.url not found in release status"
+    fi
+    echo "✅ First release advisory URL: ${first_advisory_url}"
+
+    # Get snapshot name from first release to reuse in second release
+    local snapshot_name
+    snapshot_name=$(kubectl get release "${first_release_name}" -n "${tenant_namespace}" \
+        -o jsonpath='{.spec.snapshot}' 2>/dev/null)
+    if [ -z "${snapshot_name}" ] || [ "${snapshot_name}" == "null" ]; then
+        log_error "Could not get snapshot name from first release"
+    fi
+    echo "Using snapshot for second release: ${snapshot_name}"
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  rh-advisories Idempotent Test - Phase 2: Trigger Second Release"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    local second_release_name="${component_name}-retry"
+    echo "Creating second release: ${second_release_name}"
+    create_release_cr "${second_release_name}" "${snapshot_name}" "idempotent-second-release"
+
+    echo "Waiting for second release to complete (Released=True)..."
+    RELEASE_NAME="${second_release_name}" RELEASE_NAMESPACE="${tenant_namespace}" \
+        "${SUITE_DIR}/../scripts/wait-for-release.sh"
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  rh-advisories Idempotent Test - Phase 3: Verify Idempotent Behavior"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    local failures=0
+
+    # Verify filter-already-released-advisory-images ran (not skipped) and detected existing advisory
+    echo "Checking filter-already-released-advisory-images ran (not skipped)..."
+    if is_task_skipped "${second_release_name}" "filter-already-released-advisory-images"; then
+        echo "🔴 filter-already-released-advisory-images was skipped in second release (should have run)"
+        failures=$((failures+1))
+    else
+        echo "✅ filter-already-released-advisory-images ran (detected existing advisory)"
+    fi
+
+    # Verify all tasks gated by skip_release=false were skipped in second release
+    local major_tasks=(
+        "collect-task-params"
+        "collect-signing-params"
+        "collect-atlas-params"
+        "check-labels"
+        "verify-conforma"
+        "populate-release-notes"
+        "embargo-check"
+        "set-advisory-severity"
+        "rh-sign-image"
+        "rh-sign-image-cosign"
+        "push-snapshot"
+        "create-pyxis-image"
+        "publish-pyxis-repository"
+        "push-rpm-data-to-pyxis"
+        "process-component-sbom"
+        "process-product-sbom"
+        "run-file-updates"
+        "check-data-keys"
+        "create-advisory"
+        "close-advisory-issues"
+        "update-cr-status"
+    )
+
+    echo "Checking all major tasks are in skippedTasks..."
+    for task in "${major_tasks[@]}"; do
+        if is_task_skipped "${second_release_name}" "${task}"; then
+            echo "  ✅ ${task}: skipped"
+        else
+            echo "  🔴 ${task}: NOT skipped (expected to be skipped)"
+            failures=$((failures+1))
+        fi
+    done
+
+    # Verify tasks that always run (not gated by skip_release) were NOT skipped
+    local always_run_tasks=(
+        "verify-access-to-resources"
+        "collect-data"
+        "reduce-snapshot"
+        "apply-mapping"
+        "filter-already-released-advisory-images"
+    )
+    echo "Checking always-running tasks were not skipped..."
+    for task in "${always_run_tasks[@]}"; do
+        if is_task_skipped "${second_release_name}" "${task}"; then
+            echo "  🔴 ${task}: was skipped (should always run)"
+            failures=$((failures+1))
+        else
+            echo "  ✅ ${task}: ran (expected)"
+        fi
+    done
+
+    # Verify update-cr-status-skipped ran (not skipped) to write advisory URL
+    echo "Checking update-cr-status-skipped ran..."
+    if is_task_skipped "${second_release_name}" "update-cr-status-skipped"; then
+        echo "🔴 update-cr-status-skipped was skipped in second release (should have run)"
+        failures=$((failures+1))
+    else
+        echo "✅ update-cr-status-skipped ran (wrote advisory URL to release status)"
+    fi
+
+    # Verify skip_release=true directly from the filter task's TaskRun result
+    echo "Checking filter task result skip_release=true directly..."
+    local filter_skip_result
+    if filter_skip_result=$(get_filter_skip_release_result "${second_release_name}"); then
+        if [ "${filter_skip_result}" == "true" ]; then
+            echo "✅ filter-already-released-advisory-images.results.skip_release=true (confirmed)"
+        else
+            echo "🔴 filter-already-released-advisory-images.results.skip_release='${filter_skip_result}' (expected 'true')"
+            failures=$((failures+1))
+        fi
+    else
+        echo "🔴 could not resolve filter-already-released-advisory-images skip_release result from TaskRun"
+        failures=$((failures+1))
+    fi
+
+    # Verify advisory.url is present in second release status (from filter, not create-advisory)
+    echo "Checking advisory.url in second release status..."
+    local second_advisory_url
+    second_advisory_url=$(get_advisory_artifact_field_from_release "${second_release_name}" url)
+    if [ -z "${second_advisory_url}" ]; then
+        echo "🔴 advisory.url not found in second release status"
+        failures=$((failures+1))
+    else
+        echo "✅ advisory.url present in second release status: ${second_advisory_url}"
+
+        if [ "${first_advisory_url}" == "${second_advisory_url}" ]; then
+            echo "✅ advisory.url matches first release (same advisory reused)"
+        else
+            echo "⚠️  advisory.url differs from first release:"
+            echo "   First:  ${first_advisory_url}"
+            echo "   Second: ${second_advisory_url}"
+        fi
+    fi
+
+    # Verify advisory_internal_url is also propagated to second release status
+    echo "Checking advisory_internal_url in second release status..."
+    local second_advisory_internal_url
+    second_advisory_internal_url=$(get_advisory_artifact_field_from_release "${second_release_name}" internal_url)
+    if [ -z "${second_advisory_internal_url}" ]; then
+        echo "🔴 advisory_internal_url not found in second release status"
+        failures=$((failures+1))
+    else
+        echo "✅ advisory_internal_url present in second release status: ${second_advisory_internal_url}"
+    fi
+
+    # Note: the pipeline-level advisory_url result on the second release PipelineRun will be
+    # empty — this is an inherent Tekton behavior. When create-advisory is skipped, its result
+    # is unresolvable at pipeline-result evaluation time and Tekton drops the entire expression.
+    # The advisory URL is correctly propagated to the Release CR status via update-cr-status-skipped
+    # (verified above), which is the actual acceptance criterion.
+    local pipeline_advisory_url
+    pipeline_advisory_url=$(get_pipelinerun_result "${second_release_name}" "advisory_url")
+    if [ -z "${pipeline_advisory_url}" ]; then
+        echo "ℹ️  pipeline-level advisory_url result is empty (expected: Tekton drops results that"
+        echo "    reference skipped-task outputs; advisory.url in Release CR status is the source of truth)"
+    else
+        echo "✅ pipeline-level advisory_url result: ${pipeline_advisory_url}"
+    fi
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  rh-advisories Idempotent Test - Phase 4: Concurrent Releases"
+    echo "  (Race Condition: 3rd and 4th releases submitted simultaneously)"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    # Create two releases AT THE SAME TIME without waiting for either.
+    # Both target the same already-released snapshot. This verifies:
+    #   - No race condition causes a second advisory to be created
+    #   - The filter handles concurrent in-flight releases correctly
+    local third_release_name="${component_name}-concurrent-a"
+    local fourth_release_name="${component_name}-concurrent-b"
+
+    echo "Submitting 3rd release: ${third_release_name}"
+    create_release_cr "${third_release_name}" "${snapshot_name}" "idempotent-concurrent-a"
+    echo "Submitting 4th release: ${fourth_release_name} (immediately, before 3rd completes)"
+    create_release_cr "${fourth_release_name}" "${snapshot_name}" "idempotent-concurrent-b"
+
+    # Wait for both in parallel using background processes
+    local result_file_3 result_file_4
+    result_file_3=$(mktemp)
+    result_file_4=$(mktemp)
+    trap 'rm -f "${result_file_3}" "${result_file_4}"' RETURN
+
+    wait_for_release_async "${third_release_name}" "${result_file_3}"
+    wait_for_release_async "${fourth_release_name}" "${result_file_4}"
+
+    echo "Waiting for both concurrent releases to complete..."
+    wait
+
+    local rc3 rc4
+    rc3=$(cat "${result_file_3}" 2>/dev/null || echo "1")
+    rc4=$(cat "${result_file_4}" 2>/dev/null || echo "1")
+
+    if [ "${rc3}" != "0" ]; then
+        echo "🔴 3rd release (${third_release_name}) did not complete successfully"
+        failures=$((failures+1))
+    else
+        echo "✅ 3rd release completed (${third_release_name})"
+    fi
+
+    if [ "${rc4}" != "0" ]; then
+        echo "🔴 4th release (${fourth_release_name}) did not complete successfully"
+        failures=$((failures+1))
+    else
+        echo "✅ 4th release completed (${fourth_release_name})"
+    fi
+
+    # Both concurrent releases must also get skip_release=true
+    for concurrent_release in "${third_release_name}" "${fourth_release_name}"; do
+        echo "Checking concurrent release ${concurrent_release}..."
+        local concurrent_skip_result
+        if concurrent_skip_result=$(get_filter_skip_release_result "${concurrent_release}"); then
+            if [ "${concurrent_skip_result}" == "true" ]; then
+                echo "  ✅ ${concurrent_release}: skip_release=true (no duplicate advisory)"
+            else
+                echo "  🔴 ${concurrent_release}: skip_release='${concurrent_skip_result}' (expected 'true' — possible duplicate advisory!)"
+                failures=$((failures+1))
+            fi
+        else
+            echo "  🔴 ${concurrent_release}: could not resolve skip_release result"
+            failures=$((failures+1))
+        fi
+    done
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  rh-advisories Idempotent Test - Phase 5: Advisory URL Stability"
+    echo "  (All filtered releases must report the exact same advisory URL)"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    # All releases after the first must report an identical advisory URL.
+    # If any retrigger incorrectly created a new advisory the URL would differ.
+    local all_filtered_releases=("${second_release_name}" "${third_release_name}" "${fourth_release_name}")
+    for filtered_release in "${all_filtered_releases[@]}"; do
+        local filtered_url
+        filtered_url=$(get_advisory_artifact_field_from_release "${filtered_release}" url)
+        if [ -z "${filtered_url}" ]; then
+            echo "🔴 ${filtered_release}: advisory.url missing"
+            failures=$((failures+1))
+        elif [ "${filtered_url}" != "${first_advisory_url}" ]; then
+            echo "🔴 ${filtered_release}: advisory.url '${filtered_url}' differs from first release '${first_advisory_url}' (duplicate advisory created!)"
+            failures=$((failures+1))
+        else
+            echo "✅ ${filtered_release}: advisory.url matches first release (stable, no duplicate)"
+        fi
+    done
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  rh-advisories Idempotent Test - Phase 6: Advisory Content Validation"
+    echo "  (Fetch actual advisory and verify it references the built image)"
+    echo "════════════════════════════════════════════════════════════════════"
+
+    # Fetch the advisory content via the OCI artifact pipeline and verify it
+    # contains the component image digest from the first release.
+    local advisory_output_dir
+    advisory_output_dir=$(mktemp -d)
+    trap 'rm -rf "${advisory_output_dir}"' RETURN
+
+    local first_image_digest
+    first_image_digest=$(kubectl get release "${first_release_name}" -n "${tenant_namespace}" \
+        -o jsonpath='{.status.artifacts.components[0].containerImage}' 2>/dev/null || echo "")
+
+    if [ -z "${first_image_digest}" ]; then
+        echo "⚠️  Could not retrieve component image digest from first release status — skipping content check"
+    else
+        echo "Component image digest from first release: ${first_image_digest}"
+
+        "${SUITE_DIR}/../scripts/get-advisory-content.sh" \
+            "${managed_namespace}" "${managed_sa_name}" "${first_advisory_url}" "${advisory_output_dir}" \
+            2>/dev/null || true
+
+        local advisory_file
+        advisory_file=$(find "${advisory_output_dir}" -name "advisory.yaml" 2>/dev/null | head -1)
+
+        if [ -z "${advisory_file}" ]; then
+            echo "⚠️  Advisory YAML not retrieved — skipping content check (advisory pipeline may not be configured in this environment)"
+        else
+            echo "Advisory file retrieved: ${advisory_file}"
+            # Extract just the digest portion (sha256:...) for comparison
+            local digest_only
+            digest_only=$(echo "${first_image_digest}" | grep -oP 'sha256:[a-f0-9]+' || echo "")
+
+            if [ -n "${digest_only}" ] && grep -q "${digest_only}" "${advisory_file}"; then
+                echo "✅ Advisory content contains component image digest (${digest_only})"
+            elif [ -n "${digest_only}" ]; then
+                echo "🔴 Advisory content does NOT contain component image digest (${digest_only})"
+                echo "   Advisory file contents:"
+                cat "${advisory_file}" | head -30
+                failures=$((failures+1))
+            else
+                echo "⚠️  Could not parse digest from image reference '${first_image_digest}' — skipping digest check"
+            fi
+        fi
+    fi
+
+    if [ "${failures}" -gt 0 ]; then
+        echo ""
+        echo "🔴 IDEMPOTENT RELEASE TEST FAILED with ${failures} failure(s)"
+        return 1
+    fi
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  ✅ rh-advisories IDEMPOTENT RELEASE TEST PASSED"
+    echo "════════════════════════════════════════════════════════════════════"
+    echo ""
+    echo "Summary:"
+    echo "  • First release: all tasks ran, advisory created"
+    echo "  • Second release (sequential): filter detected existing advisory (skip_release=true)"
+    echo "  • filter task result skip_release=true confirmed directly"
+    echo "  • All major downstream tasks skipped in second release"
+    echo "  • advisory.url present in second release status (from filter result)"
+    echo "  • advisory_internal_url present in second release status"
+    echo "  • 3rd and 4th releases (concurrent): both got skip_release=true — no race condition"
+    echo "  • advisory.url identical across all filtered releases — no duplicate advisory created"
+    echo "  • advisory.url: ${second_advisory_url}"
+    echo "  • advisory_internal_url: ${second_advisory_internal_url}"
+    echo ""
+}

--- a/integration-tests/rh-advisories-idempotent/vault/managed-secrets.yaml
+++ b/integration-tests/rh-advisories-idempotent/vault/managed-secrets.yaml
@@ -1,0 +1,1 @@
+../../collectors/vault/managed-secrets.yaml

--- a/integration-tests/rh-advisories-idempotent/vault/tenant-secrets.yaml
+++ b/integration-tests/rh-advisories-idempotent/vault/tenant-secrets.yaml
@@ -1,0 +1,1 @@
+../../collectors/vault/tenant-secrets.yaml


### PR DESCRIPTION
## Describe your changes
Adds a new integration test suite rh-advisories-idempotent that validates safe re-release behavior when the same snapshot is released twice through the rh-advisories pipeline.

Test flow:
- First release: all tasks run, advisory created (skip_release=false)
- Second release (same snapshot): filter-already-released-advisory-images detects the existing advisory in Pyxis → skip_release=true
- Test asserts the second release completes successfully (Released=True), that all major downstream tasks appear in skippedTasks, and that advisory.url is present in the second release status (populated from the filter result, not create-advisory)

## Relevant Jira
[RELEASE-2325](https://redhat.atlassian.net/browse/RELEASE-2325)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`


[RELEASE-2325]: https://redhat.atlassian.net/browse/RELEASE-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ