### PR TITLE
fix(RELEASE-2367): bump utils image in push-disk-images tasks

### DIFF
--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -86,7 +86,7 @@ spec:
 
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-gzip.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwfileprefix.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductcode.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-cgwproductversionname.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-containerimage.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stageddestination.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilesfilename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedfilessource.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-no-stagedversion.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-oras-pull.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-pulp-push.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images-fail-same-filename.yaml
@@ -44,7 +44,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/tests/test-pulp-push-disk-images.yaml
@@ -43,7 +43,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -115,7 +115,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-ir-failure.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -136,7 +136,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-contentgateway-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-data.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-fail-no-snapshot.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-production.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-production.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -168,7 +168,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -227,7 +227,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-qa.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-qa.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -168,7 +168,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -227,7 +227,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-results.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-results.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -185,7 +185,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -203,7 +203,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/push-disk-images/tests/test-push-disk-images-stage.yaml
+++ b/tasks/managed/push-disk-images/tests/test-push-disk-images-stage.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -168,7 +168,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env bash
               set -ex
@@ -227,7 +227,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION
Update release-service-utils image digest to pick up idempotency changes from konflux-ci/release-service-utils PR 739: Pulp pre-push cleanup for timestamped content variants and shared CGW idempotency logic extracted into utils/cgw_idempotency.py.

Old: sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
New: sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
