### PR TITLE
chore: add label_check ci check

### DIFF
--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -1,0 +1,24 @@
+---
+name: Label Check
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+jobs:
+  do-not-merge:
+    if: ${{ !contains(github.event.*.labels.*.name, 'prod/approved') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is missing label 'prod/approved'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1
+    if: ${{ contains(github.event.*.labels.*.name, 'prod/approved') }}
+    name: Allow Merging  # Without this, the action would be skipped instead of pass
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is okay to merge"
+          exit 0


### PR DESCRIPTION
We can make this check blocking to prevent accidental merges of PRs missing the prod/approved label.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
