### PR TITLE
RELEASE-2015: add {{ component-incrementer }} for uniform multi-repo tags

### DIFF
--- a/integration-tests/push-to-external-registry/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-external-registry/resources/managed/rpa.yaml
@@ -26,7 +26,11 @@ spec:
                 - '{{ git_short_sha }}'
                 - '{{ digest_sha }}'
                 - 'v1.0.0-{{ incrementer }}'
+                - 'v1.0.0-{{ component-incrementer }}'
                 - '{{ oci_version }}'
+            - url: quay.io/hacbs-release-tests/${component_name}-b
+              tags:
+                - 'v1.0.0-{{ component-incrementer }}'
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/integration-tests/push-to-external-registry/test.sh
+++ b/integration-tests/push-to-external-registry/test.sh
@@ -93,6 +93,42 @@ verify_release_contents() {
         failures=$((failures+1))
     fi
 
+    # Verify both repositories received the same {{ component-incrementer }} tag
+    echo "Verifying uniform {{ component-incrementer }} tag across both repositories..."
+    local auth_file
+    auth_file=$(mktemp)
+    chmod 600 "${auth_file}"
+    trap 'rm -f "${auth_file}"' EXIT
+    yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" \
+        | base64 -d > "${auth_file}"
+
+    local repo_a="quay.io/hacbs-release-tests/${component_name}"
+    local repo_b="quay.io/hacbs-release-tests/${component_name}-b"
+    local repo_a_tag repo_b_tag
+    repo_a_tag=$(skopeo list-tags --retry-times 3 --authfile "${auth_file}" "docker://${repo_a}" \
+        2>/dev/null | jq -r '.Tags[]' 2>/dev/null | grep -E '^v1\.0\.0-[0-9]+$' | sort -t- -k2 -rn | head -1 || true)
+    repo_b_tag=$(skopeo list-tags --retry-times 3 --authfile "${auth_file}" "docker://${repo_b}" \
+        2>/dev/null | jq -r '.Tags[]' 2>/dev/null | grep -E '^v1\.0\.0-[0-9]+$' | sort -t- -k2 -rn | head -1 || true)
+
+    rm -f "${auth_file}"
+    trap - EXIT
+
+    echo "Repository A (${component_name}) got component-incrementer tag: ${repo_a_tag:-<not found>}"
+    echo "Repository B (${component_name}-b) got component-incrementer tag: ${repo_b_tag:-<not found>}"
+
+    if [ -n "${repo_a_tag}" ] && [ -n "${repo_b_tag}" ]; then
+        if [ "${repo_a_tag}" = "${repo_b_tag}" ]; then
+            echo "✅️ Both repositories received the same uniform component-incrementer tag: ${repo_a_tag}"
+        else
+            echo "🔴 Tag mismatch! Repository A got '${repo_a_tag}' but Repository B got '${repo_b_tag}'"
+            failures=$((failures+1))
+        fi
+    else
+        echo "🔴 Could not retrieve component-incrementer tag from one or both repositories"
+        failures=$((failures+1))
+    fi
+
     if [ "${failures}" -gt 0 ]; then
       echo "🔴 Test has FAILED with ${failures} failure(s)!"
       exit 1

--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -21,6 +21,11 @@ This task supports variable expansion in tag values from the mapping. The curren
 * "{{ digest_sha }}" -> The image digest of the respective component
 * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
   repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
+* "{{ component-incrementer }}" -> Like {{ incrementer }}, but finds the highest existing tag
+  across ALL repositories in the component and generates the next sequential tag uniformly.
+  Use this instead of {{ incrementer }} when pushing to multiple registries to ensure every
+  registry receives the same tag (e.g., if repo-a has v1.0.0-3 and repo-b has v1.0.0-5,
+  both will receive v1.0.0-6).
 * "{{ oci_version }}" -> The version from OCI image annotations (org.opencontainers.image.version), with fallback
   to OCI image labels if not present in annotations (converts + to _ for tag compliance)
 

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -29,6 +29,11 @@ spec:
     * "{{ digest_sha }}" -> The image digest of the respective component
     * "{{ incrementer }}" -> Automatically finds the highest existing incremented tag in the
       repository and generates the next sequential tag (e.g., if the highest tag is v1.0.0-2, it will generate v1.0.0-3)
+    * "{{ component-incrementer }}" -> Like {{ incrementer }}, but finds the highest existing tag
+      across ALL repositories in the component and generates the next sequential tag uniformly.
+      Use this instead of {{ incrementer }} when pushing to multiple registries to ensure every
+      registry receives the same tag (e.g., if repo-a has v1.0.0-3 and repo-b has v1.0.0-5,
+      both will receive v1.0.0-6).
     * "{{ oci_version }}" -> The version from OCI image annotations (org.opencontainers.image.version), with fallback
       to OCI image labels if not present in annotations (converts + to _ for tag compliance)
 
@@ -228,6 +233,84 @@ spec:
             echo "$tag"  # Return the final tag
         }
 
+        # Function to handle component-incrementer logic: finds the highest increment across
+        # ALL repositories in a component and returns the next uniform sequential tag.
+        # Results are cached by version_prefix to avoid redundant skopeo calls.
+        # Expected arguments are: [tag_template, all_repos_json]
+        component_increment_tag() {
+            local tag_template="$1"
+            local all_repos_json="${2:-[]}"
+
+            # Remove {{ component-incrementer }} placeholder to get the version prefix
+            local version_prefix
+            # shellcheck disable=SC2001
+            version_prefix=$(echo "${tag_template}" | sed 's/{{ *component-incrementer *}}//g')
+
+            # Return cached result if available for this prefix.
+            # Cache files survive subshell boundaries; associative arrays do not.
+            local cache_key
+            cache_key=$(printf '%s' "${version_prefix}" | base64 | tr -d '=\n' | tr '+/' '-_')
+            local cache_file="${_inc_cache_dir}/${cache_key}"
+            if [[ -f "${cache_file}" ]]; then
+                local cached_increment
+                cached_increment=$(< "${cache_file}")
+                local tag
+                # shellcheck disable=SC2001
+                tag=$(echo "${tag_template}" | sed "s/{{ *component-incrementer *}}/${cached_increment}/g")
+                if [[ ! "${tag}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                    echo "Error: Invalid tag format after substitution: ${tag}" >&2
+                    exit 1
+                fi
+                echo "$tag"
+                return
+            fi
+
+            # Escape version_prefix for safe use in ERE (grep -E) and sed -E.
+            # Without escaping, a prefix like "v1.0.0-" would treat the dots as
+            # regex wildcards, potentially matching unintended tags.
+            local escaped_prefix
+            # shellcheck disable=SC2016
+            escaped_prefix=$(printf '%s' "${version_prefix}" | sed 's/[.[\\*^$()+?{|]/\\&/g')
+
+            # Match tags with 1–6 digit increments only. Ignore 7+ digit tags to avoid
+            # treating short commit SHAs as incrementer values
+            local tag_pattern="^${escaped_prefix}[0-9]{1,6}$"
+
+            # Find the global maximum increment across all repositories in the component
+            local global_max=0
+            local num_repos
+            num_repos=$(jq 'length' <<< "$all_repos_json")
+            for ((r = 0; r < num_repos; r++)); do
+                local repo
+                repo=$(jq -r --argjson r "$r" '.[$r]' <<< "$all_repos_json")
+                local existing_tags
+                existing_tags=$(skopeo list-tags --retry-times 3 docker://"${repo}" | jq -r '.Tags[]')
+                local repo_max
+                repo_max=$(echo "${existing_tags}" | { grep -E "${tag_pattern}" || true; } \
+                    | sed -E "s/^${escaped_prefix}//" | sort -nr | head -n1)
+                # Use 10# to force decimal input preventing leading 0 from being treated as octal
+                if [[ -n "$repo_max" ]] && [[ $((10#${repo_max})) -gt $global_max ]]; then
+                    global_max=$((10#${repo_max}))
+                fi
+            done
+
+            local increment=$((global_max + 1))
+
+            # Cache the result so subsequent repos in this component reuse the same value
+            echo "${increment}" > "${cache_file}"
+
+            local tag
+            # shellcheck disable=SC2001
+            tag=$(echo "${tag_template}" | sed "s/{{ *component-incrementer *}}/${increment}/g")
+
+            if [[ ! "${tag}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                echo "Error: Invalid tag format after substitution: ${tag}" >&2
+                exit 1
+            fi
+
+            echo "$tag"
+        }
+
         # Expected arguments are: [variable, substitute_map, labels_map]
         substitute() {
             variable=$1
@@ -261,20 +344,23 @@ spec:
             echo "$tags_json" | jq -c --arg ts "$timestamp_val" '. + [$ts] | unique'
         }
 
-        # Expected arguments are [tags, substitute_map, labels_map, repo]
+        # Expected arguments are [tags, substitute_map, labels_map, repo, all_repos_json]
         # The tags argument is a json array
         translate_tags () {
-            tags=$1
-            substitute_map=$2
-            labels_map=$3
-            repo=$4
+            local tags=$1
+            local substitute_map=$2
+            local labels_map=$3
+            local repo=$4
+            local all_repos_json="${5:-[]}"
             if [ "$tags" = '' ] ; then
                 echo ''
                 return
             fi
 
-            translated_tags='[]'
+            local translated_tags='[]'
+            local NUM_TAGS
             NUM_TAGS="$(jq 'length' <<< "${tags}")"
+            local i tag var_name replacement
             for ((i = 0; i < NUM_TAGS; i++)); do
                 tag="$(jq -r --argjson i "$i" '.[$i]' <<< "${tags}")"
 
@@ -292,6 +378,8 @@ spec:
                   # Handle incrementer logic
                   if [[ "$var_name" == "incrementer" ]]; then
                       tag=$(increment_tag "$tag" "$repo")
+                  elif [[ "$var_name" == "component-incrementer" ]]; then
+                      tag=$(component_increment_tag "$tag" "$all_repos_json")
                   else
                       replacement=$(substitute "$var_name" "$substitute_map" "$labels_map")
                       if [ -z "$replacement" ]; then
@@ -423,7 +511,18 @@ spec:
         currentTimestamp="$(date "+%Y%m%d %T")"
         defaultCGWSettings=$(jq -c '.defaults.contentGateway // {}' <<< "$MAPPING")
         NUM_MAPPED_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
+
+        # File-based cache dir for component-incrementer results. A file-based
+        # approach is required because component_increment_tag is invoked inside
+        # $(...) subshells (via translate_tags), so bash associative array writes
+        # would be lost on subshell exit. Files persist across subshell boundaries.
+        _inc_cache_dir=$(mktemp -d)
+        trap 'rm -rf "${_inc_cache_dir}"' EXIT
+
         for ((i = 0; i < NUM_MAPPED_COMPONENTS; i++)) ; do
+            # Clear the cache at the start of each component so that different
+            # components with the same tag template use independent repo sets.
+            rm -f "${_inc_cache_dir}/"* 2>/dev/null || true
             component=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
             componentTags=$(jq '.componentTags // []' <<< "$component")
             defaultComponentTags=$(jq -n --argjson defaults "$defaultTags" --argjson componentTags \
@@ -574,6 +673,17 @@ spec:
               "${SNAPSHOT_SPEC_FILE}" > /tmp/temp && mv /tmp/temp "${SNAPSHOT_SPEC_FILE}"
             fi
 
+            # Build a JSON array of all repository URLs for this component.
+            # This is used by {{ component-incrementer }} to query all repos and compute a
+            # uniform increment value across registries.
+            component_repos_json='[]'
+            _ci_num_repos=$(jq '.repositories | length' <<< "$component")
+            for ((_ci_j = 0; _ci_j < _ci_num_repos; _ci_j++)) ; do
+                _ci_repo_url=$(jq -r --argjson j "$_ci_j" '.repositories[$j].url' <<< "$component")
+                component_repos_json=$(jq -c --arg url "$_ci_repo_url" '. + [$url]' \
+                    <<< "$component_repos_json")
+            done
+
             NUM_REPOSITORIES=$(jq '.repositories | length' <<< "$component")
             for ((j = 0; j < NUM_REPOSITORIES; j++)) ; do
                 repository=$(jq -c --argjson j "$j" '.repositories[$j]' <<< "$component")
@@ -583,7 +693,8 @@ spec:
 
                 allTagsPreSubstitution=$(jq -n --argjson defaults "$defaultComponentTags" --argjson repoTags \
                   "$repoTags" '$defaults? + $repoTags? | unique')
-                tags=$(translate_tags "${allTagsPreSubstitution}" "${substitute_map}" "${labels}" "${url}")
+                tags=$(translate_tags "${allTagsPreSubstitution}" "${substitute_map}" "${labels}" "${url}" \
+                    "${component_repos_json}")
                 tags=$(ensure_implicit_timestamp_value "${tags}" "${timestamp}")
                 if [ "$(jq 'length' <<< "$tags")" -gt 0 ] ; then
                   jq --argjson i "$i" --argjson j "$j" --argjson updatedTags "$tags" \

--- a/tasks/managed/apply-mapping/tests/mocks.sh
+++ b/tasks/managed/apply-mapping/tests/mocks.sh
@@ -51,7 +51,23 @@ function skopeo() {
       echo '{"Tags": ["1.2.1", "1.2.1-26", "1.2.1-67", "1.2.1-135", "1.2.1-1737653481", "1.2.1-1740048934", "1.2.1-1745398585"]}'
       return
   fi
-  
+
+  # component-incrementer test repos: repo-ci-a has max 3, repo-ci-b has max 5 → global max 5 → next 6
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-ci-a ]]; then
+      echo '{"Tags": ["v1.0.0-1", "v1.0.0-2", "v1.0.0-3"]}'
+      return
+  fi
+
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-ci-b ]]; then
+      echo '{"Tags": ["v1.0.0-1", "v1.0.0-2", "v1.0.0-3", "v1.0.0-4", "v1.0.0-5"]}'
+      return
+  fi
+
+  # component-incrementer single-repo test: repo-ci-c has max 3 → next 4
+  if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-ci-c ]]; then
+      echo '{"Tags": ["v2.0.0-1", "v2.0.0-2", "v2.0.0-3"]}'
+      return
+  fi
   # 7 digit tags: ignored by {1,6} regex, incrementer starts at 1
   if [[ "$*" =~ list-tags\ --retry-times\ 3\ docker://repo-leadingzero ]]; then
       echo '{"Tags": ["v0.7.0-0760387", "v0.7.0-0760386"]}'

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-component-incrementer.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-component-incrementer.yaml
@@ -1,0 +1,241 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-apply-mapping-component-incrementer
+spec:
+  description: |
+    Run the apply-mapping task and verify that {{ component-incrementer }} produces a uniform
+    tag value across all repositories in a component by taking the global maximum increment
+    from every repository and adding 1.
+
+    Test cases:
+    - comp1-multi: 2 repos where repo-ci-a has max increment 3 and repo-ci-b has max increment 5.
+      Both repos must receive tag v1.0.0-6 (global max 5 + 1).
+    - comp2-single: 1 repo (repo-ci-c) with max increment 3.
+      The repo must receive tag v2.0.0-4.
+    - cache behavior: comp1-multi uses {{ component-incrementer }} for both repos. The first
+      translate_tags call queries all repos and caches the result; the second call must hit
+      the cache and not issue any additional skopeo calls. Verified by asserting that each
+      repo-ci-a and repo-ci-b is queried exactly once in the skopeo call log.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "comp1-multi",
+                      "repositories": [
+                        {
+                          "url": "repo-ci-a",
+                          "tags": [
+                            "v1.0.0-{{ component-incrementer }}"
+                          ]
+                        },
+                        {
+                          "url": "repo-ci-b",
+                          "tags": [
+                            "v1.0.0-{{ component-incrementer }}"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "comp2-single",
+                      "repositories": [
+                        {
+                          "url": "repo-ci-c",
+                          "tags": [
+                            "v2.0.0-{{ component-incrementer }}"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp1-multi",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  },
+                  {
+                    "name": "comp2-single",
+                    "containerImage": "registry.io/image@sha256:123456",
+                    "source": {
+                      "git": {
+                        "revision": "testrevision",
+                        "url": "myurl"
+                      }
+                    }
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/test_snapshot_spec.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/test_data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              SNAPSHOT="$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json"
+
+              echo Test that comp1-multi repo-ci-a receives the global maximum tag v1.0.0-6
+              test "$(
+                jq -c '.components[] | select(.name=="comp1-multi") |
+                  .repositories[] | select(.url=="repo-ci-a") | .tags' \
+                < "$SNAPSHOT"
+              )" == '["v1.0.0-6"]'
+
+              echo Test that comp1-multi repo-ci-b also receives the same uniform tag v1.0.0-6
+              test "$(
+                jq -c '.components[] | select(.name=="comp1-multi") |
+                  .repositories[] | select(.url=="repo-ci-b") | .tags' \
+                < "$SNAPSHOT"
+              )" == '["v1.0.0-6"]'
+
+              echo Test that comp2-single repo-ci-c receives tag v2.0.0-4 based on its own max of 3
+              test "$(
+                jq -c '.components[] | select(.name=="comp2-single") |
+                  .repositories[0].tags' \
+                < "$SNAPSHOT"
+              )" == '["v2.0.0-4"]'
+
+              echo Test cache behavior: each repo in comp1-multi must be queried exactly once
+              echo "(first translate_tags call queries all repos and caches; second call hits cache)"
+              SKOPEO_LOG="$(params.dataDir)/mock_skopeo.txt"
+              repo_a_calls=$(grep -c "list-tags.*docker://repo-ci-a" "$SKOPEO_LOG" || true)
+              repo_b_calls=$(grep -c "list-tags.*docker://repo-ci-b" "$SKOPEO_LOG" || true)
+              echo "repo-ci-a skopeo list-tags calls: $repo_a_calls (expected: 1)"
+              echo "repo-ci-b skopeo list-tags calls: $repo_b_calls (expected: 1)"
+              test "$repo_a_calls" == "1"
+              test "$repo_b_calls" == "1"


### PR DESCRIPTION
## Describe your changes

The existing {{ incrementer }} variable queries skopeo list-tags per repository independently. When a component pushes to multiple registries with different tag histories, each registry can receive a different increment value, breaking tag uniformity.

The new {{ component-incrementer }} variable queries ALL repositories in the component and takes the global maximum increment across every registry before computing the next value. A per-component-prefix cache prevents redundant skopeo calls when the same tag template is used across multiple repos in the same pipeline run.

Existing {{ incrementer }} behaviour is fully preserved.

## Relevant Jira
[RELEASE-2015](https://redhat.atlassian.net/browse/RELEASE-2015)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`


[RELEASE-2015]: https://redhat.atlassian.net/browse/RELEASE-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ