### PR TITLE
Export pulp-upload credentials from mounted secret

### DIFF
--- a/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
+++ b/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
@@ -131,8 +131,13 @@ spec:
           value: $(params.sourceDataArtifact)
     - name: upload
       image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:48c6eff749812d5757933f2f16448866923e15c7d8f5ff88539760b0cc290ba1
-      command:
-        - pulp-upload
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        TWINE_USERNAME=$(< /etc/service-account-secret/username)
+        TWINE_PASSWORD=$(< /etc/service-account-secret/password)
+        export TWINE_USERNAME TWINE_PASSWORD
+        pulp-upload
       computeResources:
         limits:
           memory: 256Mi


### PR DESCRIPTION
The plumbing-utils image was updated to expect TWINE_USERNAME and TWINE_PASSWORD as environment variables, but the task YAML still mounted the secret as a file. Since the script no longer reads from /etc/service-account-secret/, twine fails with "Credential not found."

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
