### PR TITLE
test(RELEASE-2326): add collectors-no-cve e2e test for the no-CVE path

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -7,6 +7,7 @@ This directory contains end-to-end integration tests for the Release Service Cat
 The following integration test suites are available:
 
 - **[collectors](collectors/)** - Tests for advisory data collection and processing
+- **[collectors-no-cve](collectors-no-cve/)** - Tests for the no-CVE path of advisory data collection
 - **[fbc-release](fbc-release/)** - Tests for File-Based Catalog (FBC) release pipeline
 - **[push-to-addons-registry](push-to-addons-registry/)** - Tests for pushing to addon registries
 - **[rh-push-helm-chart-to-registry-redhat-io](rh-push-helm-chart-to-registry-redhat-io/)** - Tests for Helm OCI chart release pipeline

--- a/integration-tests/collectors-no-cve/README.md
+++ b/integration-tests/collectors-no-cve/README.md
@@ -1,0 +1,30 @@
+# collectors-no-cve
+
+This is a variant of the `collectors` integration test that exercises the **no-CVE path**.
+
+## What it tests
+
+When a component image has no CVEs (i.e., the commit message does not reference any CVE IDs):
+
+- The CVE collector produces an empty `releaseNotes.cves` array
+- `set-advisory-severity` leaves severity unset (null) since the advisory type remains RHBA
+- The advisory description contains no CVE entries
+- The release notes `cves` array is empty
+
+This complements the standard `collectors` test which always runs with CVE-2024-8260
+present in the commit message.
+
+## Running locally
+
+```bash
+./integration-tests/run-test.sh collectors-no-cve
+```
+
+## Relationship to `collectors`
+
+This suite shares all Kubernetes resource definitions, vault secrets, and pipeline
+configuration with the `collectors` suite via symlinks. The only differences are:
+
+- `test.env`: Unique resource names to avoid collisions with parallel runs, and
+  `export NO_CVE="true"` (vs `NO_CVE="false"` in the `collectors` suite)
+- `test.sh`: Symlink to `collectors/test.sh` (same verification logic for both paths)

--- a/integration-tests/collectors-no-cve/resources/managed/ec-policy.yaml
+++ b/integration-tests/collectors-no-cve/resources/managed/ec-policy.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/ec-policy.yaml

--- a/integration-tests/collectors-no-cve/resources/managed/kustomization.yaml
+++ b/integration-tests/collectors-no-cve/resources/managed/kustomization.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/kustomization.yaml

--- a/integration-tests/collectors-no-cve/resources/managed/rpa.yaml
+++ b/integration-tests/collectors-no-cve/resources/managed/rpa.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/rpa.yaml

--- a/integration-tests/collectors-no-cve/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/collectors-no-cve/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/sa-rolebinding.yaml

--- a/integration-tests/collectors-no-cve/resources/managed/sa.yaml
+++ b/integration-tests/collectors-no-cve/resources/managed/sa.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/managed/sa.yaml

--- a/integration-tests/collectors-no-cve/resources/tenant/application.yaml
+++ b/integration-tests/collectors-no-cve/resources/tenant/application.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/application.yaml

--- a/integration-tests/collectors-no-cve/resources/tenant/component.yaml
+++ b/integration-tests/collectors-no-cve/resources/tenant/component.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/component.yaml

--- a/integration-tests/collectors-no-cve/resources/tenant/kustomization.yaml
+++ b/integration-tests/collectors-no-cve/resources/tenant/kustomization.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/kustomization.yaml

--- a/integration-tests/collectors-no-cve/resources/tenant/rp.yaml
+++ b/integration-tests/collectors-no-cve/resources/tenant/rp.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/rp.yaml

--- a/integration-tests/collectors-no-cve/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/collectors-no-cve/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/sa-rolebinding.yaml

--- a/integration-tests/collectors-no-cve/resources/tenant/sa.yaml
+++ b/integration-tests/collectors-no-cve/resources/tenant/sa.yaml
@@ -1,0 +1,1 @@
+../../../collectors/resources/tenant/sa.yaml

--- a/integration-tests/collectors-no-cve/test.env
+++ b/integration-tests/collectors-no-cve/test.env
@@ -2,9 +2,9 @@ uuid=${uuid:-"$(openssl rand -hex 4)"}
 # make sure uuid is 8 chars long
 uuid="${uuid:0:8}"
 
-export NO_CVE="false"
+export NO_CVE="true"
 
-export originating_tool="collector-e2e-test"
+export originating_tool="collector-no-cve-e2e-test"
 
 # Namespaces
 export tenant_namespace=dev-release-team-tenant
@@ -15,7 +15,7 @@ export tenant_namespace=dev-release-team-tenant
 export managed_namespace=managed-release-team-tenant
 
 export application_name=e2eapp-${uuid}
-export component_type=collectors
+export component_type=collectors-no-cve
 export component_name=${component_type}-${uuid}
 export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux
@@ -27,9 +27,9 @@ export component_repo_name=${component_github_org}/${component_name}
 export component_base_repo_name=${component_github_org}/e2e-base
 export component_git_url=https://github.com/$component_repo_name
 
-export tenant_collector_sa_name=collector-sa-${uuid}
-export tenant_sa_name=collector-tenant-sa-${uuid}
-export release_plan_name=collector-rp-${uuid}
+export tenant_collector_sa_name=collector-no-cve-sa-${uuid}
+export tenant_sa_name=collector-no-cve-tenant-sa-${uuid}
+export release_plan_name=collector-no-cve-rp-${uuid}
 
-export managed_sa_name=collector-sa-${uuid}
-export release_plan_admission_name=collector-rpa-${uuid}
+export managed_sa_name=collector-no-cve-sa-${uuid}
+export release_plan_admission_name=collector-no-cve-rpa-${uuid}

--- a/integration-tests/collectors-no-cve/test.sh
+++ b/integration-tests/collectors-no-cve/test.sh
@@ -1,0 +1,1 @@
+../collectors/test.sh

--- a/integration-tests/collectors-no-cve/utils/cleanup-resources.sh
+++ b/integration-tests/collectors-no-cve/utils/cleanup-resources.sh
@@ -1,0 +1,1 @@
+../../collectors/utils/cleanup-resources.sh

--- a/integration-tests/collectors-no-cve/vault/managed-secrets.yaml
+++ b/integration-tests/collectors-no-cve/vault/managed-secrets.yaml
@@ -1,0 +1,1 @@
+../../collectors/vault/managed-secrets.yaml

--- a/integration-tests/collectors-no-cve/vault/tenant-secrets.yaml
+++ b/integration-tests/collectors-no-cve/vault/tenant-secrets.yaml
@@ -1,0 +1,1 @@
+../../collectors/vault/tenant-secrets.yaml

--- a/integration-tests/collectors/test.sh
+++ b/integration-tests/collectors/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # --- Global Script Variables (Defaults) ---
 CLEANUP="true"
-NO_CVE="false" # Default to false
+NO_CVE="${NO_CVE:-false}"
 
 
 verify_atlas_url() {

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -99,8 +99,8 @@ spec:
               failed_test_cases=()
               success_test_cases=()
 
-              ALL_TESTCASES=("collectors" "e2e" "fbc-release" "push-rpms-to-pulp" "push-to-addons-registry" \
-                "push-to-external-registry-idempotent" \
+              ALL_TESTCASES=("collectors" "collectors-no-cve" "e2e" "fbc-release" "push-rpms-to-pulp" \
+                "push-to-addons-registry" "push-to-external-registry-idempotent" \
                 "push-to-external-registry" "release-to-github" "rh-push-helm-chart-to-registry-redhat-io" \
                 "rh-push-to-external-registry" "rh-push-to-registry-redhat-io" "rhtap-service-push")
               overall_test_count=${#ALL_TESTCASES[@]}

--- a/integration-tests/scripts/find_release_pipelines_from_pr.sh
+++ b/integration-tests/scripts/find_release_pipelines_from_pr.sh
@@ -213,7 +213,7 @@ _emit_integration_testcase_string() {
     while IFS= read -r suite_name; do
       # Add suite_name if not already present
       # special care is needed for collectors
-      if [ "$suite_name" == "collectors" ]; then
+      if [ "$suite_name" == "collectors" ] || [ "$suite_name" == "collectors-no-cve" ]; then
         suite_name="rh-advisories"
       fi
       if [[ ! " ${FOUND_PIPELINENAMES[*]} " =~ " ${suite_name} " ]]; then
@@ -246,6 +246,10 @@ _emit_integration_testcase_string() {
   if [[ " ${SELECTED_TESTCASES[*]} " =~ " push-to-external-registry " ]]; then
     SELECTED_TESTCASES+=("push-to-external-registry-self-hosted-quay")
     SELECTED_TESTCASES+=("push-to-external-registry-idempotent")
+  fi
+  # rh-advisories has an extra test suite for the no-CVE path
+  if [[ " ${SELECTED_TESTCASES[*]} " =~ " rh-advisories " ]]; then
+    SELECTED_TESTCASES+=("collectors-no-cve")
   fi
   if (( ${#SELECTED_TESTCASES[@]} > 0 )); then
     echo -n "${SELECTED_TESTCASES[*]}"


### PR DESCRIPTION
The collectors test always runs with NO_CVE=false, exercising only the CVE-present path. This adds a collectors-no-cve variant that tests the complementary no-CVE path where set-advisory-severity leaves severity unset and the advisory description contains no CVE entries.

The new suite reuses all resources from the collectors suite via symlinks, including test.sh itself. The NO_CVE flag is set explicitly in each suite's test.env, with test.sh respecting a pre-set value via ${NO_CVE:-false}.

The original test.sh already contains all the verification logic for the no-CVE path (guarded by NO_CVE checks), it was just never invoked with NO_CVE=true. A symlink to the same script is therefore sufficient — the only difference is the NO_CVE flag, set explicitly in each suite's test.env, with test.sh respecting a pre-set value via ${NO_CVE:-false}.

Assisted-by: Cursor

## Describe your changes

## Relevant Jira
RELEASE-2326
## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
