### PR TITLE
fix(RELEASE-2253): prevent redundant tags on pre-GA and hotfix index images

### DIFF
--- a/integration-tests/fbc-release/test.sh
+++ b/integration-tests/fbc-release/test.sh
@@ -639,14 +639,56 @@ verify_staged() {
 verify_prega() {
     local release_name=$1
     echo "🔍 Verifying prega scenario for: $release_name"
-    # Add prega-specific verification logic here
-    return 0
+    verify_no_redundant_timestamp "$release_name"
+    return $?
 }
 
 verify_hotfix() {
     local release_name=$1
     echo "🔍 Verifying hotfix scenario for: $release_name"
-    # Add hotfix-specific verification logic here
+    verify_no_redundant_timestamp "$release_name"
+    return $?
+}
+
+# Verify that target_index tags do not contain redundant timestamps.
+# Hotfix/pre-GA tags already include a unique suffix (e.g., v4.13-bz12345-<ts>).
+# A bug in collect-index-images could append a second timestamp, producing
+# something like v4.13-bz12345-1715000000-1715000099. This function catches that.
+verify_no_redundant_timestamp() {
+    local release_name=$1
+    local failures=0
+
+    local release_json
+    release_json=$(kubectl get release/"${release_name}" -n "${RELEASE_NAMESPACE}" -ojson)
+
+    local component_count
+    component_count=$(jq '.status.artifacts.components | length' <<< "${release_json}")
+
+    for ((i=0; i<component_count; i++)); do
+        local target_index
+        target_index=$(jq -r --argjson i "$i" \
+            '.status.artifacts.components[$i].target_index // ""' <<< "${release_json}")
+
+        if [ -z "${target_index}" ]; then
+            continue
+        fi
+
+        local tag="${target_index##*:}"
+
+        # A redundant timestamp looks like two consecutive numeric segments of 10+ digits
+        # at the end of the tag, e.g. v4.13-bz12345-1715000000-1715000099
+        if [[ "${tag}" =~ -[0-9]{10,}-[0-9]{10,}$ ]]; then
+            echo "🔴 target_index tag has redundant timestamp: ${tag}"
+            failures=$((failures + 1))
+        else
+            echo "✅ target_index tag has no redundant timestamp: ${tag}"
+        fi
+    done
+
+    if (( failures > 0 )); then
+        echo "🔴 Found ${failures} target_index tag(s) with redundant timestamps"
+        return 1
+    fi
     return 0
 }
 

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -136,7 +136,11 @@ spec:
 
           TAG=${TARGETINDEX#*:}
           TAGS=("${TAG}")
-          if [[ ! "${TAG}" =~ .*$(params.buildTimestamp)$ ]]; then
+          # Only add a buildTimestamp tag for bare OCP version tags (e.g., "v4.13").
+          # Hotfix and pre-GA tags already have unique suffixes from prepare-fbc-snapshot
+          # (e.g., "v4.13-RELEASE-1234-<ts>" or "v4.13-product-1.0-<ts>"), so appending
+          # a second timestamp would create a redundant tag.
+          if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+$ ]]; then
             TAGS+=("${TAG}-$(params.buildTimestamp)")
           fi
           JSON_TAGS=$(jq -n -c '$ARGS.positional' --args -- "${TAGS[@]}")

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images-hotfix.yaml
@@ -5,7 +5,8 @@ metadata:
   name: test-collect-index-images-hotfix
 spec:
   description: |
-    Run the collect-index-images task for hotfix index image and verify the results
+    Run the collect-index-images task for hotfix and pre-GA index images and verify
+    that no redundant buildTimestamp tag is appended to tags that already have unique suffixes
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -60,6 +61,10 @@ spec:
                   {
                     "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12-12345-6789",
                     "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk"
+                  },
+                  {
+                    "target_index": "quay.io/redhat/redhat----preview-operator-index:v4.13-myproduct-1.0-20250220143022",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:lmnopqrstuv"
                   }
                 ]
               }
@@ -81,7 +86,7 @@ spec:
         - name: internalRequestResultsFile
           value: "internal-requests-results.json"
         - name: buildTimestamp
-          value: "6789"
+          value: "9999"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -186,6 +191,25 @@ spec:
                 exit 1
               fi
 
+              # Verify pre-GA component (index 1) - tag should remain as-is
+              if [ "$(jq -r '.components[1].containerImage' < "${SNAPSHOT_FILE}")" != \
+                "redhat.com/rh-stage/iib@sha256:lmnopqrstuv" ]; then
+                echo "pre-GA containerImage does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.components[1].repositories[0].url' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/redhat/redhat----preview-operator-index" ]; then
+                echo "pre-GA repository does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -c '.components[1].repositories[0].tags' < "${SNAPSHOT_FILE}")" != \
+                "[\"v4.13-myproduct-1.0-20250220143022\"]" ]; then
+                echo "pre-GA tags do not match - buildTimestamp may have been incorrectly appended"
+                exit 1
+              fi
+
               # Remove from here to next comment when repository key support is removed
               if [ "$(jq -r '.components[0].repository' < "${SNAPSHOT_FILE}")" != \
                 "quay.io/redhat/redhat----fbc-target-index" ]; then
@@ -194,6 +218,16 @@ spec:
               fi
               if [ "$(jq -c '.components[0].tags' < "${SNAPSHOT_FILE}")" != "[\"v4.12-12345-6789\"]" ]; then
                 echo "tags do not match"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[1].repository' < "${SNAPSHOT_FILE}")" != \
+                "quay.io/redhat/redhat----preview-operator-index" ]; then
+                echo "pre-GA repository does not match"
+                exit 1
+              fi
+              if [ "$(jq -c '.components[1].tags' < "${SNAPSHOT_FILE}")" != \
+                "[\"v4.13-myproduct-1.0-20250220143022\"]" ]; then
+                echo "pre-GA tags do not match - buildTimestamp may have been incorrectly appended"
                 exit 1
               fi
               # End of block to be removed


### PR DESCRIPTION
## Describe your changes
### Problem
The `collect-index-images` task adds a `buildTimestamp` tag to each published index image (e.g., `v4.13-1740067822`). It has a regex check to skip this if the tag already ends with the `buildTimestamp` value. However, in production this check never works for hotfix/pre-GA releases because:
1. `prepare-fbc-snapshot` generates timestamp **T1** and embeds it in the tag suffix (e.g., `v4.13-RELEASE-1234-T1`)
2. `add-fbc-contribution` generates timestamp **T2** (minutes/hours later) and stores it as `buildTimestamp`
3. `collect-index-images` checks if the tag ends with T2 — it doesn't (it ends with T1) — so a redundant tag is appended
This results in pre-GA/hotfix images getting two tags when they should only have one, which can confuse downstream tasks like `create-pyxis-image`.
### Fix
Changed the condition from "does the tag end with buildTimestamp?" to "is this a bare OCP version tag (`^v[0-9]+\.[0-9]+$`)?"
- **Bare tags** (e.g., `v4.13`) → buildTimestamp tag added (correct, intended behavior for normal releases)
- **Suffixed tags** (e.g., `v4.13-RELEASE-1234-6789` or `v4.13-product-1.0-20250220143022`) → already unique, no extra tag
### Changes
- `collect-index-images.yaml`: Updated tag-append condition
- `test-collect-index-images-hotfix.yaml`: Added pre-GA component as second test case with mismatched buildTimestamp to cover both hotfix and pre-GA scenarios in a single test
### Testing
- Existing `single-version` and `multiple-versions` tests still pass (normal releases get timestamp tag)
- Updated hotfix test verifies both hotfix and pre-GA tags remain as-is (no redundant timestamp appended)
### Note
Related to [#2087](https://github.com/konflux-ci/release-service-catalog/pull/2087) (KONFLUX-12379) which fixes Pyxis/registry tag mismatch by unifying on `completion_time`. Different bugs, same area of code. Our regex guard is independent — it controls **when** a timestamp tag is added, not **which** timestamp is used. Trivial rebase conflict expected with whoever merges second.
## Relevant Jira
[RELEASE-2253](https://issues.redhat.com/browse/RELEASE-2253)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`


[RELEASE-2253]: https://redhat.atlassian.net/browse/RELEASE-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ