### PR TITLE
feat(KONFLUX-13586): run keyless signing after keyless sbom

### DIFF
--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -586,6 +586,7 @@ spec:
         - name: buildIdentityRegexp
           value: "$(tasks.collect-signing-params.results.buildIdentityRegexp)"
       runAfter:
+        - sign-image-cosign-keyless
         - collect-data
         - apply-mapping
         - collect-tpa-params


### PR DESCRIPTION
sign-image-cosign-keyless cannot run concurently to process-component-sbom as it could lead to
missing signature in destination repository

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
