### PR TITLE
fix(create-advisory-task): add disk-image to supported values

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -40,7 +40,7 @@ spec:
       description: Name of the PipelineRun that called this task
     - name: contentType
       type: string
-      description: The contentType of the release artifact. One of [image|binary|generic|rpm]
+      description: The contentType of the release artifact. One of [image|binary|generic|rpm|disk-image]
       default: "image"
     - name: caTrustConfigMapName
       type: string
@@ -175,7 +175,7 @@ spec:
             echo "Content type is image."
             spec_content_type=".content.images"
           elif [ "$(params.contentType)" == "binary" ] || [ "$(params.contentType)" == "generic" ] \
-          || [ "$(params.contentType)" == "rpm" ]; then
+          || [ "$(params.contentType)" == "rpm" ] || [ "$(params.contentType)" == "disk-image" ]; then
             echo "Content type is generic or rpm artifact."
             spec_content_type=".content.artifacts"
           else


### PR DESCRIPTION
We need to support disk-image in the contentTypes.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
