### PR TITLE
feat(RELEASE-2382): bump utils for exponential backoff

### DIFF
--- a/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
+++ b/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
@@ -73,7 +73,7 @@ spec:
         readOnly: true
   steps:
     - name: check-opt-in
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -86,7 +86,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+      image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-all-images-found-latest.yaml
@@ -65,7 +65,7 @@ spec:
             type: string
         steps:
           - name: verify-latest-advisory-returned
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-custom-live-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-schema.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-check-schema.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -ex # if set -u is here, there will be STDERR_FILE unbound variable errors

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail-existing-id.yaml
@@ -52,7 +52,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-fail.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-generic-content.yaml
@@ -53,7 +53,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-multiple-image.yaml
@@ -61,7 +61,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-idempotency-single-image.yaml
@@ -55,7 +55,7 @@ spec:
             type: string
         steps:
           - name: verify-idempotency
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-jinja-cross-field-references.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-jinja-cross-field-references.yaml
@@ -56,7 +56,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-preserves-tags.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-preserves-tags.yaml
@@ -56,7 +56,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory-stage.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:a9fc6af1db5fefe43c655b3241326e8115cd9569b810bac7effb33b45dd2a855
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/get-advisory-severity.yaml
@@ -57,7 +57,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: get-advisory-severity
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-component.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-empty-component-impact.yaml
@@ -37,7 +37,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-no-cves.yaml
@@ -35,7 +35,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-osidb-calls-parallel.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-osidb-calls-parallel.yaml
@@ -16,7 +16,7 @@ spec:
             type: string
         steps:
           - name: record-time
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-purl-processing-performance.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity-purl-processing-performance.yaml
@@ -17,7 +17,7 @@ spec:
             type: string
         steps:
           - name: record-time
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
+++ b/tasks/internal/get-advisory-severity/tests/test-get-advisory-severity.yaml
@@ -36,7 +36,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-auth-failure.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-auth-failure.yaml
@@ -58,7 +58,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-empty-fragments-array.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-empty-fragments-array.yaml
@@ -14,7 +14,7 @@ spec:
       taskSpec:
         steps:
           - name: verify-failure
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             script: |
               #!/bin/bash
               set -x

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-error.yaml
@@ -48,7 +48,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-hotfix.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-index-mismatch.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-index-mismatch.yaml
@@ -41,7 +41,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-multiple-fragments.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-multiple-fragments.yaml
@@ -48,7 +48,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-stage-resume-inprogress.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-stage-resume-inprogress.yaml
@@ -57,7 +57,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
+++ b/tasks/internal/update-fbc-catalog-task/tests/test-update-fbc-catalog-staged-index.yaml
@@ -51,7 +51,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
             env:
               - name: BUILD_STATE
                 value: $(params.buildState)

--- a/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
+++ b/tasks/internal/update-fbc-catalog-task/update-fbc-catalog-task.yaml
@@ -96,7 +96,7 @@ spec:
   steps:
     - name: update-fbc-catalog-prepare-and-call-iib-step
       image: >-
-        quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+        quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
       securityContext:
         runAsUser: 1001
       computeResources:
@@ -423,7 +423,7 @@ spec:
         echo "${iib_response}" | gzip -c | base64 -w0 > "$(results.jsonBuildInfo.path)"
     - name: update-fbc-catalog-wait-for-iib-build-step
       image: >-
-        quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+        quay.io/konflux-ci/release-service-utils@sha256:b524cefd4f00d386fd50fcc4892b761f09c8c5ca49242700c5ee129aae1408d3
       computeResources:
         limits:
           memory: 256Mi


### PR DESCRIPTION
Update the release-service-utils image digest in all internal tasks that use the retry script to pick up the exponential backoff change from release-service-utils [1].

[1] https://github.com/konflux-ci/release-service-utils/pull/729

Assisted-by: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
