### PR TITLE
feat(HUM-959): use custom mock config for e2e builds

### DIFF
--- a/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/pull-request-template-comp2.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/pull-request-template-comp2.yaml
@@ -33,6 +33,8 @@ spec:
       value: ["x86_64"]
     - name: build-platforms
       value: ["linux/amd64", "localhost"]
+    - name: mock-config-template-filename-in-sources
+      value: "mock.cfg"
   pipelineRef:
     resolver: git
     params:

--- a/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/pull-request-template.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/pull-request-template.yaml
@@ -33,6 +33,8 @@ spec:
       value: ["x86_64", "aarch64"]
     - name: build-platforms
       value: ["linux/amd64", "linux/arm64", "localhost"]
+    - name: mock-config-template-filename-in-sources
+      value: "mock.cfg"
   pipelineRef:
     resolver: git
     params:

--- a/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/push-template-comp2.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/push-template-comp2.yaml
@@ -31,6 +31,8 @@ spec:
       value: ["x86_64"]
     - name: build-platforms
       value: ["linux/amd64", "localhost"]
+    - name: mock-config-template-filename-in-sources
+      value: "mock.cfg"
   pipelineRef:
     resolver: git
     params:

--- a/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/push-template.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/tenant/templates/tekton/push-template.yaml
@@ -31,6 +31,8 @@ spec:
       value: ["x86_64", "aarch64"]
     - name: build-platforms
       value: ["linux/amd64", "linux/arm64", "localhost"]
+    - name: mock-config-template-filename-in-sources
+      value: "mock.cfg"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Add `mock-config-template-filename-in-sources` parameter to push-rpms-to-pulp build templates
- Points to `hack/buildroot.cfg` in the e2e-base component repo which pins builds to Fedora 44
- Avoids flaky rawhide mirror failures (404s from stale CDN/mirrors) that were causing build pipeline failures

## Test plan
- [ ] Verify hello component builds successfully using the f44 mock config
- [ ] Verify RPMs are built correctly with f44 dist tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)