### PR TITLE
feat(RELEASE-2170): remove workspace from signing pipeline

### DIFF
--- a/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
+++ b/pipelines/internal/simple-signing-pipeline/simple-signing-pipeline.yaml
@@ -58,8 +58,6 @@ spec:
     - name: signer_type
       description: single or batch from signing configMap SIGNER_TYPE
       type: string
-  workspaces:
-    - name: pipeline
   tasks:
     - name: request-and-upload-signature
       retries: 2
@@ -97,7 +95,3 @@ spec:
           value: $(params.pyxis_url)
         - name: signer_type
           value: $(params.signer_type)
-      workspaces:
-        - name: data
-          workspace: pipeline
-          subPath: signing

--- a/tasks/internal/request-and-upload-signature/README.md
+++ b/tasks/internal/request-and-upload-signature/README.md
@@ -3,6 +3,8 @@
 Tekton task to request and upload a simple signature.
 - This task is meant to be used in an internal pipeline that can be triggered frequently
   and is expected to complete as quickly as possible.
+- Note: This task uses an emptyDir volume for inter-step data sharing. Tests inject
+  a workspace for verification purposes via pre-apply-task-hook.
 
 ## Parameters
 

--- a/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
+++ b/tasks/internal/request-and-upload-signature/request-and-upload-signature.yaml
@@ -11,6 +11,8 @@ spec:
     Tekton task to request and upload a simple signature.
     - This task is meant to be used in an internal pipeline that can be triggered frequently
       and is expected to complete as quickly as possible.
+    - Note: This task uses an emptyDir volume for inter-step data sharing. Tests inject
+      a workspace for verification purposes via pre-apply-task-hook.
   params:
     - description: |
         List of space separated manifest digests for the signed content, usually in the format sha256:xxx
@@ -84,6 +86,8 @@ spec:
           - key: $(params.caTrustConfigMapKey)
             path: ca-bundle.crt
         optional: true
+    - name: workspace-data
+      emptyDir: {}
   results:
     - name: certificate-issuer
       description: issuer uid extracted from the certificate
@@ -92,6 +96,8 @@ spec:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
         readOnly: true
+      - name: workspace-data
+        mountPath: /workspace/data
   steps:
     - name: check-certificates
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
@@ -142,7 +148,7 @@ spec:
         requests:
           memory: 128Mi
           cpu: 100m
-      workingDir: "$(workspaces.data.path)"
+      workingDir: "/workspace/data"
       volumeMounts:
         - name: umb-ssl-cert-secret
           mountPath: /mnt/umb_ssl_cert_secret
@@ -166,7 +172,7 @@ spec:
         requests:
           memory: 128Mi
           cpu: 100m
-      workingDir: "$(workspaces.data.path)"
+      workingDir: "/workspace/data"
       env:
         - name: UMB_CERT_PATH
           value: "/tmp/crt"
@@ -196,7 +202,7 @@ spec:
           creator="{creator}"
         fi
 
-        cat <<EOF > "$(workspaces.data.path)/pubtools-sign-config.yaml"
+        cat <<EOF > "/workspace/data/pubtools-sign-config.yaml"
         msg_signer:
           messaging_brokers:
             - "amqps://${umb_url}:5671"
@@ -228,7 +234,7 @@ spec:
           chunk_size: 200
         EOF
         echo "Using signing config:"
-        cat "$(workspaces.data.path)/pubtools-sign-config.yaml"
+        cat "/workspace/data/pubtools-sign-config.yaml"
     - name: check-umb-connection
       image: "quay.io/konflux-ci/release-service-utils:13e379cb498293f8f7b8b9c84c57d9e8ab141be2"
       computeResources:
@@ -237,7 +243,7 @@ spec:
         requests:
           memory: 128Mi
           cpu: 100m
-      workingDir: "$(workspaces.data.path)"
+      workingDir: "/workspace/data"
       volumeMounts:
         - name: umb-ssl-cert-secret
           mountPath: /mnt/umb_ssl_cert_secret
@@ -269,7 +275,7 @@ spec:
         requests:
           memory: 128Mi
           cpu: 100m
-      workingDir: "$(workspaces.data.path)"
+      workingDir: "/workspace/data"
       volumeMounts:
         - name: umb-ssl-cert-secret
           mountPath: /mnt/umb_ssl_cert_secret
@@ -329,12 +335,12 @@ spec:
         done
 
         echo "Running pubtools-sign-msg-container-sign "
-        echo "${signing_key_args[@]}" " --config-file $(workspaces.data.path)/pubtools-sign-config.yaml "
+        echo "${signing_key_args[@]}" " --config-file /workspace/data/pubtools-sign-config.yaml "
         echo "${reference_args[@]}" " " "${digest_args[@]}" "--task-id $task_id"
 
         pubtools-sign-msg-container-sign \
           --requester "${requester}" \
-          --config-file "$(workspaces.data.path)/pubtools-sign-config.yaml" \
+          --config-file "/workspace/data/pubtools-sign-config.yaml" \
           "${reference_args[@]}" \
           "${digest_args[@]}" \
           --signer-type "${signer_type}" \
@@ -351,7 +357,7 @@ spec:
         requests:
           memory: 128Mi
           cpu: 100m
-      workingDir: "$(workspaces.data.path)"
+      workingDir: "/workspace/data"
       env:
         - name: signature_data_file
           value: "$(params.signature_data_file)"
@@ -360,13 +366,13 @@ spec:
       script: |
         #!/usr/bin/env /bin/bash
         set -xe
-        STATUS=$(cat "$(workspaces.data.path)/${signature_data_file}" | jq ".signer_result.status" | tr -d \")
-        ERRORS=$(cat "$(workspaces.data.path)/${signature_data_file}" | jq ".signer_result.error_message")
+        STATUS=$(cat "/workspace/data/${signature_data_file}" | jq ".signer_result.status" | tr -d \")
+        ERRORS=$(cat "/workspace/data/${signature_data_file}" | jq ".signer_result.error_message")
         if [ "${STATUS}" != "ok" ]; then
           echo "Signing failed with error: ${ERRORS}"
           exit 1
         fi
-        SIGNATURE_ERRORS=$(cat "$(workspaces.data.path)/${signature_data_file}" |\
+        SIGNATURE_ERRORS=$(cat "/workspace/data/${signature_data_file}" |\
           jq -c '[.operation_results[]?[0]?.msg?.errors? // [] | select(length > 0)]')
         if [ "$SIGNATURE_ERRORS" != "[]" ]; then
           echo "Signing failed with errors:"
@@ -376,7 +382,7 @@ spec:
 
         if [ "$signer_type" == "single" ]; then
           SIGNATURE_DATA=$(
-            cat "$(workspaces.data.path)/${signature_data_file}" | \
+            cat "/workspace/data/${signature_data_file}" | \
             jq -cM "[
               [.operation_results, .operation.references]|
               transpose|
@@ -389,7 +395,7 @@ spec:
             ]")
         elif [ "$signer_type" == "batch" ]; then
           SIGNATURE_DATA=$(
-            cat "$(workspaces.data.path)/${signature_data_file}" | \
+            cat "/workspace/data/${signature_data_file}" | \
             jq -cM '[
               (.operation_results|.[]|.[0].msg.claims)
               |.[]
@@ -414,7 +420,7 @@ spec:
         requests:
           memory: 56Mi
           cpu: 25m
-      workingDir: "$(workspaces.data.path)"
+      workingDir: "/workspace/data"
       volumeMounts:
         - name: pyxis-ssl-cert-secret
           mountPath: /mnt/pyxis_ssl_cert_secret
@@ -448,5 +454,3 @@ spec:
           --pyxis-ssl-keyfile "${PYXIS_KEY_PATH}" \
           --request-threads "${pyxis_threads}" \
           --signatures @"${signature_data_file}"
-  workspaces:
-    - name: data

--- a/tasks/internal/request-and-upload-signature/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/request-and-upload-signature/tests/pre-apply-task-hook.sh
@@ -3,9 +3,21 @@
 # Add mocks to the beginning of task step script
 TASK_PATH="$1"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-for i in `seq 0 6`; do
+
+# Inject mocks into all step scripts
+num_steps=$(yq '.spec.steps | length' "$TASK_PATH")
+for i in $(seq 0 $((num_steps - 1))); do
   yq -i '.spec.steps['$i'].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps['$i'].script' "$TASK_PATH"
 done
+
+# Replace emptyDir volume with workspace for testing
+# The production task uses emptyDir mounted at /workspace/data for inter-step data sharing,
+# but tests need a workspace to verify mock calls by sharing data with the check-result task.
+# Since Tekton mounts workspaces at /workspace/<name> by default, a workspace named "data"
+# will mount at /workspace/data - the same path as the emptyDir - so no path changes needed.
+yq -i 'del(.spec.volumes[] | select(.name == "workspace-data"))' "$TASK_PATH"
+yq -i 'del(.spec.stepTemplate.volumeMounts[] | select(.name == "workspace-data"))' "$TASK_PATH"
+yq -i '.spec.workspaces += [{"name": "data"}]' "$TASK_PATH"
 
 # Create a dummy secret for ssl cert for pyxis interactions (and delete it first if it exists)
 kubectl delete secret pyxis-ssl-cert --ignore-not-found


### PR DESCRIPTION
## Describe your changes

Replace workspace with emptyDir volume for inter-step data sharing in the request-and-upload-signature task. This improves performance and reduces scheduling issues on the cluster.

Using PVC-backed workspaces can create scheduling challenges when multiple TaskRuns need to run concurrently, as PVCs may have access mode limitations and node affinity constraints. The emptyDir approach eliminates these issues since the data only needs to be shared between steps within the same TaskRun, not across tasks.

For testing, the pre-apply-task-hook now injects a workspace to allow the check-result task to verify mock calls. This is a testing fixture pattern that doesn't affect the production task.

## Relevant Jira

RELEASE-2170

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
