### PR TITLE
fix(CALUNGA-231): populate mapping contentType for Python wheel releases

### DIFF
--- a/tasks/managed/extract-py-artifacts/README.md
+++ b/tasks/managed/extract-py-artifacts/README.md
@@ -1,6 +1,9 @@
 # extract-py-artifacts
 
 Extract Python packages from OCI artifacts for signing and upload.
+The populate-release-notes step parses wheel SBOMs for pkg:pypi PURLs,
+populates releaseNotes.content.artifacts, and ensures mapping.components
+entries have contentType set to "generic" for downstream advisory creation.
 The fetch-chains-provenance step verifies and retrieves Tekton Chains SLSA provenance
 using cosign with the public key from k8s://openshift-pipelines/public-key.
 The pipeline service account must have get access to this secret

--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   description: |
     Extract Python packages from OCI artifacts for signing and upload.
+    The populate-release-notes step parses wheel SBOMs for pkg:pypi PURLs,
+    populates releaseNotes.content.artifacts, and ensures mapping.components
+    entries have contentType set to "generic" for downstream advisory creation.
     The fetch-chains-provenance step verifies and retrieves Tekton Chains SLSA provenance
     using cosign with the public key from k8s://openshift-pipelines/public-key.
     The pipeline service account must have get access to this secret
@@ -263,6 +266,32 @@ spec:
         TMP_DATA=$(mktemp)
         jq --argjson artifacts "$DEDUPED" '
           .releaseNotes.content.artifacts = (.releaseNotes.content.artifacts // []) + $artifacts
+        ' "$DATA_FILE" > "$TMP_DATA" && mv "$TMP_DATA" "$DATA_FILE"
+
+        # Ensure mapping.components[] includes each artifact component with contentType
+        COMPONENT_NAMES=$(jq -r '[.[].component] | unique | .[]' <<< "$DEDUPED")
+        MAPPING_ENTRIES="[]"
+        while IFS= read -r comp; do
+          MAPPING_ENTRIES=$(jq -c --arg name "$comp" \
+            '. + [{name: $name, contentType: "generic"}]' \
+            <<< "$MAPPING_ENTRIES")
+        done <<< "$COMPONENT_NAMES"
+        jq --argjson new_comps "$MAPPING_ENTRIES" '
+          ($new_comps | map(.name)) as $names |
+          (.mapping.components // []) as $existing |
+          ($existing | map(.name)) as $existing_names |
+          .mapping.components = [
+            $existing[] |
+            if (.name as $n | $names | index($n))
+               and ((.contentGateway?.contentType //
+                     .contentType // "") == "")
+            then . + {contentType: "generic"}
+            else . end
+          ] + [
+            $new_comps[]
+            | select(.name as $n |
+                $existing_names | index($n) | not)
+          ]
         ' "$DATA_FILE" > "$TMP_DATA" && mv "$TMP_DATA" "$DATA_FILE"
 
         echo "Done. Updated artifacts:"

--- a/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/tests/test-extract-py-artifacts.yaml
@@ -70,6 +70,13 @@ spec:
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "test_package"
+                    }
+                  ]
+                },
                 "releaseNotes": {
                   "product_id": [123],
                   "type": "RHBA",
@@ -213,12 +220,34 @@ spec:
                 exit 1
               fi
 
+              # Verify existing mapping entry was patched with contentType
+              MAPPING_COUNT=$(jq '.mapping.components | length' "$DATA_FILE")
+              if [ "$MAPPING_COUNT" -ne 1 ]; then
+                echo "ERROR: Expected 1 mapping component (patched, not duplicated), got: $MAPPING_COUNT"
+                jq '.mapping.components' "$DATA_FILE"
+                exit 1
+              fi
+
+              MAPPED_NAME=$(jq -r '.mapping.components[0].name' "$DATA_FILE")
+              if [ "$MAPPED_NAME" != "test_package" ]; then
+                echo "ERROR: Expected mapping component name 'test_package', got: $MAPPED_NAME"
+                exit 1
+              fi
+
+              MAPPED_TYPE=$(jq -r '.mapping.components[0].contentType' "$DATA_FILE")
+              if [ "$MAPPED_TYPE" != "generic" ]; then
+                echo "ERROR: Expected contentType 'generic', got: $MAPPED_TYPE"
+                exit 1
+              fi
+
               echo "Files extracted:"
               ls -la "${FILES_DIR}"
               echo "Chains provenance:"
               ls -la "${FILES_DIR}/chains-provenance"
               echo "Release notes artifacts:"
               jq '.releaseNotes.content.artifacts' "$DATA_FILE"
+              echo "Mapping components:"
+              jq '.mapping.components' "$DATA_FILE"
 
               echo "All checks passed!"
       runAfter:


### PR DESCRIPTION
The create-advisory task defaults to contentType "image" when mapping.components[] lacks a contentType field, causing it to use .content.images instead of .content.artifacts for wheel advisories.

Add contentType: "generic" entries to mapping.components[] in the extract-py-artifacts populate-release-notes step (which already iterated through the wheels) so downstream tasks correctly identify the artifact type.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
