### PR TITLE
feat(HUM-2065): signing key support in tasks

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -294,8 +294,11 @@ spec:
           signingKey=$(kubectl get configmap "$(params.config_map_name)" -o jsonpath="{.data.SIG_KEY_NAME}")
           # Write to temp file to avoid argument length limits
           echo "$NEW_ADVISORY_JSON" > /tmp/new_advisory.json
+          # Add signingKey only if not already present in the artifact (supports pre-populated values from
+          # populate-release-notes for RPM releases)
           jq -c --arg key "$signingKey" \
-            "${spec_content_type}[] += {\"signingKey\": \$key}" /tmp/new_advisory.json > /tmp/advisory_with_key.json
+            "${spec_content_type} |= map(if .signingKey then . else . + {\"signingKey\": \$key} end)" \
+            /tmp/new_advisory.json > /tmp/advisory_with_key.json
 
           LIVE_ID=$(jq -r '.live_id' /tmp/advisory_decoded.json)
           if [[ "$LIVE_ID" == null ]]; then

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -443,6 +443,7 @@ spec:
 
         append_artifact_entry() {
           local component="$1" arch="$2" os="$3" purl="$4" sbom="${5:-}" attestation="${6:-}"
+          local signingKey="${7:-}"
           local jsonString
           jsonString=$(jq -cn \
             --arg component "$component" \
@@ -455,6 +456,9 @@ spec:
           fi
           if [ -n "$attestation" ]; then
             jsonString=$(jq --arg att "$attestation" '. + {attestation: $att}' <<< "$jsonString")
+          fi
+          if [ -n "$signingKey" ]; then
+            jsonString=$(jq --arg key "$signingKey" '. + {signingKey: $key}' <<< "$jsonString")
           fi
 
           if [ "$(jq '.cves.fixed | length' <<< "$CVEsJson")" -gt 0 ]; then
@@ -573,8 +577,12 @@ spec:
               fi
 
               # Read Pulp domain for constructing SBOM URLs
-              PULP_DOMAIN=$(jq -r '.pulp.domain // empty' "$DATA_FILE")
+              # SBOMs/attestations are uploaded to the signed RPMs domain
+              PULP_DOMAIN=$(jq -r '.signOptions.signedRpmsDomain // .pulp.domain // empty' "$DATA_FILE")
               PULP_CONTENT_BASE_URL="https://packages.redhat.com/api/pulp-content"
+
+              # Read signing key alias for advisory artifacts
+              SIGNING_KEY=$(jq -r '.signOptions.signKeyAlias.key // empty' "$DATA_FILE")
 
               RPM_FILES_LENGTH=$(jq --arg name "$name" \
                 '[.components[]? | select(.name == $name) | .rpmsToPublish[]?] | length' "${SNAPSHOT_FILE}")
@@ -606,7 +614,7 @@ spec:
                   # If no targetRepos is present, fall back to a best-effort purl without repository_id.
                   purl=$(generate_purl_rpm "$rpm_name" "$version" "$release" "$arch" "$distro" "")
                   echo "purl: $purl"
-                  append_artifact_entry "$name" "$arch" "$os" "$purl"
+                  append_artifact_entry "$name" "$arch" "$os" "$purl" "" "" "$SIGNING_KEY"
                 else
                   for ((r = 0; r < TARGET_REPOS_LEN; r++)); do
                     repo_obj=$(jq -c --argjson r "$r" '.targetRepos[$r]' <<< "$rpmfile")
@@ -626,9 +634,9 @@ spec:
                       [ -n "${sbom_url}" ] && echo "sbom: $sbom_url"
                       [ -n "${attestation_url}" ] && echo "attestation: $attestation_url"
                       append_artifact_entry "$name" "$arch_for_entry" "$os" "$purl" \
-                        "$sbom_url" "$attestation_url"
+                        "$sbom_url" "$attestation_url" "$SIGNING_KEY"
                     else
-                      append_artifact_entry "$name" "$arch_for_entry" "$os" "$purl"
+                      append_artifact_entry "$name" "$arch_for_entry" "$os" "$purl" "" "" "$SIGNING_KEY"
                     fi
                   done
                 fi

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rpms.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-rpms.yaml
@@ -60,6 +60,11 @@ spec:
                 "pulp": {
                   "domain": "public-hummingbird"
                 },
+                "signOptions": {
+                  "signKeyAlias": {
+                    "key": "hummingbird-signing-key"
+                  }
+                },
                 "mapping": {
                   "rpm-repositories": [
                     {
@@ -290,3 +295,13 @@ spec:
                 exit 1
               fi
               echo "Attestation URL verified: $ATT_URL"
+
+              # Verify signingKey is present on all artifacts
+              for i in 0 1; do
+                SIGNING_KEY=$(jq -r ".releaseNotes.content.artifacts[$i].signingKey // \"\"" "$DATA_FILE")
+                if [ "$SIGNING_KEY" != "hummingbird-signing-key" ]; then
+                  echo "Error: Expected signingKey 'hummingbird-signing-key' on artifact $i, got '$SIGNING_KEY'"
+                  exit 1
+                fi
+              done
+              echo "signingKey verified on all artifacts"

--- a/tasks/managed/upload-src-rpm-sbom-attestation/upload-src-rpm-sbom-attestation.yaml
+++ b/tasks/managed/upload-src-rpm-sbom-attestation/upload-src-rpm-sbom-attestation.yaml
@@ -133,10 +133,10 @@ spec:
       computeResources:
         limits:
           memory: 512Mi
-          cpu: 350m
+          cpu: 1
         requests:
           memory: 512Mi
-          cpu: 350m
+          cpu: 1
       volumeMounts:
         - name: pulp-secret-name-vol
           mountPath: "/etc/secrets"
@@ -144,6 +144,11 @@ spec:
         #!/bin/bash
         set -euo pipefail
         set +x
+
+        # RPM SBOM attestations can exceed cosign's default max download size;
+        # raise the limit to 200MB to permit large artifact downloads and uploads
+        COSIGN_MAX_ATTACHMENT_SIZE=200000000
+        export COSIGN_MAX_ATTACHMENT_SIZE
 
         SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
         if [[ ! -f "${SNAPSHOT_PATH}" ]]; then


### PR DESCRIPTION
## Summary
- Use correct domain with signing for SBOM/attestation URLs in populate-release-notes
- Pass signingKey from RPA data to create-advisory and populate-release-notes
- Add RPM signing key test case for populate-release-notes
- Increase CPU for upload-src-rpm-sbom-attestation

## Test plan
- [ ] Unit tests pass for `tasks/managed/populate-release-notes`
- [ ] Unit tests pass for `tasks/managed/upload-src-rpm-sbom-attestation`

## Jira
https://redhat.atlassian.net/browse/HUM-2065

Part of [HUM-959](https://redhat.atlassian.net/browse/HUM-959) - PR 3 of 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HUM-959]: https://redhat.atlassian.net/browse/HUM-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ