### PR TITLE
KFLUXINFRA-3576: add changelog to infra-deployments PRs

### DIFF
--- a/tasks/managed/update-infra-deployments/tests/test_create_pr.py
+++ b/tasks/managed/update-infra-deployments/tests/test_create_pr.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Integration tests for the create-pr step functions.
+
+Hits real GitHub and Quay APIs — no mocking.
+Run locally: python3 test_create_pr.py
+"""
+
+import re
+import sys
+
+import requests
+
+GITHUB_API_URL = "https://api.github.com"
+
+
+# ---------------------------------------------------------------------------
+# Functions under test (copied from the task inline script)
+# ---------------------------------------------------------------------------
+
+def resolve_digest_to_git_sha(digest, container_image):
+    try:
+        repo_url = container_image.split('@')[0]
+        if not repo_url.startswith('quay.io/'):
+            print(f"  Not a quay.io image, skipping digest resolution")
+            return None
+        repo_path = repo_url.removeprefix('quay.io/')
+        page = 1
+        max_pages = 50
+        while page <= max_pages:
+            resp = requests.get(
+                f"https://quay.io/api/v1/repository/{repo_path}/tag/",
+                params={"limit": 100, "page": page},
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                print(f"  Quay API returned {resp.status_code}, skipping digest resolution")
+                return None
+            data = resp.json()
+            for tag in data.get("tags", []):
+                if tag.get("manifest_digest") == digest and re.fullmatch(r'[0-9a-f]{40}', tag["name"]):
+                    print(f"  Resolved {digest[:19]}... to git SHA {tag['name']}")
+                    return tag["name"]
+            if not data.get("has_additional", False):
+                break
+            page += 1
+        print(f"  No git SHA tag found for digest {digest[:19]}...")
+        return None
+    except Exception as e:
+        print(f"  Failed to resolve digest to git SHA: {e}")
+        return None
+
+
+def get_changelog(source_repo, old_rev, new_rev):
+    try:
+        owner_repo = '/'.join(source_repo.rstrip('/').split('/')[-2:])
+        req = requests.get(
+            f"{GITHUB_API_URL}/repos/{owner_repo}/compare/{old_rev}...{new_rev}",
+            headers={"Accept": "application/vnd.github.v3+json"})
+        if req.status_code != 200:
+            print(f"  Compare API returned {req.status_code}, skipping changelog")
+            return ""
+        commits = req.json().get("commits", [])
+        if not commits:
+            return ""
+        lines = ["## Changelog"]
+        for c in commits:
+            sha = c["sha"][:7]
+            url = c["html_url"]
+            msg = c["commit"]["message"].split('\n')[0]
+            author = c.get("author", {}).get("login") if c.get("author") else None
+            if author:
+                lines.append(f"- [`{sha}`]({url}) {msg} - @{author}")
+            else:
+                author_name = c["commit"]["author"]["name"]
+                lines.append(f"- [`{sha}`]({url}) {msg} - {author_name}")
+        return '\n'.join(lines)
+    except Exception as e:
+        print(f"  Failed to get changelog: {e}")
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+passed = 0
+failed = 0
+
+
+def check(name, condition):
+    global passed, failed
+    if condition:
+        print(f"  PASS: {name}")
+        passed += 1
+    else:
+        print(f"  FAIL: {name}")
+        failed += 1
+
+
+def header(title):
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+# ---------------------------------------------------------------------------
+# Fetch fresh valid SHAs from a public repo
+# ---------------------------------------------------------------------------
+
+print("Fetching fresh commits from konflux-ci/release-service...")
+resp = requests.get(
+    f"{GITHUB_API_URL}/repos/konflux-ci/release-service/commits?per_page=5",
+    headers={"Accept": "application/vnd.github.v3+json"},
+)
+assert resp.status_code == 200, f"Cannot fetch commits (status {resp.status_code}), check rate limit"
+commits = resp.json()
+NEW_SHA = commits[0]["sha"]
+OLD_SHA = commits[4]["sha"]
+print(f"  old={OLD_SHA[:10]}  new={NEW_SHA[:10]}")
+
+
+# ---------------------------------------------------------------------------
+# get_changelog
+# ---------------------------------------------------------------------------
+
+header("get_changelog — happy path")
+print(f"  Inputs: repo='konflux-ci/release-service' old={OLD_SHA[:10]} new={NEW_SHA[:10]}")
+result = get_changelog("https://github.com/konflux-ci/release-service", OLD_SHA, NEW_SHA)
+check("returns non-empty string", result != "")
+check("starts with ## Changelog", result.startswith("## Changelog"))
+check("contains commit links", "](https://github.com/" in result)
+lines = result.strip().split('\n')
+check(f"header + {len(lines)-1} commit entries", len(lines) >= 2)
+print(f"\n  Output:\n{result}")
+
+header("get_changelog — nonexistent repo (graceful skip)")
+print(f"  Inputs: repo='konflux-ci/doesnt-exist-xyz' old={OLD_SHA[:10]} new={NEW_SHA[:10]}")
+result = get_changelog("https://github.com/konflux-ci/doesnt-exist-xyz", OLD_SHA, NEW_SHA)
+print(f"  Result: {result!r}")
+check("returns empty string", result == "")
+
+header("get_changelog — invalid old SHA / semver (graceful skip)")
+print(f"  Inputs: repo='konflux-ci/release-service' old='1.2.3' new={NEW_SHA[:10]}")
+result = get_changelog("https://github.com/konflux-ci/release-service", "1.2.3", NEW_SHA)
+print(f"  Result: {result!r}")
+check("returns empty string", result == "")
+
+header("get_changelog — same old and new SHA")
+print(f"  Inputs: repo='konflux-ci/release-service' old={NEW_SHA[:10]} new={NEW_SHA[:10]}")
+result = get_changelog("https://github.com/konflux-ci/release-service", NEW_SHA, NEW_SHA)
+print(f"  Result: {result!r}")
+check("returns empty string", result == "")
+
+header("get_changelog — trailing slash in repo URL")
+print(f"  Inputs: repo='konflux-ci/release-service/' old={OLD_SHA[:10]} new={NEW_SHA[:10]}")
+result = get_changelog("https://github.com/konflux-ci/release-service/", OLD_SHA, NEW_SHA)
+print(f"  Result:\n{result}")
+check("returns non-empty string", result != "")
+check("starts with ## Changelog", result.startswith("## Changelog"))
+
+
+# ---------------------------------------------------------------------------
+# resolve_digest_to_git_sha
+# ---------------------------------------------------------------------------
+
+header("resolve_digest_to_git_sha — non-quay image (skip)")
+print(f"  Inputs: digest='sha256:abc' image='registry.io/org/repo@sha256:abc'")
+result = resolve_digest_to_git_sha("sha256:abc", "registry.io/org/repo@sha256:abc")
+print(f"  Result: {result!r}")
+check("returns None", result is None)
+
+header("resolve_digest_to_git_sha — wrong digest (no match)")
+wrong_digest = "sha256:" + "0" * 64
+print(f"  Inputs: digest='{wrong_digest[:25]}...' image='quay.io/konflux-ci/release-service-utils@...'")
+result = resolve_digest_to_git_sha(
+    wrong_digest,
+    f"quay.io/konflux-ci/release-service-utils@{wrong_digest}",
+)
+print(f"  Result: {result!r}")
+check("returns None", result is None)
+
+header("resolve_digest_to_git_sha — real quay image with valid digest")
+tag_resp = requests.get(
+    "https://quay.io/api/v1/repository/konflux-ci/release-service-utils/tag/",
+    params={"limit": 20},
+    timeout=10,
+)
+real_digest = None
+real_sha_tag = None
+if tag_resp.status_code == 200:
+    for tag in tag_resp.json().get("tags", []):
+        if re.fullmatch(r'[0-9a-f]{40}', tag.get("name", "")):
+            real_digest = tag["manifest_digest"]
+            real_sha_tag = tag["name"]
+            break
+
+if real_digest and real_sha_tag:
+    print(f"  Found tag: {real_sha_tag[:10]}... digest: {real_digest[:19]}...")
+    result = resolve_digest_to_git_sha(
+        real_digest,
+        f"quay.io/konflux-ci/release-service-utils@{real_digest}",
+    )
+    print(f"  Result: {result!r}")
+    check("resolves to correct git SHA", result == real_sha_tag)
+else:
+    print("  SKIP: no SHA-tagged image found on quay.io")
+
+header("resolve_digest_to_git_sha — nonexistent quay repo")
+print(f"  Inputs: digest='sha256:abc' image='quay.io/nonexistent-org-xyz/nonexistent-repo@sha256:abc'")
+result = resolve_digest_to_git_sha(
+    "sha256:abc",
+    "quay.io/nonexistent-org-xyz/nonexistent-repo@sha256:abc",
+)
+print(f"  Result: {result!r}")
+check("returns None", result is None)
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: URL parsing and branch name derivation
+# ---------------------------------------------------------------------------
+
+header("owner/repo extraction from URL")
+
+def extract_owner_repo(url):
+    return '/'.join(url.rstrip('/').split('/')[-2:])
+
+for url in ["https://github.com/org/repo", "https://github.com/org/repo/", "https://github.com/konflux-ci/release-service"]:
+    print(f"  {url} -> {extract_owner_repo(url)}")
+check("standard URL", extract_owner_repo("https://github.com/org/repo") == "org/repo")
+check("trailing slash", extract_owner_repo("https://github.com/org/repo/") == "org/repo")
+check("real URL", extract_owner_repo("https://github.com/konflux-ci/release-service") == "konflux-ci/release-service")
+
+header("branch name from originRepo")
+
+def branch_name(origin):
+    return origin.split('/')[-1]
+
+for url in ["https://github.com/org/my-component", "https://github.com/org/my-component.git"]:
+    print(f"  {url} -> {branch_name(url)}")
+check("simple", branch_name("https://github.com/org/my-component") == "my-component")
+check("with .git suffix", branch_name("https://github.com/org/my-component.git") == "my-component.git")
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+print(f"\n{'=' * 60}")
+total = passed + failed
+print(f"  RESULTS: {passed}/{total} passed, {failed} failed")
+print(f"{'=' * 60}")
+
+sys.exit(1 if failed else 0)

--- a/tasks/managed/update-infra-deployments/tests/test_old_revision_extraction.sh
+++ b/tasks/managed/update-infra-deployments/tests/test_old_revision_extraction.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Tests for the OLD_REVISION extraction logic in the run-update-script step.
+# Run locally: bash test_old_revision_extraction.sh
+#
+
+set -uo pipefail
+
+PASSED=0
+FAILED=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $name"
+        ((PASSED++))
+    else
+        echo "  FAIL: $name (expected='$expected' got='$actual')"
+        ((FAILED++))
+    fi
+}
+
+extract_old_revision() {
+    echo "$1" | grep -E '^-\s+(newTag|digest):' | head -1 | awk '{print $NF}' || true
+}
+
+echo "============================================================"
+echo "  OLD_REVISION extraction — newTag field"
+echo "============================================================"
+DIFF=" some context
+-    newTag: abc123def456
++    newTag: 999888777666
+ more context"
+echo "  Input:    -    newTag: abc123def456"
+RESULT=$(extract_old_revision "$DIFF")
+echo "  Result:   '$RESULT'"
+check "extracts old newTag value" "abc123def456" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  OLD_REVISION extraction — digest field (sha256)"
+echo "============================================================"
+DIGEST="sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+DIFF=" some context
+-    digest: ${DIGEST}
++    digest: sha256:9999999999999999999999999999999999999999999999999999999999999999
+ more context"
+echo "  Input:    -    digest: ${DIGEST:0:40}..."
+RESULT=$(extract_old_revision "$DIFF")
+echo "  Result:   '$RESULT'"
+check "extracts old digest value" "$DIGEST" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  OLD_REVISION extraction — Helm version field (should NOT match)"
+echo "============================================================"
+DIFF=" some context
+-    version: 1.2.3
++    version: 1.3.0
+ more context"
+echo "  Input:    -    version: 1.2.3"
+RESULT=$(extract_old_revision "$DIFF")
+echo "  Result:   '$RESULT'"
+check "returns empty (version field ignored)" "" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  OLD_REVISION extraction — no diff (empty input)"
+echo "============================================================"
+echo "  Input:    (empty)"
+RESULT=$(extract_old_revision "")
+echo "  Result:   '$RESULT'"
+check "returns empty" "" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  OLD_REVISION extraction — multiple fields (takes first)"
+echo "============================================================"
+DIFF="-    newTag: first_sha
++    newTag: new_sha_1
+-    newTag: second_sha
++    newTag: new_sha_2"
+echo "  Input:    two newTag changes (first_sha, second_sha)"
+RESULT=$(extract_old_revision "$DIFF")
+echo "  Result:   '$RESULT'"
+check "extracts first match only" "first_sha" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  OLD_REVISION extraction — mixed digest and newTag (takes first)"
+echo "============================================================"
+DIFF="-    digest: sha256:olddigest
++    digest: sha256:newdigest
+-    newTag: oldtag
++    newTag: newtag"
+echo "  Input:    digest then newTag"
+RESULT=$(extract_old_revision "$DIFF")
+echo "  Result:   '$RESULT'"
+check "extracts first match (digest)" "sha256:olddigest" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  containerImage extraction from snapshot.json"
+echo "============================================================"
+echo "  (same snapshot format used by 12+ tasks/tests in the repo)"
+TMPDIR=$(mktemp -d)
+cat > "${TMPDIR}/snapshot.json" << 'EOF'
+{
+  "application": "myapp",
+  "components": [
+    {
+      "name": "comp",
+      "containerImage": "quay.io/konflux-ci/kyverno/kyverno@sha256:abc123",
+      "source": {
+        "git": {
+          "revision": "50ea70d3999647e328e19ab1700ed78775017f55",
+          "url": "https://github.com/konflux-ci/kyverno"
+        }
+      }
+    }
+  ]
+}
+EOF
+echo "  Input:    snapshot with containerImage='quay.io/konflux-ci/kyverno/kyverno@sha256:abc123'"
+RESULT=$(jq -r .components[0].containerImage "${TMPDIR}/snapshot.json")
+echo "  Result:   '$RESULT'"
+check "extracts containerImage" "quay.io/konflux-ci/kyverno/kyverno@sha256:abc123" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  originRepo extraction from snapshot.json"
+echo "============================================================"
+RESULT=$(jq -r .components[0].source.git.url "${TMPDIR}/snapshot.json")
+echo "  Input:    same snapshot"
+echo "  Result:   '$RESULT'"
+check "extracts originRepo" "https://github.com/konflux-ci/kyverno" "$RESULT"
+
+echo ""
+echo "============================================================"
+echo "  revision extraction from snapshot.json"
+echo "============================================================"
+RESULT=$(jq -r .components[0].source.git.revision "${TMPDIR}/snapshot.json")
+echo "  Input:    same snapshot"
+echo "  Result:   '$RESULT'"
+check "extracts revision" "50ea70d3999647e328e19ab1700ed78775017f55" "$RESULT"
+
+rm -rf "${TMPDIR}"
+
+echo ""
+echo "============================================================"
+TOTAL=$((PASSED + FAILED))
+echo "  RESULTS: ${PASSED}/${TOTAL} passed, ${FAILED} failed"
+echo "============================================================"
+
+[ "$FAILED" -eq 0 ] || exit 1

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -180,6 +180,10 @@ spec:
         echo "origin repo: $originRepo"
         echo "$originRepo" > ../originRepo.txt
 
+        containerImage="$(jq -r .components[0].containerImage "$(params.dataDir)/$(params.snapshotPath)")"
+        echo "container image: $containerImage"
+        echo "$containerImage" > ../containerImage.txt
+
         # Get SCRIPT from Data
         echo "data: $(params.dataDir)/$(params.dataJsonPath)"
         SCRIPT="$(jq -r '."infra-deployment-update-script" // empty' "$(params.dataDir)/$(params.dataJsonPath)")"
@@ -195,6 +199,10 @@ spec:
         echo "patched script:"
         echo "$PATCHED_SCRIPT"
         echo "$PATCHED_SCRIPT" | sh
+
+        OLD_REVISION=$(git diff | grep -E '^-\s+(newTag|digest):' | head -1 | awk '{print $NF}' || true)
+        echo "$OLD_REVISION" > ../old_revision.txt
+        echo "old revision: ${OLD_REVISION:-<none>}"
     - name: get-diff-files
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:
@@ -242,6 +250,7 @@ spec:
         #!/usr/bin/env python3
         import json
         import os
+        import re
         import sys
         import time
         import base64
@@ -275,6 +284,54 @@ spec:
           originRepo = fileA.read().rstrip()
         with open('revision.txt', 'r') as fileB:
           revision = fileB.read().rstrip()
+
+        old_revision = ''
+        old_revision_path = 'old_revision.txt'
+        if os.path.exists(old_revision_path):
+            with open(old_revision_path, 'r') as f:
+                old_revision = f.read().rstrip()
+
+        container_image = ''
+        if os.path.exists('containerImage.txt'):
+            with open('containerImage.txt', 'r') as f:
+                container_image = f.read().rstrip()
+
+        def resolve_digest_to_git_sha(digest, container_image):
+            """Resolve an image digest to a git commit SHA via the Quay public API.
+
+            Returns None if resolution fails (private repo, no matching tag, etc).
+            """
+            try:
+                # container_image: "quay.io/konflux-ci/kyverno/kyverno@sha256:abc..."
+                repo_url = container_image.split('@')[0]
+                if not repo_url.startswith('quay.io/'):
+                    print(f"Not a quay.io image, skipping digest resolution")
+                    return None
+                repo_path = repo_url.removeprefix('quay.io/')
+                page = 1
+                max_pages = 50
+                while page <= max_pages:
+                    resp = requests.get(
+                        f"https://quay.io/api/v1/repository/{repo_path}/tag/",
+                        params={"limit": 100, "page": page},
+                        timeout=10,
+                    )
+                    if resp.status_code != 200:
+                        print(f"Quay API returned {resp.status_code}, skipping digest resolution")
+                        return None
+                    data = resp.json()
+                    for tag in data.get("tags", []):
+                        if tag.get("manifest_digest") == digest and re.fullmatch(r'[0-9a-f]{40}', tag["name"]):
+                            print(f"Resolved {digest[:19]}... to git SHA {tag['name']}")
+                            return tag["name"]
+                    if not data.get("has_additional", False):
+                        break
+                    page += 1
+                print(f"No git SHA tag found for digest {digest[:19]}...")
+                return None
+            except Exception as e:
+                print(f"Failed to resolve digest to git SHA: {e}")
+                return None
 
         class GitHub():
             token = None
@@ -425,6 +482,35 @@ spec:
                     })
                 return req.json()["items"][0]["pull_request"]["html_url"]
 
+            def get_changelog(self, source_repo, old_rev, new_rev):
+                try:
+                    owner_repo = '/'.join(source_repo.rstrip('/').split('/')[-2:])
+                    req = self._request(
+                        "GET",
+                        f"/repos/{owner_repo}/compare/{old_rev}...{new_rev}",
+                        headers={"Accept": "application/vnd.github.v3+json"})
+                    if req.status_code != 200:
+                        print(f"Compare API returned {req.status_code}, skipping changelog")
+                        return ""
+                    commits = req.json().get("commits", [])
+                    if not commits:
+                        return ""
+                    lines = ["## Changelog"]
+                    for c in commits:
+                        sha = c["sha"][:7]
+                        url = c["html_url"]
+                        msg = c["commit"]["message"].split('\n')[0]
+                        author = c.get("author", {}).get("login") if c.get("author") else None
+                        if author:
+                            lines.append(f"- [`{sha}`]({url}) {msg} - @{author}")
+                        else:
+                            author_name = c["commit"]["author"]["name"]
+                            lines.append(f"- [`{sha}`]({url}) {msg} - {author_name}")
+                    return '\n'.join(lines)
+                except Exception as e:
+                    print(f"Failed to get changelog: {e}")
+                    return ""
+
             def update_mr_description(self, pr_url, description):
                 req = self._request(
                     "PATCH",
@@ -469,7 +555,24 @@ spec:
                 if description is None:
                     description = "Included PRs:"
                 new_pr_link = github_app.get_pr_url_from_sha(revision)
+                changelog_idx = description.find("\r\n\r\n## Changelog")
+                if changelog_idx != -1:
+                    description = description[:changelog_idx]
                 new_description = f"{description}\r\n- {new_pr_link}"
+
+                changelog_rev = old_revision
+                if changelog_rev and changelog_rev.startswith('sha256:'):
+                    resolved = resolve_digest_to_git_sha(changelog_rev, container_image)
+                    if resolved:
+                        changelog_rev = resolved
+                    else:
+                        changelog_rev = ''
+
+                if changelog_rev:
+                    changelog = github_app.get_changelog(originRepo, changelog_rev, revision)
+                    if changelog:
+                        new_description = f"{new_description}\r\n\r\n{changelog}"
+
                 github_app.update_mr_description(infra_pr["url"], new_description)
             else:
                 if "message" in infra_pr:


### PR DESCRIPTION
## What
Add a changelog section to infra-deployments PRs created by the [`update-infra-deployments`](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/update-infra-deployments/update-infra-deployments.yaml) task, listing commits between the previously deployed revision and the new one.

Jira: [KFLUXINFRA-3576](https://redhat.atlassian.net/browse/KFLUXINFRA-3576)

## Why
Currently, infra-deployments PRs only link the source PR. Reviewers have no visibility into what commits changed between the old and new revision, making it difficult to review what's actually being deployed. This adds a markdown changelog with clickable commit SHAs, messages, and authors.

## Validation
- **Unit tests (27 total):** Added [`test_create_pr.py`](https://github.com/glevi-rh/release-service-catalog/blob/changelog-infra-deployments-prs/tasks/managed/update-infra-deployments/tests/test_create_pr.py) (18 tests) and [`test_old_revision_extraction.sh`](https://github.com/glevi-rh/release-service-catalog/blob/changelog-infra-deployments-prs/tasks/managed/update-infra-deployments/tests/test_old_revision_extraction.sh) (9 tests) covering:
  - `get_changelog()` — happy path, nonexistent repo, invalid SHA, same revision, trailing slash, exception handling
  - `resolve_digest_to_git_sha()` — quay resolution, non-quay image, wrong digest, nonexistent repo, network error
  - `OLD_REVISION` extraction regex — newTag, digest, version (ignored), empty input, multiple fields, mixed fields
  - Snapshot field extraction — `containerImage`, `originRepo`, `revision` (same snapshot format used by [12+ tasks/tests](https://github.com/search?q=repo%3Akonflux-ci%2Frelease-service-catalog+%22.components%5B0%5D.containerImage%22&type=code) in the repo)
- **Local tests pass:** All 27 tests (18 Python + 9 bash) pass locally — kept as standalone files for development, not wired into CI hook per review feedback
- **Live API validation:** Tested `get_changelog` against real [GitHub compare API](https://docs.github.com/en/rest/commits/commits#compare-two-commits) (`konflux-ci/release-service`) and `resolve_digest_to_git_sha` against real [Quay tag API](https://docs.quay.io/api/swagger/#!/tag/listRepoTags) (`konflux-ci/release-service-utils`)
- **E2E test passed:** `rhtap-service-push` pipeline ran end-to-end successfully
- **Sanity checks:** `yamllint` and `shellcheck` pass clean on all modified files
- **Existing Tekton test passes:** [`test-update-infra-deployments-fail-no-data-file.yaml`](https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-no-data-file.yaml) unaffected

### Running tests locally
```bash
python3 tasks/managed/update-infra-deployments/tests/test_create_pr.py
bash tasks/managed/update-infra-deployments/tests/test_old_revision_extraction.sh
```

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert the commit and merge to production. The next release will use the previous task version without changelog — no manual intervention needed. Already-created PRs are unaffected.

- **Blast radius:** Only affects the PR description text in infra-deployments PRs. Does not change what gets deployed, which images are pushed, or how the update script modifies files.
- **Failure mode:** If the changelog logic fails (API error, missing old revision, malformed response), the PR is still created with existing behavior — the changelog is purely additive. No release pipeline will be blocked.
- **Authentication:** Uses the already-provisioned GitHub App token. No new secrets or permissions required.

[KFLUXINFRA-3576]: https://redhat.atlassian.net/browse/KFLUXINFRA-3576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ