### PR TITLE
fix(RELEASE-2369): update RSU image in internal create-advisory

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -86,7 +86,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+      image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
       computeResources:
         limits:
           memory: 256Mi
@@ -342,7 +342,7 @@ spec:
           # Create advisory file using the apply_template.py script
           /home/utils/apply_template.py -o "$JSON_ADVISORY_FILEPATH" --data-file /tmp/template_data_final.json \
           --template /home/templates/advisory.yaml.jinja -v 2> "$STDERR_FILE"
-           
+
           # Convert to yaml for readability
           yq eval -o yaml "$JSON_ADVISORY_FILEPATH" | tee "$YAML_ADVISORY_FILEPATH"
 

--- a/tasks/internal/create-advisory-task/tests/mocks.sh
+++ b/tasks/internal/create-advisory-task/tests/mocks.sh
@@ -31,7 +31,7 @@ function git() {
 		  }
 		}
 		EOF
-    
+
     mkdir -p "$gitRepo"/data/advisories/dev-tenant/2025/1602
     mkdir -p "$gitRepo"/data/advisories/dev-tenant/2025/1601
     mkdir -p "$gitRepo"/data/advisories/dev-tenant/2024/1452
@@ -67,7 +67,7 @@ function yq() {
 
     # Check that tags are preserved correctly in json/yaml conversion.
     product_name=$(jq -r '.spec.product_name' "$json_file")
-    if [[ "$product_name" == "preserves tags" ]]; then
+    if [[ "$product_name" == "preserves data" ]]; then
       json_tags=$(jq -r '.spec.content.images[].tags[]' "$json_file")
       yaml_tags=$(command yq '.spec.content.images[].tags[]' "$yaml_tmpfile")
       while IFS= read -r tag; do
@@ -77,6 +77,20 @@ function yq() {
         fi
       done <<< "$json_tags"
       echo "Tags are preserved correctly" >&2
+
+      # Check that version is not truncated e.g. 1.20 not 1.2
+      yaml_version=$(command yq '.spec.product_version' "$yaml_tmpfile")
+      if [ "$yaml_version" != "1.20" ]; then
+        echo "Error: product_version truncated from '1.20' to '$yaml_version'" >&2
+        exit 1
+      fi
+
+      yaml_stream=$(command yq '.spec.product_stream' "$yaml_tmpfile")
+      if [ "$yaml_stream" != "preserver-data-1.20" ]; then
+        echo "Error: product_stream expected 'preserver-data-1.20' got '$yaml_stream'" >&2
+        exit 1
+      fi
+      echo "Quoted fields are preserved correctly" >&2
     fi
     return
   fi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
@@ -65,7 +65,7 @@ spec:
             type: string
         steps:
           - name: verify-latest-advisory-returned
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-schema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-schema.yaml
@@ -53,11 +53,11 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors
-                
+
               echo Test that result contains the schema errors
               grep "wrongType" <<< "$(params.result)"
               grep "wrongSeverity" <<< "$(params.result)"

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-jinja-cross-field-references.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-jinja-cross-field-references.yaml
@@ -56,7 +56,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-preserves-data.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-preserves-data.yaml
@@ -2,12 +2,12 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-advisory-preserves-tags
+  name: test-create-advisory-preserves-data
 spec:
   description: |
-    Test that tags are preserved correctly during JSON to YAML conversion.
-    Verifies that tag values like "33158e1" don't get converted to integers
-    like 331580 in the YAML.
+    Test that data is preserved correctly during JSON to YAML conversion.
+    Verifies tags like 33158e1 are not converted to integers and that
+    version like 1.20 is not truncated to 1.2.
   tasks:
     - name: run-task
       taskRef:
@@ -15,12 +15,12 @@ spec:
       params:
         - name: advisory_json
           value: >-
-            H4sICMSxfGkAA2RhdGEuanNvbgB9UjtPwzAQ3vsroswoaVpaIU9lQIIVsaEKHc7RWiS28V0qoqr/Hfvc58Jk3/c4f/Z5PymK0gfXDpo/TFuqopnN765BCz1GONZIGHZIBcOGyhvNDgMZZ5Osqaa3HHFA6BOVd02mtZeucVE1KEZidXRknscseH1+eswIjdZ5MpTQt6gvzkA2OG/0mcuVEC2SDsbzMaDQ11hu7rrhRnEGhA74hQGtxnT6e7ll9qTqGn+h9x1W2vXlOl/LWUbLUbWPZQRMD5vsysBRA8ZieElcOvFngLEy7tSvFtOKtjBbLBV86jgTySH2gN6RYRfGZD1ZEnrRyIhS0vm8WTxgfHOZTJpNUXaQnjvtdrNqis00ZxcjBL01jJqHIMmgb5f3l75+CJ18hu+N+i+s6A/ruBwmh8kfw609a2UCAAA=
+            H4sIAMS36GkAA31RO0/DMBDe+yuizG1epRXyBAMSrIgNVehwjtYisc35UhFV/e/4EUq6MPnue93ZPi2yLLdk2kHym2pzkdXNejkHNfToYd+jQzqiy1pgyK80RySnjA6yumiqa9IxIfTzCFqFiNWfVNo4wh+iBMHoWEzuxPOYBM+PD/cJcaM21ikX0Bevzy5AMhir5IVLXSRadJKU5WnbSM+xFG664UpxASJN+IGEWmKY/pofmK0TZYnf0NsOC2n6fJeuZTSjZq86+dYDqod9csU+m/DIBTEojfQURGH01wBjocxvcBndd+4AzWYr4F36n4oLTQGE1jjFhsZg/jUFdK5i2Ke11+t6c4t1vgx/VhVVKDoIbx+qY1NUWFfpIpMVSB4Uo+SB4n7Qt9ubebYdqIv//LkX/y09Oc7x3C1CdV78AH1x4diKAgAA
           # advisory_json string before `gzip -c|base64 -w 0` encoding:
-          # {"product_id":123, "product_name":"preserves tags", "product_version":"1.0",
-          # "product_stream":"stream1", "cpe":"cpe:/a:test:product", "type":"RHEA", "synopsis":"Test synopsis",
-          # "topic":"Test topic", "description":"Test description", "solution":"Test solution",
-          # "references":["https://example.com"],
+          # {"product_id":123, "product_name":"preserves data", "product_version":"1.20",
+          # "product_stream":"preserver-data-1.20", "cpe":"cpe:/a:test:product", "type":"RHEA",
+          # "synopsis":"Test synopsis", "topic":"Test topic", "description":"Test description",
+          # "solution":"Test solution", "references":["https://example.com"],
           # "content":{"images":[{"containerImage":"quay.io/example/image@sha256:abc123",
           # "repository":"example/repo", "tags":["33158e1", "1.0.0", "latest", "v2.0e10"], "architecture":"amd64",
           # "purl":"pkg:example/image@sha256:abc123"}]}}
@@ -56,7 +56,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9460d206ab78a096679cf0d96bf812b3f9a5227dd2f7061e06e8e58c49cdad16
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes
Update [release-service-utils](https://issues.redhat.com/browse/RELEASE-service-utils) image to sha256:50d5f0abb0d which quotes product_version to prevent YAML float truncation & update tests.
Related to:
https://github.com/konflux-ci/release-service-utils/pull/736
## Relevant Jira
RELEASE-2369
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
