### PR TITLE
fix(KFLUXVNGD-887): strip .git suffix from origin repo URL when deriving branch name

### DIFF
--- a/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-git-suffix-url.yaml
+++ b/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments-fail-git-suffix-url.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-update-infra-deployments-fail-git-suffix-url
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the update-infra-deployments task with a snapshot whose git URL ends in '.git'.
+    No data file is provided so the task fails fast at the git-clone step. This test
+    ensures the task can be invoked with a .git-suffixed URL without issues in the
+    setup phase, and documents the .git URL scenario for the bash-level strip fix.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/image:tag",
+                    "repository": "prod-registry.io/prod-location",
+                    "tags": [
+                      "tag"
+                    ],
+                    "source": {
+                      "git": {
+                        "revision": "abc123",
+                        "url": "https://github.com/myorg/myrepo.git"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+              # Intentionally NOT creating data.json to trigger fast failure at git-clone step
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: update-infra-deployments
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataJsonPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -177,6 +177,7 @@ spec:
         echo "$revision" > ../revision.txt
 
         originRepo="$(jq -r .components[0].source.git.url "$(params.dataDir)/$(params.snapshotPath)")"
+        originRepo="${originRepo%.git}"
         echo "origin repo: $originRepo"
         echo "$originRepo" > ../originRepo.txt
 


### PR DESCRIPTION
## Describe your changes
When the snapshot's source.git.url ends with '.git', the derived branch name used for infra-deployments PRs included the suffix (e.g. 'caching.git' instead of 'caching'), causing duplicate PRs to be opened for the same logical update. Use removesuffix('.git') to normalize the URL before extracting the branch name.

## Relevant Jira
https://redhat.atlassian.net/browse/KFLUXVNGD-887

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
