### PR TITLE
chore: add retry to deploy kind registry

### DIFF
--- a/.github/workflows/tekton_task_tests.yaml
+++ b/.github/workflows/tekton_task_tests.yaml
@@ -66,7 +66,7 @@ jobs:
         if: |
           steps.changed-dirs.outputs.any_changed == 'true'
         run: |
-          . .github/scripts/deploy_registry.sh
+          retry 3 .github/scripts/deploy_registry.sh
           echo "DOCKER_CONFIG_JSON=${DOCKER_CONFIG_JSON}" >> "$GITHUB_OUTPUT"
       - name: Install Tekton
         timeout-minutes: 10

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-all-components-released.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-all-components-released.yaml
@@ -79,7 +79,7 @@ spec:
                 "apiVersion": "appstudio.redhat.com/v1alpha1",
                 "kind": "ReleasePlanAdmission",
                 "metadata": {
-                  "name": "test",
+                  "name": "ftest",
                   "namespace": "default"
                 },
                 "spec": {


### PR DESCRIPTION
I often see CI jobs fail on the Deploy Local Kind Registry step and it working on retry. So, this commit adds some retries to the step in hopes it reduces the amount of manual retrying required.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
