### PR TITLE
fix(RELEASE-1939): use standard advisory repos for all content types

### DIFF
--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -471,8 +471,10 @@ spec:
         stagingSecretName="create-advisory-stage-secret"
         stagingErrataSecretName="errata-stage-service-account"
 
-        # See decision in https://redhat.atlassian.net/browse/HUM-434
-        # why we only publish image or rpm to main advisory repos
+        # All content types use the standard prod/stage advisory repos.
+        # This conditional remains because env selection differs by content type:
+        # - image/rpm: derive env from params.environment
+        # - other types: derive env from data.json .intention
         if [[ "$content_type" =~ ^(image|rpm)$ ]] ; then
 
           advisorySecretName="${prodSecretName}"
@@ -483,11 +485,10 @@ spec:
             errataSecretName="${stagingErrataSecretName}"
           fi
         else
-          # Continue using the POC and staging credentials until CLDX-225
-          # is complete and stakeholders are ready to ingest these advisories
-          prodSecretName="create-advisory-poc-secret"
-          prodErrataSecretName="errata-stage-service-account"
-          stagingSecretName="create-advisory-poc-stage-secret"
+          # Keep explicit assignments here for readability in this branch.
+          prodSecretName="create-advisory-prod-secret"
+          prodErrataSecretName="errata-prod-service-account"
+          stagingSecretName="create-advisory-stage-secret"
           stagingErrataSecretName="errata-stage-service-account"
 
           DATA_FILE="$(params.dataDir)/$(params.dataPath)"

--- a/tasks/managed/create-advisory/tests/test-create-advisory-disk-image-secrets.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-disk-image-secrets.yaml
@@ -265,9 +265,9 @@ spec:
 
               internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
 
-              # For disk-image content types with intention=staging, expect POC staging secrets
+              # For disk-image content types with intention=staging, expect standard staging secrets
               advisory_secret_name=$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name')
-              if [ "$advisory_secret_name" != "create-advisory-poc-stage-secret" ]; then
+              if [ "$advisory_secret_name" != "create-advisory-stage-secret" ]; then
                 echo "InternalRequest has the wrong advisory_secret_name parameter"
                 echo "$internalRequest" | jq
                 exit 1


### PR DESCRIPTION
Now that we have confirmed downstream tools (sdengine and customer portal) can consume advisories from non-image content types we can remove the poc testing repos and use the production/stage ones. 

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
