### PR TITLE
fix(RELEASE-2646): fix empty `pids` array

### DIFF
--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -181,7 +181,7 @@ spec:
 
               # Cap parallel suites to limit kubectl/API and memory spikes (step memory: 6Gi).
               MAX_PARALLEL="$(params.MAX_PARALLEL)"
-              declare -A pids
+              declare -A pids=()
               testcase_index=0
 
               reap_finished_test_jobs() {


### PR DESCRIPTION
Access to empty `pids` cannot be done via "${#pids[@]}" as that's causing `unbound variable` error.
Instead it has to be access as "${#pids[@]:-0}"

Assited-By: claude

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
