### PR TITLE
test(RELEASE-2331): multi-arch manifest list for push-to-addons-registry

### DIFF
--- a/integration-tests/push-to-addons-registry/README.md
+++ b/integration-tests/push-to-addons-registry/README.md
@@ -2,6 +2,9 @@
 
 This test validates the addon registry push pipeline functionality.
 
+The Konflux build is configured for a **multi-arch manifest list** (amd64 and arm64), matching common OSD addon index images.
+**Note:** This test patches the component’s PaC templates in the PR *before merge* to ensure the `build-platforms` param 
+includes `linux/amd64` and `linux/arm64`, so the push pipeline produces a multi-arch index for verification.
 ## Test-Specific Configuration
 
 ### Files Structure

--- a/integration-tests/push-to-addons-registry/resources/tenant/component.yaml
+++ b/integration-tests/push-to-addons-registry/resources/tenant/component.yaml
@@ -6,6 +6,7 @@ metadata:
     git-provider: github
     build.appstudio.openshift.io/request: configure-pac
     image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-multi-platform-oci-ta", "bundle": "latest"}'
   name: ${component_name}
   labels:
     originating-tool: "${originating_tool}"

--- a/integration-tests/push-to-addons-registry/test.sh
+++ b/integration-tests/push-to-addons-registry/test.sh
@@ -1,6 +1,8 @@
 # --- Global Script Variables (Defaults) ---
 CLEANUP="true"
 NO_CVE="true" # Default to true
+# GitHub API curl retries (override in CI/local: export GITHUB_API_CURL_RETRY=5)
+GITHUB_API_CURL_RETRY="${GITHUB_API_CURL_RETRY:-3}"
 
 # Variables that will be set by functions and used globally:
 # component_branch, component_base_branch, component_repo_name (from test.env or similar)
@@ -14,6 +16,140 @@ NO_CVE="true" # Default to true
 # SHA (set by merge_github_pr)
 # component_push_plr_name (set by wait_for_plr_to_appear)
 # RELEASE_NAME, RELEASE_NAMESPACE (set and exported by wait_for_release)
+
+# GET a GitHub API JSON resource; prints the response body on success, returns 1 on curl/HTTP error.
+# Args: token url detail_msg fallback_msg (used when curl fails, with/without .message from body)
+github_api_get_json() {
+  local token="$1"
+  local url="$2"
+  local detail_msg="$3"
+  local fallback_msg="$4"
+  local response api_msg
+  local xtrace_was_on=0
+  case $- in
+    *x*) xtrace_was_on=1 ;;
+  esac
+  if [ "${xtrace_was_on}" -eq 1 ]; then
+    set +x
+  fi
+
+  if ! response=$(curl --retry "${GITHUB_API_CURL_RETRY}" -s --fail-with-body \
+    -H "Authorization: token ${token}" \
+    "${url}"); then
+    if [ "${xtrace_was_on}" -eq 1 ]; then
+      set -x
+    fi
+    if api_msg=$(jq -r '.message // empty' <<< "${response}" 2>/dev/null) && [ -n "${api_msg}" ]; then
+      echo "❌ error: ${detail_msg}: ${api_msg}" >&2
+    else
+      echo "❌ error: ${fallback_msg}" >&2
+    fi
+    return 1
+  fi
+  if [ "${xtrace_was_on}" -eq 1 ]; then
+    set -x
+  fi
+  echo "${response}"
+}
+
+patch_component_source_before_merge() {
+  # CI often runs scripts under xtrace (bash -x). Disable tracing only while handling tokens.
+  local xtrace_was_on=0
+  case $- in
+    *x*) xtrace_was_on=1 ;;
+  esac
+  if [ "${xtrace_was_on}" -eq 1 ]; then
+    set +x
+  fi
+
+  trap 'unset secret_value 2>/dev/null; if [ "${xtrace_was_on}" -eq 1 ]; then set -x; fi' RETURN
+
+  echo "Patching component source BEFORE MERGE to ensure multi-arch build..."
+
+  # PaC GitHub token: do not export — scoped env only for the helper that requires GH_TOKEN.
+  # Vault file uses ${component_name} placeholders; envsubst runs at kubectl apply, not on disk.
+  local secret_value
+  secret_value=$(yq '. | select(.metadata.name | contains("pipelines-as-code-secret-")) | .stringData.password' \
+    "${SUITE_DIR}/resources/tenant/secrets/tenant-secrets.yaml" | head -n 1)
+  while [[ "${secret_value}" == *$'\n' ]]; do
+    secret_value="${secret_value%$'\n'}"
+  done
+
+  if [ -z "${secret_value}" ] || [ "${secret_value}" = "null" ]; then
+    log_error "PaC token not found in tenant secrets (pipelines-as-code-secret-*)"
+  fi
+
+  local file_names=(
+    ".tekton/${component_name}-pull-request.yaml"
+    ".tekton/${component_name}-push.yaml"
+  )
+  local head_sha pr_response
+  pr_response=$(github_api_get_json "${secret_value}" \
+    "https://api.github.com/repos/${component_repo_name}/pulls/${pr_number}" \
+    "GitHub API error fetching PR ${pr_number}" \
+    "failed to fetch PR ${pr_number} from ${component_repo_name} (check PaC token and repo access)") || exit 1
+  head_sha=$(jq -r -e '.head.sha' <<< "${pr_response}") || {
+    log_error "missing or invalid .head.sha in PR ${pr_number} response"
+  }
+
+  for file_name in "${file_names[@]}"; do
+    local decoded_contents encoded_contents
+    local contents_response encoded_content_field
+    echo "Patching ${file_name}..."
+
+    contents_response=$(github_api_get_json "${secret_value}" \
+      "https://api.github.com/repos/${component_repo_name}/contents/${file_name}?ref=${head_sha}" \
+      "GitHub API error fetching ${file_name}" \
+      "failed to fetch ${file_name} at ref ${head_sha} from ${component_repo_name}") || exit 1
+
+    encoded_content_field=$(jq -r -e '.content' <<< "${contents_response}") || {
+      log_error "missing or invalid .content for ${file_name} in PR ${pr_number}"
+    }
+    if ! decoded_contents=$(base64 -d <<< "${encoded_content_field}"); then
+      log_error "failed to base64-decode ${file_name} from PR ${pr_number}"
+    fi
+    if [ -z "${decoded_contents}" ]; then
+      log_error "decoded contents for ${file_name} are empty"
+    fi
+
+    encoded_contents=$(
+      set -eo pipefail
+      work_dir=$(mktemp -d)
+      trap 'rm -rf "${work_dir}"' EXIT
+      nopath_file_name=$(basename "${file_name}")
+      echo "${decoded_contents}" > "${work_dir}/${nopath_file_name}"
+
+      # Ensure linux/amd64 + linux/arm64 are present.
+      if yq -e '(.spec.params[]? | select(.name == "build-platforms") | .value | type) == "!!seq"' \
+        "${work_dir}/${nopath_file_name}" >/dev/null 2>&1; then
+        yq -i '(.spec.params[] | select(.name == "build-platforms") | .value) |= ([.[] | select(. != "linux/arm64")] + ["linux/arm64"])' \
+          "${work_dir}/${nopath_file_name}"
+        yq -i '(.spec.params[] | select(.name == "build-platforms") | .value) |= ([.[] | select(. != "linux/amd64")] + ["linux/amd64"])' \
+          "${work_dir}/${nopath_file_name}"
+      elif yq -e '(.spec.params[]? | select(.name == "build-platforms"))' \
+        "${work_dir}/${nopath_file_name}" >/dev/null 2>&1; then
+        yq -i '(.spec.params[] | select(.name == "build-platforms") | .value) = ["linux/amd64", "linux/arm64"]' \
+          "${work_dir}/${nopath_file_name}"
+      else
+        yq -i '.spec.params += [{"name": "build-platforms", "value": ["linux/amd64", "linux/arm64"]}]' \
+          "${work_dir}/${nopath_file_name}"
+      fi
+
+      base64 -w 0 < "${work_dir}/${nopath_file_name}"
+    ) || {
+      log_error "failed to patch ${file_name} for multi-arch build"
+    }
+
+    GH_TOKEN="${secret_value}" "${SCRIPT_DIR}/scripts/update-file-in-pull-request.sh" \
+      "${component_repo_name}" \
+      "${pr_number}" \
+      "${file_name}" \
+      "Update PaC templates for multi-arch build" \
+      "${encoded_contents}" || log_error "failed to update ${file_name} in PR ${pr_number}"
+  done
+
+  echo "✅️ Successfully patched component PaC templates for multi-arch."
+}
 
 # Function to verify Release contents
 # Relies on global variables: RELEASE_NAMES, RELEASE_NAMESPACE, SCRIPT_DIR, managed_namespace, managed_sa_name, NO_CVE
@@ -29,13 +165,34 @@ verify_release_contents() {
           log_error "Could not retrieve Release JSON for ${RELEASE_NAME}"
       fi
 
-      echo "Release JSON: ${release_json}"
-
       local failures=0
-      local image_url mergerequest_url
+      local image_url mergerequest_url image_arches image_shasum released_status
 
-      image_url=$(jq -r '.status.artifacts.images[0].urls[0] // ""' <<< "${release_json}")
-      mergerequest_url=$(jq -r '.status.artifacts.merge_requests[0].url // ""' <<< "${release_json}")
+      image_url=$(jq -r '.status.artifacts.images[0]?.urls[0]? // ""' <<< "${release_json}")
+      mergerequest_url=$(jq -r '.status.artifacts.merge_requests[0]?.url? // ""' <<< "${release_json}")
+      # Release may list one arch per manifest/index entry (e.g. duplicate amd64); compare distinct sets.
+      # Strip optional linux/ prefix (e.g. linux/amd64 -> amd64). Default null/missing .arches to [].
+      image_arches=$(jq -r '(.status.artifacts.images[0]?.arches? // [])
+        | map((tostring | split("/") | .[-1]))
+        | unique
+        | join(" ")' <<< "${release_json}")
+      image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum? // ""' <<< "${release_json}")
+      released_status=$(jq -r '([.status.conditions[]? | select(.type=="Released") | .status] | first) // ""' <<< "${release_json}")
+
+      echo "Release fields under validation:"
+      echo "  Released: ${released_status}"
+      echo "  image_url: ${image_url}"
+      echo "  mergerequest_url: ${mergerequest_url}"
+      echo "  image_arches: ${image_arches}"
+      echo "  image_shasum: ${image_shasum}"
+
+      echo "Checking Released=True..."
+      if [ "${released_status}" = "True" ]; then
+        echo "✅️ Released=True"
+      else
+        echo "🔴 Released was not True (found: '${released_status}')"
+        failures=$((failures+1))
+      fi
 
       echo "Checking image_url..."
       if [ -n "${image_url}" ]; then
@@ -49,6 +206,39 @@ verify_release_contents() {
         echo "✅️ mergerequest_url: ${mergerequest_url}"
       else
         echo "🔴 mergerequest_url was empty!"
+        failures=$((failures+1))
+      fi
+
+      echo "Checking image arches include amd64 and arm64..."
+      if [[ " ${image_arches} " == *" amd64 "* && " ${image_arches} " == *" arm64 "* ]]; then
+        echo "✅️ Found required arches: ${image_arches}"
+      else
+        echo "🔴 Missing required arches (need: amd64 and arm64), found: '${image_arches}'"
+        failures=$((failures+1))
+      fi
+
+      echo "Checking image shasum (manifest list digest) is present..."
+      if [[ "${image_shasum}" == sha256:* ]]; then
+        echo "✅️ image_shasum: ${image_shasum}"
+      else
+        echo "🔴 image_shasum missing or invalid: '${image_shasum}'"
+        failures=$((failures+1))
+      fi
+
+      echo "Checking skopeo inspect succeeds for both arches (digest pull + registry auth)..."
+      if [ -n "${image_url}" ] && [[ "${image_shasum}" == sha256:* ]]; then
+        set +e
+        "${SCRIPT_DIR}/scripts/skopeo-verify-image.sh" \
+          "${image_url}" "${image_shasum}" \
+          "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" \
+          "amd64 arm64"
+        skopeo_rc=$?
+        set -e
+        if [ "${skopeo_rc}" -ne 0 ]; then
+          failures=$((failures+1))
+        fi
+      elif [ -n "${image_url}" ]; then
+        echo "🔴 Skipping skopeo multi-arch check: image_shasum missing or not sha256:*"
         failures=$((failures+1))
       fi
 

--- a/integration-tests/scripts/skopeo-verify-image.sh
+++ b/integration-tests/scripts/skopeo-verify-image.sh
@@ -1,45 +1,128 @@
 #!/usr/bin/env bash
 # Verifies that an image is pullable from its target registry using skopeo.
 #
-# Usage: skopeo-verify-image.sh <image_url> <image_shasum> <managed_secrets_yaml>
+# Usage: skopeo-verify-image.sh <image_url> <image_shasum> <managed_secrets_yaml> [arches]
 #
 # Arguments:
 #   image_url            - The published image URL (may include a tag or digest)
 #   image_shasum         - The image digest (e.g. sha256:abc123...)
 #   managed_secrets_yaml - Path to the decrypted managed-secrets.yaml file
+#   arches (optional)    - Space-separated list of GOARCH values (e.g. "amd64 arm64").
+#                          When set, verifies the digest is an OCI image index or Docker
+#                          manifest list (--raw mediaType), then runs skopeo inspect with
+#                          --override-arch for each arch. On failure, re-runs the failing
+#                          inspect without suppressing stderr so logs stay debuggable.
+#
+# Environment:
+#   SKOPEO_RETRY_TIMES - skopeo --retry-times value (default: 3). Override in CI/local:
+#                        export SKOPEO_RETRY_TIMES=5
 #
 # Exits with 0 on success, 1 on failure.
 
 set -euo pipefail
 
+SKOPEO_RETRY_TIMES="${SKOPEO_RETRY_TIMES:-3}"
+
 image_url="${1:?image_url argument is required}"
 image_shasum="${2:?image_shasum argument is required}"
 managed_secrets_yaml="${3:?managed_secrets_yaml argument is required}"
+optional_arches="${4:-}"
 
-if [[ "${image_url}" == *"@"* ]]; then
-    STRIPPED_PULLSPEC="${image_url%@*}"
+STRIPPED_PULLSPEC="${image_url}"
+if [[ "${STRIPPED_PULLSPEC}" == *"@"* ]]; then
+    STRIPPED_PULLSPEC="${STRIPPED_PULLSPEC%@*}"
     echo "Stripped digest from: ${image_url} -> ${STRIPPED_PULLSPEC}"
-elif [[ "${image_url}" == *":"* ]]; then
-    STRIPPED_PULLSPEC="${image_url%:*}"
-    echo "Stripped tag from: ${image_url} -> ${STRIPPED_PULLSPEC}"
+fi
+
+# Tags appear only after the last '/'; registry ports (host:port) must not be stripped.
+if [[ "${STRIPPED_PULLSPEC}" == */* ]]; then
+    path_prefix="${STRIPPED_PULLSPEC%/*}"
+    final_segment="${STRIPPED_PULLSPEC##*/}"
 else
-    STRIPPED_PULLSPEC="${image_url}"
+    path_prefix=""
+    final_segment="${STRIPPED_PULLSPEC}"
+fi
+if [[ "${final_segment}" == *":"* ]]; then
+    final_segment="${final_segment%:*}"
+    if [[ -n "${path_prefix}" ]]; then
+        STRIPPED_PULLSPEC="${path_prefix}/${final_segment}"
+    else
+        STRIPPED_PULLSPEC="${final_segment}"
+    fi
+    echo "Stripped tag from: ${image_url} -> ${STRIPPED_PULLSPEC}"
+elif [[ "${STRIPPED_PULLSPEC}" == "${image_url}" ]]; then
     echo "No tag or digest found, using original as is: ${STRIPPED_PULLSPEC}"
 fi
 
 COMPLETE_PULLSPEC="${STRIPPED_PULLSPEC}@${image_shasum}"
 echo "New complete pullspec: ${COMPLETE_PULLSPEC}"
 
+# CI often runs scripts under xtrace (bash -x). Disable tracing while loading registry credentials.
+xtrace_was_on=0
+case $- in
+  *x*) xtrace_was_on=1 ;;
+esac
+if [ "${xtrace_was_on}" -eq 1 ]; then
+  set +x
+fi
+
 DOCKER_CONFIG="$(mktemp -d)"
 export DOCKER_CONFIG
+cleanup_skopeo_verify() {
+  if [ "${xtrace_was_on}" -eq 1 ]; then
+    set -x
+  fi
+  rm -rf "${DOCKER_CONFIG}"
+}
+trap cleanup_skopeo_verify EXIT
 
-yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
-    "${managed_secrets_yaml}" | base64 -d > "${DOCKER_CONFIG}/config.json"
+dockerconfig_b64="$(
+  yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
+    "${managed_secrets_yaml}" | head -n 1
+)"
+if [[ -z "${dockerconfig_b64}" || "${dockerconfig_b64}" == "null" ]]; then
+  echo "🔴 Failed to find push-* dockerconfigjson in managed secrets."
+  exit 1
+fi
+printf '%s' "${dockerconfig_b64}" | base64 -d > "${DOCKER_CONFIG}/config.json"
+unset dockerconfig_b64
 
-if skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
+if [[ -n "${optional_arches}" ]]; then
+    set +e
+    raw_manifest="$(skopeo inspect --tls-verify=true --retry-times "${SKOPEO_RETRY_TIMES}" --raw "docker://${COMPLETE_PULLSPEC}" 2>/dev/null)"
+    rc=$?
+    set -e
+    if [[ "${rc}" -ne 0 ]]; then
+      echo "🔴 Failed to fetch raw manifest for '${COMPLETE_PULLSPEC}'."
+      skopeo inspect --tls-verify=true --retry-times "${SKOPEO_RETRY_TIMES}" --raw "docker://${COMPLETE_PULLSPEC}"
+      exit 1
+    fi
+
+    if ! media_type="$(jq -r '.mediaType // empty' <<< "${raw_manifest}")" || [[ -z "${media_type}" ]]; then
+      echo "🔴 Unable to determine manifest mediaType from raw inspect output."
+      echo "Raw manifest (first 200 chars): $(head -c 200 <<< "${raw_manifest}")"
+      exit 1
+    fi
+    if [[ "${media_type}" != "application/vnd.oci.image.index.v1+json" ]] &&
+       [[ "${media_type}" != "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
+        echo "🔴 Expected OCI image index or Docker manifest list, found mediaType: '${media_type}'"
+        exit 1
+    fi
+    echo "✅️ Verified multi-arch index (mediaType: ${media_type})."
+
+    for arch in ${optional_arches}; do
+        if skopeo inspect --tls-verify=true --retry-times "${SKOPEO_RETRY_TIMES}" --override-arch "${arch}" "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
+            echo "✅️ Image '${COMPLETE_PULLSPEC}' can be inspected for arch ${arch}."
+        else
+            echo "🔴 Failed skopeo inspect for arch ${arch} on '${COMPLETE_PULLSPEC}'."
+            skopeo inspect --tls-verify=true --retry-times "${SKOPEO_RETRY_TIMES}" --override-arch "${arch}" "docker://${COMPLETE_PULLSPEC}"
+            exit 1
+        fi
+    done
+elif skopeo inspect --tls-verify=true --retry-times "${SKOPEO_RETRY_TIMES}" "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
     echo "✅️ Image '${COMPLETE_PULLSPEC}' can be pulled using skopeo."
 else
     echo "🔴 Failed to pull or inspect image '${COMPLETE_PULLSPEC}'."
-    skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}"
+    skopeo inspect --tls-verify=true --retry-times "${SKOPEO_RETRY_TIMES}" "docker://${COMPLETE_PULLSPEC}"
     exit 1
 fi


### PR DESCRIPTION
## Describe your changes
Adds end-to-end coverage for **multi-arch (amd64 + arm64) operator index** flows for the **push-to-addons-registry** pipeline. 

## Relevant Jira
[RELEASE-2331](https://redhat.atlassian.net/browse/RELEASE-2331)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`

Assisted-by: Claude

[RELEASE-2331]: https://redhat.atlassian.net/browse/RELEASE-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ