### PR TITLE
feat(RELEASE-2318): assert github release assets

### DIFF
--- a/integration-tests/scripts/verify-github-release.sh
+++ b/integration-tests/scripts/verify-github-release.sh
@@ -78,8 +78,6 @@ RESPONSE_BODY="${RESPONSE%???}"
 case "$HTTP_STATUS" in
     200)
         log_info "✅ Release tag '$RELEASE_TAG' exists in repository '$REPO_PATH'"
-
-        exit 0
         ;;
     404)
         log_error "❌ Release tag '$RELEASE_TAG' does not exist in repository '$REPO_PATH'"
@@ -113,3 +111,28 @@ case "$HTTP_STATUS" in
         exit 1
         ;;
 esac
+
+FAIL_CHECK=0
+if ! jq -e 'any(.assets[]?; .name | test(".*SHA256SUMS$"))' <<< "$RESPONSE_BODY" >/dev/null; then
+    log_error "❌ Missing asset 'SHA256SUMS' in release"
+    FAIL_CHECK=1
+fi
+
+if ! jq -e '[ .assets[]? | select(.name | endswith(".sig")) ] | length == 1' <<< "$RESPONSE_BODY" >/dev/null; then
+    log_error "❌ Expected exactly one '.sig' asset in release"
+    FAIL_CHECK=1
+fi
+
+if ! jq -e '[ .assets[]? | select(.name | endswith(".zip")) ] | length == 1' <<< "$RESPONSE_BODY" >/dev/null; then
+    log_error "❌ Expected exactly one '.zip' asset in release"
+    FAIL_CHECK=1
+fi
+
+if [ "$FAIL_CHECK" -eq 1 ]; then
+    log_info "Available assets:"
+    jq -r '.assets[]?.name' <<< "$RESPONSE_BODY"
+    exit 1
+fi
+
+log_info "✅ All requested assets ('SHA256SUMS', '.sig', and '.zip') are present in the release."
+exit 0


### PR DESCRIPTION
Extend verify-github-release to check release have following assets
- SHA256SUMS
- one *.sig asset
- one *.zip asset

Assisted-by: gemini

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`