### PR TITLE
fix(KONFLUX-12187): filter-advisory-images keeps image on fail

### DIFF
--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -166,6 +166,8 @@ spec:
         echo "Transforming snapshot components using get-image-architectures..."
         SNAPSHOT_JSON=$(jq '.' "$SNAPSHOT_FILE")
         TRANSFORMED_COMPONENTS=$(mktemp)
+        FAILED_COMPONENTS=$(mktemp)
+        echo [] > "$FAILED_COMPONENTS"
 
         jq -c '.components[]' <<< "$SNAPSHOT_JSON" | while IFS= read -r component; do
             CONTAINER_IMAGE=$(jq -r '.containerImage' <<< "$component")
@@ -174,7 +176,9 @@ spec:
             echo "Processing component: $COMPONENT_NAME with image: $CONTAINER_IMAGE" >&2
 
             if ! digests=$(get-image-architectures "${CONTAINER_IMAGE}"); then
-                echo "Warning: Failed to resolve architectures for ${CONTAINER_IMAGE}, skipping component" >&2
+                echo "Warning: Failed to resolve architectures for ${CONTAINER_IMAGE}, assuming not released" >&2
+                jq -c --arg name "$COMPONENT_NAME" '. += [$name]' "$FAILED_COMPONENTS" > failed.tmp && \
+                  mv failed.tmp "$FAILED_COMPONENTS"
                 continue
             fi
 
@@ -342,6 +346,9 @@ spec:
           FILTERED_SNAPSHOT=$(mktemp)
 
           echo "$UNRELEASED_COMPONENTS_RAW" | base64 -d | gunzip | tee "$UNRELEASED_COMPONENTS"
+          # Add in the components that get-image-architectures failed on
+          jq -cn '[inputs] | add | unique' "$UNRELEASED_COMPONENTS" "$FAILED_COMPONENTS" > unreleased.tmp && \
+            mv unreleased.tmp "$UNRELEASED_COMPONENTS"
 
           # Filter the original snapshot using the unreleased components list
           jq --slurpfile unreleased "$UNRELEASED_COMPONENTS" '

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -6,8 +6,10 @@ set -ex
 function get-image-architectures() {
   echo "Mock get-image-architectures called with: $*" >&2
   local image="$1"
+  if [[ "$image" == "quay.io/redhat-pending/fail-get-arch@sha256:abc123" ]]; then
+    exit 1
   # Produce a single-arch amd64 entry per input image index
-  if [[ "$image" == *"sha256:abc123"* ]]; then
+  elif [[ "$image" == *"sha256:abc123"* ]]; then
     echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_abc123"}'
   elif [[ "$image" == *"sha256:def456"* ]]; then
     echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_def456"}'

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-processing-component-fails.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-processing-component-fails.yaml
@@ -1,0 +1,250 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-processing-component-fails
+spec:
+  description: |
+    Test the filter-already-released-advisory-images managed task when processing a
+    component (in this case, get-image-architectures fails) fails. Ensure that the
+    component is still present in the filtered snapshot.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "fail-get-image-architectures-component",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/repo",
+                        "rh-registry-repo": "quay.io/redhat-pending/repo"
+                      }
+                    ],
+                    "containerImage": "quay.io/redhat-pending/fail-get-arch@sha256:abc123"
+                  },
+                  {
+                    "name": "old-component",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/repo",
+                        "rh-registry-repo": "quay.io/redhat-pending/repo"
+                      }
+                    ],
+                    "containerImage": "quay.io/redhat-pending/repo@sha256:abc123"
+                  },
+                  {
+                    "name": "new-component",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/repo2",
+                        "rh-registry-repo": "quay.io/redhat-pending/repo2"
+                      }
+                    ],
+                    "containerImage": "quay.io/redhat-pending/repo2@sha256:def456"
+                  }
+                ]
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      runAfter:
+        - setup
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+    - name: check-result
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: result
+            type: string
+          - name: skip_release
+            type: string
+          - name: latest_advisory_url
+            type: string
+          - name: latest_advisory_internal_url
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Check that skip_release is set to false
+              if [ "$(params.skip_release)" != "false" ]; then
+                echo "skip_release should be false when"
+                exit 1
+              fi
+
+              # Check that the result was properly set to Success
+              if [ "$(params.result)" != "Success" ]; then
+                echo "Task failed: $(params.result)"
+                exit 1
+              fi
+
+              # Check that the filtered snapshot contains the new and failed component
+              snapshot_file="$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+              if [ "$(jq -r '.components | length' "$snapshot_file")" != "2" ]; then
+                echo "Filtered snapshot should contain two components"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[0].name' "$snapshot_file")" != \
+                "fail-get-image-architectures-component" ]; then
+                echo "Filtered snapshot should contain fail-get-image-architectures-component"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[1].name' "$snapshot_file")" != "new-component" ]; then
+                echo "Filtered snapshot should contain new-component"
+                exit 1
+              fi
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: skip_release
+          value: $(tasks.run-task.results.skip_release)
+        - name: latest_advisory_url
+          value: $(tasks.run-task.results.latest_advisory_url)
+        - name: latest_advisory_internal_url
+          value: $(tasks.run-task.results.latest_advisory_internal_url)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
This commit modifies the filter-already-released-advisory-images task to keep the image in the snapshot instead of remove it if processing it fails in any way, such as get-image-architectures failing for it.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
