### PR TITLE
fix: use legacy branch for deploy-konflux-ci task

### DIFF
--- a/integration-tests/pipelines/e2e-tests-kind-quay-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-kind-quay-pipeline.yaml
@@ -160,7 +160,7 @@ spec:
         - name: repo-url
           value: https://github.com/konflux-ci/konflux-ci.git
         - name: repo-branch
-          value: main
+          value: legacy
         - name: component-name
           value: release-service-catalog
         - name: component-pr-owner


### PR DESCRIPTION
## Describe your changes
The deploy-konflux.sh script was removed from the main branch of [konflux-ci](https://issues.redhat.com/browse/KONFLUX-ci)/[konflux-ci](https://issues.redhat.com/browse/KONFLUX-ci). Switch to the legacy branch where it still exists.

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
