### PR TITLE
fix(push-disk-images): use stage CGW endpoint for stage releases

### DIFF
--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -263,6 +263,13 @@ spec:
             || (echo "Missing contentGateway.filePrefix value for component. This should be the prefix for files to \
                   upload to the Developer Portal. Failing" && exit 1)
 
+          # Set proxy for preprod CGW environment (requires squid proxy for access)
+          if [[ "$(params.cgwHostname)" == *"developers.qa.redhat.com"* ]]; then
+            export HTTP_PROXY="http://squid.corp.redhat.com:3128"
+            export HTTPS_PROXY="http://squid.corp.redhat.com:3128"
+            echo "Using squid proxy for preprod CGW access"
+          fi
+
           developer_portal_wrapper --debug --product-name "${productName}" \
             --product-code "${productCode}" \
             --product-version-name "${productVersionName}" \

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -152,18 +152,19 @@ spec:
           cgwSecret="cgw-service-account-prod-secret"
         elif [ "${env}" = "stage" ] ; then
           # The url is the same for exodus in both prod and stage, it is just a different env and pulp url
+          # stage cgw uses 'qa': developers.qa.redhat.com
           exodusGwSecret="exodus-prod-secret"
           exodusGwEnv="pre"
           pulpSecret="rhsm-pulp-stage-secret"
           udcacheSecret="udcache-stage-secret"
-          cgwHostname="https://developers.redhat.com/content-gateway/rest/admin"
-          cgwSecret="cgw-service-account-prod-secret"
+          cgwHostname="https://developers.qa.redhat.com/content-gateway/rest/admin"
+          cgwSecret="cgw-service-account-stage-secret"
         elif [ "${env}" = "qa" ]; then
           exodusGwSecret="exodus-stage-secret"
           exodusGwEnv="live"
           pulpSecret="rhsm-pulp-qa-secret"
           udcacheSecret="udcache-qa-secret"
-          cgwHostname="https://developers.stage.redhat.com/content-gateway/rest/admin"
+          cgwHostname="https://developers.qa.redhat.com/content-gateway/rest/admin"
           cgwSecret="cgw-service-account-stage-secret"
         else
           echo "cdn.env in the data file must be one of [production, stage, qa]."


### PR DESCRIPTION
Correct the cdn.env=stage mapping in push-disk-images to use the stage content gateway host and credentials, since the previous configuration routed stage releases to the wrong environment.
This is already what we are doing with push-artifacts-to-cdn pipeline.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
