### PR TITLE
fix(RELEASE-2437): handle empty componentGroup in collect-data

### DIFF
--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -211,8 +211,11 @@ spec:
         echo -e "\nFetching Snapshot Spec"
         SNAPSHOTSPEC_PATH="$(params.subdirectory)/snapshot_spec.json"
         echo -n "$SNAPSHOTSPEC_PATH" > "$(results.snapshotSpec.path)"
+        # Empty-string componentGroup is treated as unset; fall back to .application, then drop it.
         get-resource "snapshot" "${SNAPSHOT}" "{.spec}" \
-          | jq '(if .componentGroup == null then .componentGroup = .application else . end) | del(.application)' \
+          | jq '(if (.componentGroup == null or .componentGroup == "")
+            then .componentGroup = .application else . end)
+            | del(.application)' \
           | tee "$(params.dataDir)/$SNAPSHOTSPEC_PATH"
         labels=$(get-resource "snapshot" "${SNAPSHOT}" "{.metadata.labels}")
         BUILD_ID=$(jq -r '."appstudio.openshift.io/build-pipelinerun" // ""' <<< "${labels}")

--- a/tasks/managed/collect-data/tests/test-collect-data-empty-component-group.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-empty-component-group.yaml
@@ -1,0 +1,226 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-collect-data-empty-component-group
+spec:
+  description: |
+    Run the collect-data task with a Snapshot that has an empty componentGroup field
+    and verify that the application value is used as a fallback.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > release << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Release
+              metadata:
+                name: release-sample
+                namespace: default
+              spec:
+                snapshot: foo
+                releasePlan: foo
+              EOF
+              kubectl apply -f release
+
+              cat > releaseplan << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlan
+              metadata:
+                name: releaseplan-sample
+                namespace: default
+              spec:
+                application: foo
+                target: foo
+              EOF
+              kubectl apply -f releaseplan
+
+              cat > releaseplanadmission << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleasePlanAdmission
+              metadata:
+                name: releaseplanadmission-sample
+                namespace: default
+              spec:
+                applications:
+                  - foo
+                origin: foo
+                policy: foo
+                pipeline:
+                  pipelineRef:
+                    resolver: cluster
+                    params:
+                      - name: name
+                        value: release-pipeline
+                      - name: namespace
+                        value: default
+                      - name: kind
+                        value: pipeline
+              EOF
+              kubectl apply -f releaseplanadmission
+
+              cat > releaseserviceconfig << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: ReleaseServiceConfig
+              metadata:
+                name: releaseserviceconfig-sample
+                namespace: default
+              spec:
+              EOF
+              kubectl apply -f releaseserviceconfig
+
+              cat > snapshot << EOF
+              apiVersion: appstudio.redhat.com/v1alpha1
+              kind: Snapshot
+              metadata:
+                name: snapshot-sample
+                namespace: default
+                labels:
+                  appstudio.openshift.io/build-pipelinerun: sample-build-id
+              spec:
+                application: foo
+                componentGroup: ""
+                components:
+                  - name: name
+                    containerImage: newimage
+              EOF
+              kubectl apply -f snapshot
+    - name: run-task
+      taskRef:
+        name: collect-data
+      params:
+        - name: release
+          value: default/release-sample
+        - name: releasePlan
+          value: default/releaseplan-sample
+        - name: releasePlanAdmission
+          value: default/releaseplanadmission-sample
+        - name: releaseServiceConfig
+          value: default/releaseserviceconfig-sample
+        - name: snapshot
+          value: default/snapshot-sample
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: snapshotSpec
+          value: $(tasks.run-task.results.snapshotSpec)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: snapshotSpec
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo Test that componentGroup was populated from application when empty
+              test "$(jq -r '.componentGroup' < "$(params.dataDir)/$(params.snapshotSpec)")" == foo
+
+              echo Test that application field was removed from snapshot spec
+              test "$(jq -r '.application' < "$(params.dataDir)/$(params.snapshotSpec)")" == null
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete -n default --ignore-not-found=true release release-sample
+              kubectl delete -n default --ignore-not-found=true releaseplan releaseplan-sample
+              kubectl delete -n default --ignore-not-found=true releaseplanadmission releaseplanadmission-sample
+              kubectl delete -n default --ignore-not-found=true releaseserviceconfig releaseserviceconfig-sample
+              kubectl delete -n default --ignore-not-found=true snapshot snapshot-sample


### PR DESCRIPTION
## Describe your changes
The migration from application to componentGroup only checked for null missing the empty string case. This caused downstream advisory commits to have truncated titles.

Assisted-by: Claude Code

## Relevant Jira
https://redhat.atlassian.net/browse/RELEASE-2437

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
