### PR TITLE
test(RELEASE-2324): use noarch-only scenario in push-rpms-to-pulp e2e

### DIFF
--- a/integration-tests/push-rpms-to-pulp/README.md
+++ b/integration-tests/push-rpms-to-pulp/README.md
@@ -2,12 +2,12 @@
 
 This test validates the push-rpms-to-pulp pipeline with two components:
 
-- **Component A (hello)**: builds for all 4 architectures (x86_64, aarch64, s390x, ppc64le)
-- **Component B (hello2)**: builds for x86_64 only
+- **Component A (hello)**: multi-arch binaries (x86_64, aarch64, s390x, ppc64le) plus a noarch subpackage
+- **Component B (hello2)**: noarch-only — only `*.noarch.rpm` and `*.src.rpm` (no arch-specific binaries)
 
-Both components produce binary, source, and noarch RPMs. The test verifies that each RPM is pushed to the correct Pulp repository and validates noarch fanout behavior.
+hello2 was simplified from a x86_64 binary package to a data-only noarch spec so the E2E can verify a noarch-only component in a multi-component release: hello2 publishes only `*.noarch.rpm` and `*.src.rpm`, and `hello2.noarch` is fanned out to all four binary repos (hello already supplies the arch repos).
 
-Auto-release is disabled. The test waits for both component builds to complete, then manually creates a Release against the multi-component Snapshot. It also verifies idempotency by retriggering the release and checking that all RPMs are filtered as already published.
+Auto-release is disabled. The test waits for both builds, creates a Release from the multi-component Snapshot, then retriggering it to confirm already-published RPMs are filtered (`skip_release=true`).
 
 ## Test-Specific Dependencies
 

--- a/integration-tests/push-rpms-to-pulp/resources/tenant/templates/hello2.spec
+++ b/integration-tests/push-rpms-to-pulp/resources/tenant/templates/hello2.spec
@@ -1,63 +1,40 @@
 Name:           hello2
 Version:        2.12.1
 Release:        ${uuid}
-Summary:        Prints a familiar, friendly greeting (variant)
-License:        GPL-3.0-or-later AND GFDL-1.3-or-later
+Summary:        Noarch-only test component for RPM release E2E
+License:        GPL-3.0-or-later
 URL:            https://www.gnu.org/software/hello/
 Source0:        https://ftp.gnu.org/gnu/hello/hello-%{version}.tar.gz
 
-BuildRequires:  gcc
-BuildRequires:  make
-Recommends:     info
-Provides:       bundled(gnulib)
-
-%description
-A variant build of the GNU Hello program for multi-component RPM release testing.
-This package is built alongside hello to validate per-component architecture
-targeting and noarch fanout behavior.
-
-
-%package data
-Summary:        Data files for hello2
 BuildArch:      noarch
 
-%description data
-This package contains architecture-independent data files for hello2.
+%description
+Produces only noarch and source RPMs (no arch-specific binaries). Used to validate
+that push-rpms-to-pulp falls back to DEFAULT_ARCHITECTURES and fans out noarch RPMs
+to every default binary arch repo.
 
 
 %prep
+# Tarball unpacks as hello-%{version}/ (package-name=hello); Name is hello2.
 %setup -q -n hello-%{version}
 
 
 %build
-%configure
-%make_build
+# Data-only package; no compilation required.
 
 
 %install
-%make_install
-rm -f %{buildroot}%{_infodir}/dir
-%find_lang hello
-
 mkdir -p %{buildroot}%{_datadir}/hello2
-echo "hello2 data file" > %{buildroot}%{_datadir}/hello2/hello2.dat
+echo "hello2 noarch-only data" > %{buildroot}%{_datadir}/hello2/hello2.dat
 
 
-%check
-make check
-
-
-%files -f hello.lang
-%license COPYING
-%{_mandir}/man1/hello.1*
-%{_bindir}/hello
-%{_infodir}/hello.info*
-
-
-%files data
+%files
 %{_datadir}/hello2/
 
 
 %changelog
+* Tue May 19 2026 Test User <test@example.com> - 2.12.1-2
+- Noarch-only package: only *.noarch.rpm and *.src.rpm (no arch-specific binaries)
+
 * Tue Apr 22 2026 Test User <test@example.com> - 2.12.1-1
 - Initial hello2 package for multi-component RPM e2e testing

--- a/integration-tests/push-rpms-to-pulp/test.sh
+++ b/integration-tests/push-rpms-to-pulp/test.sh
@@ -241,8 +241,8 @@ verify_release_contents() {
     }
 
     # Component A (hello): 4 binary + 1 src + 4 noarch = 9
-    # Component B (hello2): 1 binary + 1 src + 4 noarch = 6
-    local expected_count=15
+    # Component B (hello2): noarch-only build -> 4 noarch fanout + 1 src = 5 (no arch-specific RPMs)
+    local expected_count=14
     echo "Checking RPM files count..."
     if [ "${rpmfiles_count}" -ne "${expected_count}" ]; then
       echo "🔴 rpmfiles count was ${rpmfiles_count}, expected ${expected_count}"
@@ -261,9 +261,11 @@ verify_release_contents() {
     _check_rpm_in_repo "hello.src in source repo" \
       "hello-[0-9].*\\.src" "${repo_prefix}/source"
 
-    echo "Checking Component B (hello2) binary RPMs..."
-    _check_rpm_in_repo "hello2.x86_64 in x86_64 repo" \
-      "hello2-[0-9].*\\.x86_64" "${repo_prefix}/x86_64"
+    echo "Checking Component B (hello2) has no arch-specific binary RPMs..."
+    for arch in x86_64 aarch64 s390x ppc64le; do
+      _check_rpm_not_in_repo "hello2 must not publish .${arch} binary" \
+        "hello2-[0-9].*\\.${arch}" "${repo_prefix}/${arch}"
+    done
 
     echo "Checking Component B (hello2) source RPM..."
     _check_rpm_in_repo "hello2.src in source repo" \
@@ -275,10 +277,10 @@ verify_release_contents() {
         "hello-data-" "${repo_prefix}/${arch}"
     done
 
-    echo "Checking Component B (hello2-data) noarch fanout..."
+    echo "Checking Component B (hello2) noarch fanout to all default arch repos..."
     for arch in x86_64 aarch64 s390x ppc64le; do
-      _check_rpm_in_repo "hello2-data.noarch in ${arch} repo" \
-        "hello2-data-" "${repo_prefix}/${arch}"
+      _check_rpm_in_repo "hello2.noarch in ${arch} repo" \
+        "hello2-[0-9].*\\.noarch" "${repo_prefix}/${arch}"
     done
 
     if [ -z "$advisory_internal_url" ]; then
@@ -430,18 +432,18 @@ verify_release_contents() {
               failures=$((failures+1))
             fi
 
-            if echo "${description}" | grep -E "hello2-[0-9].*\(.*x86_64" | grep -qv "\.src"; then
-              echo "✅️ Found hello2 binary RPM entry with x86_64 in description"
+            if echo "${description}" | grep -q "hello2-.* (noarch)"; then
+              echo "✅️ Found hello2 noarch entry in description"
             else
-              echo "🔴 Missing hello2 binary RPM entry with x86_64 in description"
+              echo "🔴 Missing hello2 noarch entry in description"
               failures=$((failures+1))
             fi
 
-            if echo "${description}" | grep -q "hello2-data-.* (noarch)"; then
-              echo "✅️ Found hello2-data noarch entry in description"
-            else
-              echo "🔴 Missing hello2-data noarch entry in description"
+            if echo "${description}" | grep -E "hello2-[0-9].*\(.*x86_64" | grep -qv "\.src"; then
+              echo "🔴 Unexpected hello2 arch-specific binary entry in description"
               failures=$((failures+1))
+            else
+              echo "✅️ No hello2 arch-specific binary entries in description (noarch-only component)"
             fi
 
             # Check for Security Fix(es) section if CVEs are present in artifacts
@@ -759,9 +761,8 @@ patch_component_source_before_merge() {
     "${component_name}" "pull-request-template.yaml" "push-template.yaml"
   _patch_spec_file "${component_repo_name}" "${component_pr_number}" "hello.spec" "hello.spec"
 
-  # Component 2: hello2 package (x86_64 only)
-  # Uses package-name=hello so dist-git-client downloads from the real Fedora hello
-  # lookaside cache. The spec has Name: hello2, so the built RPMs are hello2-*.rpm.
+  # Component 2: hello2 noarch-only package (only *.noarch.rpm + *.src.rpm in the artifact).
+  # Uses package-name=hello so dist-git-client downloads from the real Fedora hello lookaside cache.
   _patch_tekton_templates "${component2_repo_name}" "${component2_pr_number}" \
     "${component2_name}" "pull-request-template-comp2.yaml" "push-template-comp2.yaml"
   _patch_spec_file "${component2_repo_name}" "${component2_pr_number}" "hello2.spec" "hello.spec"


### PR DESCRIPTION
## Describe your changes
Component B (hello2) is changed from a x86_64 binary package with a hello2-data noarch subpackage to a minimal noarch-only spec that produces only hello2.noarch.rpm and hello2.src.rpm. Component A (hello) is unchanged and still provides multi-arch binaries plus a noarch subpackage.

This exercises a noarch-only component in a multi-component release: hello2 must not publish arch-specific binaries, and hello2.noarch must appear in all four binary Pulp repos while hello supplies the arch repos.

## Relevant Jira
[RELEASE-2324](https://redhat.atlassian.net/browse/RELEASE-2324)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`


[RELEASE-2324]: https://redhat.atlassian.net/browse/RELEASE-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ