### PR TITLE
fix(KONFLUX-13586): run process-component-sbom after cosign signing

### DIFF
--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -590,6 +590,7 @@ spec:
         - apply-mapping
         - collect-tpa-params
         - push-snapshot
+        - sign-image-cosign-keyless
     - name: update-cr-status
       params:
         - name: resource

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -865,6 +865,7 @@ spec:
         - collect-signing-params
         - collect-atlas-params
         - push-snapshot
+        - rh-sign-image-cosign
     - name: process-product-sbom
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"


### PR DESCRIPTION
## Summary

- Fix race condition where `process-component-sbom` (mobster's `cosign attest`) and cosign signing tasks run concurrently after `push-snapshot`, causing the `.att` tag to be overwritten and the release SBOM attestation to be lost.
- Added signing task dependency to `process-component-sbom`'s `runAfter` in both `push-to-external-registry` and `rh-advisories` pipelines, ensuring signing completes before SBOM attestation is pushed.

## Pipelines modified

- `push-to-external-registry`: `process-component-sbom` now runs after `sign-image-cosign-keyless`
- `rh-advisories`: `process-component-sbom` now runs after `rh-sign-image-cosign`

## Test plan

- [ ] Verify `push-to-external-registry` e2e test passes
- [ ] Verify `rh-advisories` pipeline runs successfully
- [ ] After release pipeline completes, confirm `.att` tag on released image contains the release SBOM attestation (5 layers instead of 4)

Fixes: [KONFLUX-13586](https://issues.redhat.com/browse/KONFLUX-13586)


Made with [Cursor](https://cursor.com)

[KONFLUX-13586]: https://redhat.atlassian.net/browse/KONFLUX-13586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ