### PR TITLE
test(RELEASE-2336): add rh-push-to-external-registry multi-component e2e

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Test locally first. Use `--pr-mode` for pre-merge validation. Check `test-result
 
 ## Scripting & Tooling
 
-- **Shell options**: `set -eo pipefail` minimum in Tekton task scripts; `set -euo pipefail` for standalone scripts
+- **Shell options**: `set -eo pipefail` minimum in Tekton task scripts; `set -euo pipefail` for standalone scripts. Integration test `test.sh` files are sourced (not standalone) and inherit the caller's shell options
 - **Variables**: always quote — `"${VAR}"`, `"$(command)"`; use `${VAR}` not `$VAR`
 - **JSON**: build with `jq --arg`/`--argjson` or `jq -n`, never string concatenation or `echo`
 - **jq flags**: `-r` for raw output, `-c` for compact, `-e` to exit non-zero on false/null

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -11,6 +11,7 @@ The following integration test suites are available:
 - **[push-to-addons-registry](push-to-addons-registry/)** - Tests for pushing to addon registries
 - **[rh-push-helm-chart-to-registry-redhat-io](rh-push-helm-chart-to-registry-redhat-io/)** - Tests for Helm OCI chart release pipeline
 - **[rh-push-to-external-registry](rh-push-to-external-registry/)** - Tests for pushing to external registries
+- **[rh-push-to-external-registry-multi-component](rh-push-to-external-registry-multi-component/)** - Tests for pushing multiple components to external registries in a single release
 - **[release-to-github](release-to-github/)** - Tests for GitHub release pipeline
 - **[rhtap-service-push](rhtap-service-push/)** - Tests for RHTAP service push pipeline
 - **[rh-advisories-large-snapshot](rh-advisories-large-snapshot/)** - **Manual test** for rh-advisories pipeline with large snapshots (~200 components)

--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -1236,3 +1236,66 @@ handle_test_failure() {
 
     return 1
 }
+
+wait_for_multi_component_snapshot() {
+    local application_name="${1:-${application_name}}"
+
+    echo "📸 Looking for multi-component snapshot..." >&2
+    echo "🔍 DEBUG: Search context - namespace: ${tenant_namespace}, application: ${application_name}" >&2
+
+    local max_attempts=24
+    local attempt=1
+    local snapshot_name=""
+
+    while [ $attempt -le $max_attempts ] && [ -z "$snapshot_name" ]; do
+        echo "🔍 DEBUG: Multi-component snapshot search attempt ${attempt}/${max_attempts}" >&2
+
+        local all_snapshots=""
+        if ! all_snapshots=$(kubectl get snapshots -n "$tenant_namespace" \
+            -l "appstudio.openshift.io/application=${application_name}" \
+            --sort-by=.metadata.creationTimestamp \
+            -o json 2>/dev/null) || [ -z "$all_snapshots" ]; then
+            echo "🔍 DEBUG: Failed to retrieve snapshots or no snapshots found" >&2
+            if [ $attempt -lt $max_attempts ]; then
+                echo "🔍 DEBUG: Waiting 30 seconds before retry..." >&2
+                sleep 30
+            fi
+            attempt=$((attempt + 1))
+            continue
+        fi
+
+        echo "🔍 DEBUG: Available snapshots:" >&2
+        echo "$all_snapshots" | jq -r \
+            '.items[] | "  - \(.metadata.name): \(.spec.components | length) components (\(.spec.components | map(.name // "unknown") | join(", ")))"' >&2
+
+        snapshot_name=$(echo "$all_snapshots" | jq -r \
+            '.items[] | select(.spec.components | length > 1) | .metadata.name' | tail -1)
+
+        if [ -n "$snapshot_name" ]; then
+            echo "🔍 DEBUG: Found multi-component snapshot: $snapshot_name" >&2
+            local snapshot_details
+            snapshot_details=$(echo "$all_snapshots" | jq -r --arg name "$snapshot_name" '.items[] | select(.metadata.name == $name)')
+            echo "$snapshot_details" | jq -r '"  - Created: \(.metadata.creationTimestamp)"' >&2
+            echo "$snapshot_details" | jq -r '"  - Components: \(.spec.components | map(.name) | join(", "))"' >&2
+            break
+        else
+            echo "🔍 DEBUG: No multi-component snapshot found yet (need > 1 component)" >&2
+            if [ $attempt -lt $max_attempts ]; then
+                echo "🔍 DEBUG: Waiting 30 seconds before retry..." >&2
+                sleep 30
+            fi
+        fi
+
+        attempt=$((attempt + 1))
+    done
+
+    if [ -z "$snapshot_name" ]; then
+        echo "🔴 DEBUG: Failed to find multi-component snapshot after ${max_attempts} attempts (~$(( max_attempts * 30 / 60 )) minutes)" >&2
+        echo "🔴 DEBUG: This may indicate:" >&2
+        echo "    - Multi-component snapshots are not being created" >&2
+        echo "    - Snapshot creation is slower than expected" >&2
+        echo "    - Component builds may have failed or not completed properly" >&2
+    fi
+
+    echo "$snapshot_name"
+}

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -110,7 +110,8 @@ spec:
               ALL_TESTCASES=("collectors" "collectors-no-cve" "e2e" "fbc-release" "push-rpms-to-pulp" \
                 "push-to-addons-registry" "push-to-external-registry-idempotent" \
                 "push-to-external-registry" "release-to-github" "rh-push-helm-chart-to-registry-redhat-io" \
-                "rh-push-to-external-registry" "rh-push-to-registry-redhat-io" "rhtap-service-push")
+                "rh-push-to-external-registry" "rh-push-to-external-registry-multi-component" \
+                "rh-push-to-registry-redhat-io" "rhtap-service-push")
               overall_test_count=${#ALL_TESTCASES[@]}
 
               exitfunc() {

--- a/integration-tests/rh-push-to-external-registry-multi-component/README.md
+++ b/integration-tests/rh-push-to-external-registry-multi-component/README.md
@@ -1,0 +1,65 @@
+# rh-push-to-external-registry-multi-component test
+## Overview
+This test validates pushing **multiple components** through the `rh-push-to-external-registry`
+pipeline in a single release. It registers two Components under the same Application, waits for
+both to build, finds the multi-component Snapshot, and creates a Release against it.
+
+### Acceptance Criteria
+* `status.artifacts.images` contains 2 entries with distinct URLs and shasums
+* Both images pullable via skopeo inspect
+* At least 2 Pyxis image IDs created (one per component)
+
+## Setup
+### Dependencies
+* GitHub repo: https://github.com/hacbs-release-tests/e2e-base
+* GitHub personal access token (classic) for above repo with **admin:repo_hook**, **delete_repo**, **repo** scopes.
+* The password to the vault files. (Contact a member of the Release team should you want to run this
+  test suite.)
+* Access to the target cluster and tenant and managed namespaces
+  * This test uses stg-rh01 and the dev-release-team-tenant and managed-release-team-tenant namespaces.
+### Required Environment Variables
+- GITHUB_TOKEN
+  - The GitHub personal access token needed for repo operations
+  - The repo in question can be located in [test.env](test.env)
+- VAULT_PASSWORD_FILE
+  - This is the path to a file that contains the ansible vault
+    password needed to decrypt the secrets needed for testing.
+- RELEASE_CATALOG_GIT_URL
+  - The release service catalog URL to use in the RPA
+  - This is provided when testing PRs
+- RELEASE_CATALOG_GIT_REVISION
+  - The release service catalog revision to use in the RPA
+  - This is provided when testing PRs
+### Optional Environment Variables
+- KUBECONFIG
+  - The KUBECONFIG file to used to login to the target cluster
+  - This is provided when testing PRs
+### Test Properties
+#### [test.env](test.env)
+- This file contains resource names and configuration values needed for testing.
+- Since this test requires internal services, the tenant and managed namespaces
+  should remain as-is.
+### Test Functions
+#### [lib/test-functions.sh](../lib/test-functions.sh)
+- This file contains re-usable functions for tests
+### Secrets
+- Secrets needed for testing are stored in ansible vault files (symlinked from rh-push-to-external-registry).
+  - [vault/managed-secrets.yaml](vault/managed-secrets.yaml)
+  - [vault/tenant-secrets.yaml](vault/tenant-secrets.yaml)
+- Some tests have their secret name hardcoded and therefore must exist prior to running this test:
+  - konflux-advisory-jira-secret
+### Running the test
+
+```shell
+integration-tests/run-test.sh rh-push-to-external-registry-multi-component
+```
+
+### Debugging
+
+There is a `--skip-cleanup` option to the script in the event that you want to examine the resources
+after a test has ended.
+
+### Maintenance
+- Should you require to add or update a secret, follow the instructions in the
+  [rh-push-to-external-registry README](../rh-push-to-external-registry/README.md) since the
+  vault files are symlinked from that test suite.

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/ec-policy.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/ec-policy.yaml
@@ -1,0 +1,1 @@
+../../../rh-push-to-external-registry/resources/managed/ec-policy.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/kustomization.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/kustomization.yaml
@@ -1,0 +1,1 @@
+../../../rh-push-to-external-registry/resources/managed/kustomization.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/rpa.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: ${release_plan_admission_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  applications:
+    - ${application_name}
+  data:
+    pyxis:
+      server: stage
+      secret: pyxis-${component_name}
+    mapping:
+      defaults:
+        tags:
+          - latest
+        pushSourceContainer: false
+      components:
+        - name: ${component_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+        - name: ${component2_name}
+          repositories:
+            - url: quay.io/redhat-pending/rhtap----rh-advisories-component-2
+  origin: ${tenant_namespace}
+  pipeline:
+    pipelineRef:
+      params:
+        - name: url
+          value: "${RELEASE_CATALOG_GIT_URL}"
+        - name: revision
+          value: "${RELEASE_CATALOG_GIT_REVISION}"
+        - name: pathInRepo
+          value: pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+      resolver: git
+    serviceAccountName: ${managed_sa_name}
+    timeouts:
+      pipeline: 4h0m0s
+      tasks: 4h0m0s
+  policy: standard-${component_name}

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../rh-push-to-external-registry/resources/managed/sa-rolebinding.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/sa.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/sa.yaml
@@ -1,0 +1,1 @@
+../../../rh-push-to-external-registry/resources/managed/sa.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/application.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/application.yaml
@@ -1,0 +1,1 @@
+../../../rh-push-to-external-registry/resources/tenant/application.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/component.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/component.yaml
@@ -1,0 +1,1 @@
+../../../rh-push-to-external-registry/resources/tenant/component.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/component2.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/component2.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+  name: ${component2_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component2_name}
+  secret: pipelines-as-code-secret-${component_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component2_branch}
+      url: "${component2_git_url}"

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/kustomization.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - component2.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/rp.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/rp.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    # Release is created manually after both component builds complete.
+    release.appstudio.openshift.io/auto-release: 'false'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_name}"
+    originating-tool: "${originating_tool}"
+  name: ${release_plan_name}
+spec:
+  application: ${application_name}
+  target: ${managed_namespace}

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/sa-rolebinding.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/tenant/sa-rolebinding.yaml
@@ -1,0 +1,1 @@
+../../../rh-push-to-external-registry/resources/tenant/sa-rolebinding.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/test.env
+++ b/integration-tests/rh-push-to-external-registry-multi-component/test.env
@@ -1,0 +1,43 @@
+uuid=${uuid:-"$(openssl rand -hex 4)"}
+# make sure uuid is 8 chars long
+uuid="${uuid:0:8}"
+
+export originating_tool="rh-push-to-external-registry-multi-component-e2e-test"
+
+# Namespaces
+export tenant_namespace=dev-release-team-tenant
+#
+## Since this is a test that requires internal services,
+## this name should not change.
+#
+export managed_namespace=managed-release-team-tenant
+
+export application_name=rh-external-mc-app-${uuid}
+export component_type=rh-push-to-external-registry
+export component_name=${component_type}-${uuid}
+export component_branch=${component_name}
+## do not change this. it is a known branch created by Konflux
+export appstudio_component_branch="appstudio-${component_name}"
+
+export component_github_org=hacbs-release-tests
+export component_base_branch=rh-push-to-external-registry-base
+export component_repo_name=${component_github_org}/${component_name}
+export component_base_repo_name=${component_github_org}/e2e-base
+export component_git_url=https://github.com/${component_repo_name}
+
+export component2_type=${component_type}
+export component2_github_org=${component_github_org}
+export component2_name=${component_type}-comp2-${uuid}
+export component2_branch=${component2_name}
+export component2_base_branch=${component_base_branch}
+export component2_base_repo_name=${component_base_repo_name}
+export component2_repo_name=${component_repo_name}
+export component2_git_url=https://github.com/${component2_repo_name}
+
+export PTSV_COMPONENTS="component component2"
+
+export tenant_sa_name=rh-push-to-external-registry-mc-sa-${uuid}
+export release_plan_name=rh-push-to-external-registry-mc-rp-${uuid}
+
+export managed_sa_name=rh-push-to-external-registry-mc-sa-${uuid}
+export release_plan_admission_name=rh-push-to-external-registry-mc-rpa-${uuid}

--- a/integration-tests/rh-push-to-external-registry-multi-component/test.sh
+++ b/integration-tests/rh-push-to-external-registry-multi-component/test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# test.sh - Multi-component test for rh-push-to-external-registry pipeline.
+#
+# Validates pushing multiple components in a single release through the
+# rh-push-to-external-registry pipeline, including Pyxis image creation
+# and RPM manifest verification for each component.
+#
+# This file is sourced by run-test.sh. Multi-component lifecycle is handled
+# by the framework via PTSV_COMPONENTS="component component2" in test.env.
+
+# --- Global Script Variables (Defaults) ---
+CLEANUP="true"
+NO_CVE="true"
+
+# --- Snapshot and Release Management ---
+
+wait_for_releases() {
+    local snapshot_name
+    snapshot_name=$(wait_for_multi_component_snapshot)
+    if [ -z "${snapshot_name}" ]; then
+        echo "Could not find multi-component snapshot"
+        exit 1
+    fi
+
+    local release_name="rh-ext-multi-${uuid}"
+
+    cat <<EOF | kubectl apply -f -
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${release_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-run-uuid: "${uuid}"
+spec:
+  snapshot: ${snapshot_name}
+  releasePlan: ${release_plan_name}
+EOF
+
+    export RELEASE_NAME=${release_name}
+    export RELEASE_NAMESPACE=${tenant_namespace}
+    "${SUITE_DIR}/../scripts/wait-for-release.sh"
+
+    export RELEASE_NAMES="${release_name}"
+}
+
+# --- Release Verification ---
+
+verify_release_contents() {
+    echo "Verifying Release contents for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}..."
+    local release_json
+    release_json=$(kubectl get release/"${RELEASE_NAME}" -n "${RELEASE_NAMESPACE}" -ojson)
+    if [ -z "${release_json}" ]; then
+        log_error "Could not retrieve Release JSON for ${RELEASE_NAME}"
+    fi
+
+    local failures=0
+
+    echo ""
+    echo "Checking for 2 image entries with distinct URLs and shasums..."
+
+    local image_count
+    image_count=$(jq -r '.status.artifacts.images | length' <<< "${release_json}")
+
+    echo "Found ${image_count} image entries in status.artifacts.images"
+    if [ "${image_count}" -ge 2 ]; then
+        echo "✅️ Found ${image_count} image entries (expected at least 2)"
+    else
+        echo "🔴 Found only ${image_count} image entries, expected at least 2"
+        failures=$((failures+1))
+    fi
+
+    local image0_url image0_shasum image1_url image1_shasum
+    image0_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
+    image0_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
+    image1_url=$(jq -r '.status.artifacts.images[1]?.urls[0] // ""' <<< "${release_json}")
+    image1_shasum=$(jq -r '.status.artifacts.images[1]?.shasum // ""' <<< "${release_json}")
+
+    echo "Image 0: url=${image0_url}, shasum=${image0_shasum}"
+    echo "Image 1: url=${image1_url}, shasum=${image1_shasum}"
+
+    if [ -n "${image0_url}" ] && [ -n "${image1_url}" ]; then
+        echo "✅️ Both image URLs are non-empty"
+    else
+        echo "🔴 One or both image URLs are empty"
+        failures=$((failures+1))
+    fi
+
+    if [ -n "${image0_shasum}" ] && [ -n "${image1_shasum}" ]; then
+        echo "✅️ Both image shasums are non-empty"
+    else
+        echo "🔴 One or both image shasums are empty"
+        failures=$((failures+1))
+    fi
+
+    if [ "${image0_url}" != "${image1_url}" ]; then
+        echo "✅️ Image URLs are distinct"
+    else
+        echo "🔴 Image URLs are identical: ${image0_url}"
+        failures=$((failures+1))
+    fi
+
+    if [ "${image0_shasum}" != "${image1_shasum}" ]; then
+        echo "✅️ Image shasums are distinct"
+    else
+        echo "🔴 Image shasums are identical: ${image0_shasum}"
+        failures=$((failures+1))
+    fi
+
+    echo ""
+    echo "Verifying both images are pullable via skopeo..."
+
+    for i in 0 1; do
+        local img_url img_shasum
+        img_url=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.urls[0] // ""' <<< "${release_json}")
+        img_shasum=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.shasum // ""' <<< "${release_json}")
+
+        if [ -z "${img_url}" ] || [ -z "${img_shasum}" ]; then
+            echo "🔴 Image ${i}: missing url or shasum, skipping skopeo check"
+            failures=$((failures+1))
+            continue
+        fi
+
+        echo "Verifying image ${i} pullability with skopeo: ${img_url}"
+        set +e
+        "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
+            "${img_url}" "${img_shasum}" \
+            "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+        local skopeo_rc=$?
+        set -e
+        if [ "${skopeo_rc}" -ne 0 ]; then
+            echo "🔴 Image ${i} skopeo verification failed"
+            failures=$((failures+1))
+        else
+            echo "✅️ Image ${i} is pullable"
+        fi
+    done
+
+    echo ""
+    echo "Verifying Pyxis image IDs..."
+
+    local pyxis_url="https://pyxis.preprod.api.redhat.com/"
+    local managed_plr
+    managed_plr=$(jq -r '.status.managedProcessing?.pipelineRun' <<< "${release_json}")
+    local managed_plr_name
+    managed_plr_name=$(cut -f2 -d/ <<< "${managed_plr}")
+
+    local uri
+    uri=$("${SCRIPT_DIR}/scripts/get-taskrun-result.sh" "${managed_plr_name}" "create-pyxis-image" \
+        "sourceDataArtifact" "${managed_namespace}")
+    local oci_artifact="${uri#*:}"
+    echo "oci_artifact: ${oci_artifact}"
+
+    local oci_artifact_dir
+    oci_artifact_dir=$(mktemp -d -p "$(pwd)")
+    oras blob fetch "${oci_artifact}" --output - | tar -C "${oci_artifact_dir}" --no-overwrite-dir -zxmf -
+    echo "Restored artifact to ${oci_artifact_dir}"
+
+    local pyxisDataFile
+    pyxisDataFile=$(find "${oci_artifact_dir}" -name "pyxis.json")
+
+    local imageIds
+    imageIds=$(jq -r '[.components[].pyxisImages[].imageId] | join(" ")' "${pyxisDataFile}")
+    local imageIdCount
+    imageIdCount=$(echo "${imageIds}" | wc -w)
+
+    echo "Found ${imageIdCount} Pyxis image ID(s): ${imageIds}"
+
+    if [ "${imageIdCount}" -ge 2 ]; then
+        echo "✅️ Found at least 2 Pyxis image IDs (one per component)"
+    else
+        echo "🔴 Found only ${imageIdCount} Pyxis image ID(s), expected at least 2"
+        failures=$((failures+1))
+    fi
+
+    local cert_file key_file
+    cert_file="$(mktemp)"
+    key_file="$(mktemp)"
+    chmod 600 "${cert_file}" "${key_file}"
+    local cert_secret_encoded_value key_secret_encoded_value
+    cert_secret_encoded_value=$(yq '. | select(.metadata.name | contains("pyxis-")) | .data.cert' \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml")
+    key_secret_encoded_value=$(yq '. | select(.metadata.name | contains("pyxis-")) | .data.key' \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml")
+    base64 -d <<< "${cert_secret_encoded_value}" > "${cert_file}"
+    base64 -d <<< "${key_secret_encoded_value}" > "${key_file}"
+
+    local imageIdsFound=false
+    for imageId in ${imageIds}; do
+        local result_image_json
+        result_image_json="$(curl --retry 3 --silent --show-error --fail-with-body \
+            --cert "${cert_file}" --key "${key_file}" "${pyxis_url}v1/images/id/${imageId}")"
+        local result_image_id
+        result_image_id=$(jq -r '._id' <<< "${result_image_json}")
+        if [ "${result_image_id}" == "${imageId}" ]; then
+            echo "✅️ Found imageId: ${result_image_id} in Pyxis"
+        else
+            echo "🔴 imageId: ${result_image_id} did not match expected imageId: ${imageId}"
+            failures=$((failures+1))
+        fi
+
+        local result_rpm_json
+        result_rpm_json="$(curl --retry 3 --silent --show-error --fail-with-body \
+            --cert "${cert_file}" --key "${key_file}" \
+            "${pyxis_url}v1/images/id/${imageId}/rpm-manifest")"
+        local rpm_manifest_id
+        rpm_manifest_id=$(jq -r '._id // ""' <<< "${result_rpm_json}")
+        if [ -n "${rpm_manifest_id}" ]; then
+            echo "✅️ Found RPM manifest for imageId: ${imageId} in Pyxis"
+        else
+            echo "🔴 No RPM manifest found for imageId: ${imageId}"
+            failures=$((failures+1))
+        fi
+
+        imageIdsFound=true
+    done
+
+    if [ "${imageIdsFound}" = false ]; then
+        echo "🔴 No Pyxis image IDs were found"
+        failures=$((failures+1))
+    fi
+
+    rm -f "${cert_file}" "${key_file}"
+    rm -rf "${oci_artifact_dir}" 2>/dev/null || true
+
+    echo ""
+    if [ "${failures}" -gt 0 ]; then
+        echo "🔴 Test has FAILED with ${failures} failure(s)!"
+        exit 1
+    else
+        echo "✅️ All multi-component release checks passed. Success!"
+    fi
+}

--- a/integration-tests/rh-push-to-external-registry-multi-component/vault/managed-secrets.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/vault/managed-secrets.yaml
@@ -1,0 +1,1 @@
+../../rh-push-to-external-registry/vault/managed-secrets.yaml

--- a/integration-tests/rh-push-to-external-registry-multi-component/vault/tenant-secrets.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/vault/tenant-secrets.yaml
@@ -1,0 +1,1 @@
+../../rh-push-to-external-registry/vault/tenant-secrets.yaml

--- a/integration-tests/scripts/find_release_pipelines_from_pr.sh
+++ b/integration-tests/scripts/find_release_pipelines_from_pr.sh
@@ -229,7 +229,8 @@ _emit_integration_testcase_string() {
   ALL_TESTCASES=("e2e" "rh-advisories" "fbc-release" "release-to-github" "push-to-external-registry" \
   "push-to-external-registry-self-hosted-quay" \
   "rhtap-service-push" "rh-push-to-registry-redhat-io" "rh-push-helm-chart-to-registry-redhat-io" \
-  "rh-push-to-external-registry" "push-to-addons-registry" \
+  "rh-push-to-external-registry" "rh-push-to-external-registry-multi-component" \
+  "push-to-addons-registry" \
   "push-rpms-to-pulp")
 
   declare -a SELECTED_TESTCASES=()
@@ -246,6 +247,10 @@ _emit_integration_testcase_string() {
   if [[ " ${SELECTED_TESTCASES[*]} " =~ " push-to-external-registry " ]]; then
     SELECTED_TESTCASES+=("push-to-external-registry-self-hosted-quay")
     SELECTED_TESTCASES+=("push-to-external-registry-idempotent")
+  fi
+  # rh-push-to-external-registry has an extra test suite for multi-component
+  if [[ " ${SELECTED_TESTCASES[*]} " =~ " rh-push-to-external-registry " ]]; then
+    SELECTED_TESTCASES+=("rh-push-to-external-registry-multi-component")
   fi
   # rh-advisories has an extra test suite for the no-CVE path
   if [[ " ${SELECTED_TESTCASES[*]} " =~ " rh-advisories " ]]; then


### PR DESCRIPTION
## Describe your changes

Add a new e2e test suite that validates releasing multiple components through the rh-push-to-external-registry pipeline in a single release.

The test registers two Components under the same Application, waits for both to build, finds the multi-component Snapshot, and creates a Release against it. Verification checks:
- status.artifacts.images contains 2 entries with distinct URLs and shasums
- Both images are pullable via skopeo
- At least 2 Pyxis image IDs are created (one per component)

Shared resources (ec-policy, secrets, vault files, application, component, sa-rolebinding) are symlinked from the existing rh-push-to-external-registry suite. A wait_for_multi_component_snapshot helper is added to the shared test-functions.sh library.

The new test case is registered in both the periodic pipeline and the PR-based test selection script, triggered automatically whenever rh-push-to-external-registry is selected.

Assisted-by: Cursor

## Relevant Jira
https://redhat.atlassian.net/browse/RELEASE-2336

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
