### PR TITLE
fix: scope Release cleanup to individual test suite

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -200,12 +200,13 @@ cleanup_resources() {
         echo "tmpDir not set or not a directory, skipping k8s resource cleanup." | tee -a "${cleanup_log_file}"
     fi
 
-    # Clean up Release CRs created by this specific test run
-    # Use uuid (from test.env) to support concurrent test execution
-    if [ -n "$uuid" ] && [ -n "$tenant_namespace" ]; then
-        echo "Deleting Release CRs with test-run-uuid=${uuid} in namespace ${tenant_namespace}..." | tee -a "${cleanup_log_file}"
+    # Clean up Release CRs created by this specific test suite
+    # Use both uuid and originating-tool labels to avoid deleting Release CRs
+    # belonging to other parallel test suites that share the same uuid
+    if [ -n "$uuid" ] && [ -n "$tenant_namespace" ] && [ -n "$originating_tool" ]; then
+        echo "Deleting Release CRs with test-run-uuid=${uuid},originating-tool=${originating_tool} in namespace ${tenant_namespace}..." | tee -a "${cleanup_log_file}"
         kubectl delete release -n "${tenant_namespace}" \
-            -l test-run-uuid="${uuid}" \
+            -l "test-run-uuid=${uuid},originating-tool=${originating_tool}" \
             --ignore-not-found >> "${cleanup_log_file}" 2>&1 || \
             echo "Warning: Failed to delete some Release CRs" | tee -a "${cleanup_log_file}"
     else

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -364,11 +364,13 @@ spec:
                 kubectl delete -f "$tmpDir/tenant-resources.yaml" --ignore-not-found || true
                 kubectl delete -f "$tmpDir/managed-resources.yaml" --ignore-not-found || true
 
-                # Delete Release CRs created by this test run using uuid label
-                if [ -n "$uuid" ] && [ -n "$tenant_namespace" ]; then
-                  echo "Deleting Release CRs with test-run-uuid=${uuid} in namespace ${tenant_namespace}..."
+                # Delete Release CRs created by this specific test
+                # Use both uuid and originating-tool labels to scope deletion per test suite
+                if [ -n "$uuid" ] && [ -n "$tenant_namespace" ] && [ -n "$originating_tool" ]; then
+                  echo "Deleting Release CRs with originating-tool=${originating_tool}" \
+                    "in namespace ${tenant_namespace}..."
                   kubectl delete release -n "${tenant_namespace}" \
-                    -l test-run-uuid="${uuid}" \
+                    -l "test-run-uuid=${uuid},originating-tool=${originating_tool}" \
                     --ignore-not-found || echo "Warning: Failed to delete some Release CRs"
                 fi
               done


### PR DESCRIPTION


## Describe your changes
The cleanup_resources function was deleting all Release CRs matching the shared uuid label which is the same for all test in the ITS periodic stage. When the first test finshes its cleanup removed the Release of still running tests, leaving them stuck polling for deleted resources until the timeout. Fix is adding the originating-tool label to the delete so each test suite only cleans up its own Release.

Assisted-by: Claude
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
