### PR TITLE
fix(RELEASE-2544): initialise checksum_map result before early exit

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -1756,6 +1756,9 @@ spec:
         STDERR_FILE=/tmp/stderr.txt
         CHECKSUM_MAP_REF=""
 
+        # Initialise result to empty so it is always populated regardless of exit path.
+        echo -n "" > "$(results.checksum_map.path)"
+
         # Check if the previous step finished successfully. If not, stop here.
         if [ "$(cat "$(results.result.path)")" != "Success" ]; then
           echo "Previous step failed. Exiting..."


### PR DESCRIPTION
Write an empty string to checksum_map result path before the early-exit check so Tekton always sees a populated result, even when a previous step failed. The EXIT trap that normally writes this result was registered after the early exit, leaving the path empty and causing a misleading "invalid pipelineresults" error downstream.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
