### PR TITLE
chore(CALUNGA-261): nudge plumbing-utils in upload-py-pulp

### DIFF
--- a/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
+++ b/tasks/managed/upload-py-pulp/upload-py-pulp.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: upload
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:48c6eff749812d5757933f2f16448866923e15c7d8f5ff88539760b0cc290ba1
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:749471b81ace2bd2b80dc85003512612a0d833e0a47633d6d45f23b9a5439514
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
Update the plumbing-utils image digest to include improvements from CALUNGA-261: --disable-progress-bar for twine, upload summary log, and upload failure error handling.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
