### PR TITLE
fix(RELEASE-2650): add timestamp tag to data-acceptable-bundles

### DIFF
--- a/tasks/managed/update-trusted-tasks/tests/mocks.sh
+++ b/tasks/managed/update-trusted-tasks/tests/mocks.sh
@@ -2,15 +2,29 @@
 set -eux
 
 # mocks to be injected into task step scripts
+function date() {
+  # Return a fixed timestamp for testing
+  if [[ "$*" == "+%s" ]]; then
+      echo "1234567890"
+      return
+  fi
+
+  # Fall back to real date for other uses
+  command date "$@"
+}
+
 function skopeo() {
   echo Mock skopeo called with: $* >&2
   echo $* >> "$(params.dataDir)/mock_skopeo.txt"
 
-  if [[ "$*" =~ list-tags\ docker://quay.io/exists ]]; then
-      echo '{"Tags": ["v2.0.0-3", "latest", "v2.0.0-2"]}'
-      return
-  elif [[ "$*" =~ list-tags\ docker://quay.io ]]; then
-      echo '{"Tags": ["v2.0.0-4", "v2.0.0-3", "v2.0.0-2"]}'
+  if [[ "$*" =~ inspect.*docker://quay.io/exists.*:latest ]]; then
+      # Exists repo has :latest tag - return success
+      return 0
+  elif [[ "$*" =~ inspect.*docker://quay.io/.*:latest ]]; then
+      # Other repos don't have :latest tag - return failure
+      return 1
+  elif [[ "$*" =~ ^copy ]]; then
+      # Mock skopeo copy - just record that it was called
       return
   fi
 
@@ -24,11 +38,11 @@ function ec() {
 
   if [[ "$*" =~ "track bundle".*fail-image.* ]]; then
       exit 1
-  
+
   elif [[ "$*" =~ "track bundle".* ]]; then
       return
   fi
-  
+
   echo Error: Unexpected call
   exit 1
 }

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
@@ -131,12 +131,14 @@ spec:
               #!/bin/bash
               set -eux
 
+              # Expect only 1 skopeo call for inspect (task fails before copy)
               if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
-                echo Error: skopeo was expected to be called 1 times. Actual calls:
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
                 cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi
 
+              # Expect 1 ec call which should fail
               if [ "$(wc -l < "$(params.dataDir)/mock_ec.txt")" != 1 ]; then
                 echo Error: ec was expected to be called 1 time. Actual calls:
                 cat "$(params.dataDir)/mock_ec.txt"

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
@@ -163,8 +163,9 @@ spec:
               #!/bin/bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
-                echo Error: skopeo was expected to be called 1 times. Actual calls:
+              # Expect 2 skopeo calls: 1 for inspect, 1 for copy to tag as :latest
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
                 cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi
@@ -175,12 +176,22 @@ spec:
                 exit 1
               fi
 
+              # Expect ec track bundle to use :latest as input and output to timestamp tag
               out="track bundle --bundle quay.io/exists/task-echo:0.1@sha256:abcde \
               --input oci:quay.io/exists/data-acceptable-bundles:latest \
-              --output oci:quay.io/exists/data-acceptable-bundles:latest"
+              --output oci:quay.io/exists/data-acceptable-bundles:1234567890"
 
               if ! grep -qF -- "$out" "$(params.dataDir)/mock_ec.txt"; then
                 echo "Error: $out was not found in the ec command"
                 cat "$(params.dataDir)/mock_ec.txt"
+                exit 1
+              fi
+
+              # Expect skopeo copy to tag the timestamp image as :latest
+              copy_cmd="copy --retry-times 3 docker://quay.io/exists/data-acceptable-bundles:1234567890 \
+              docker://quay.io/exists/data-acceptable-bundles:latest"
+              if ! grep -qF -- "$copy_cmd" "$(params.dataDir)/mock_skopeo.txt"; then
+                echo "Error: $copy_cmd was not found in the skopeo commands"
+                cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
@@ -195,14 +195,17 @@ spec:
               #!/bin/bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 3 ]; then
-                echo Error: skopeo was expected to be called 1 times. Actual calls:
+              # Expect 6 skopeo calls:
+              # 3 for inspect (one for notexist, two for exists repo - once per component)
+              # 3 for copy (one per component)
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 6 ]; then
+                echo Error: skopeo was expected to be called 6 times. Actual calls:
                 cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi
 
               if [ "$(wc -l < "$(params.dataDir)/mock_ec.txt")" != 3 ]; then
-                echo Error: ec was expected to be called 1 time. Actual calls:
+                echo Error: ec was expected to be called 3 times. Actual calls:
                 cat "$(params.dataDir)/mock_ec.txt"
                 exit 1
               fi
@@ -210,15 +213,15 @@ spec:
               all_found=true
               outs=(
                 "track bundle --bundle quay.io/notexist/task-echo-v01:0.1@sha256:abcde \
-              --output oci:quay.io/notexist/data-acceptable-bundles:latest"
+              --output oci:quay.io/notexist/data-acceptable-bundles:1234567890"
 
                 "track bundle --bundle quay.io/exists/task-echo-v02:0.2@sha256:abcde \
               --input oci:quay.io/exists/data-acceptable-bundles:latest \
-              --output oci:quay.io/exists/data-acceptable-bundles:latest"
+              --output oci:quay.io/exists/data-acceptable-bundles:1234567890"
 
                 "track bundle --bundle quay.io/exists/task-echo:0.3@sha256:abcde \
               --input oci:quay.io/exists/data-acceptable-bundles:latest \
-              --output oci:quay.io/exists/data-acceptable-bundles:latest"
+              --output oci:quay.io/exists/data-acceptable-bundles:1234567890"
               )
 
               for out in "${outs[@]}"; do
@@ -229,5 +232,23 @@ spec:
               done
               if ! $all_found; then
                 cat "$(params.dataDir)/mock_ec.txt"
+                exit 1
+              fi
+
+              # Expect 3 skopeo copy commands
+              notexist_copy="copy --retry-times 3 docker://quay.io/notexist/data-acceptable-bundles:1234567890 \
+              docker://quay.io/notexist/data-acceptable-bundles:latest"
+              if ! grep -qF "$notexist_copy" "$(params.dataDir)/mock_skopeo.txt"; then
+                echo "Error: expected copy for notexist repo"
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              exists_copy="copy --retry-times 3 docker://quay.io/exists/data-acceptable-bundles:1234567890 \
+              docker://quay.io/exists/data-acceptable-bundles:latest"
+              copy_count=$(grep -cF "$exists_copy" "$(params.dataDir)/mock_skopeo.txt" || true)
+              if [ "$copy_count" != 2 ]; then
+                echo "Error: expected 2 copy commands for exists repo, found $copy_count"
+                cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
@@ -159,28 +159,32 @@ spec:
               #!/bin/bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 3 ]; then
-                echo Error: skopeo was expected to be called 1 times. Actual calls:
+              # Expect 4 skopeo calls: 1 for inspect, 3 for copy (one per tag)
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 4 ]; then
+                echo Error: skopeo was expected to be called 4 times. Actual calls:
                 cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi
 
               if [ "$(wc -l < "$(params.dataDir)/mock_ec.txt")" != 3 ]; then
-                echo Error: ec was expected to be called 1 time. Actual calls:
+                echo Error: ec was expected to be called 3 times. Actual calls:
                 cat "$(params.dataDir)/mock_ec.txt"
                 exit 1
               fi
 
               all_found=true
+              # First tag creates the bundle (no input), subsequent ones use :latest as input
               outs=(
                 "track bundle --bundle quay.io/notexist/task-echo:0.1@sha256:abcde \
-              --output oci:quay.io/notexist/data-acceptable-bundles:latest"
+              --output oci:quay.io/notexist/data-acceptable-bundles:1234567890"
 
                 "track bundle --bundle quay.io/notexist/task-echo:test@sha256:abcde \
-              --output oci:quay.io/notexist/data-acceptable-bundles:latest"
+              --input oci:quay.io/notexist/data-acceptable-bundles:latest \
+              --output oci:quay.io/notexist/data-acceptable-bundles:1234567890"
 
                 "track bundle --bundle quay.io/notexist/task-echo:stage@sha256:abcde \
-              --output oci:quay.io/notexist/data-acceptable-bundles:latest"
+              --input oci:quay.io/notexist/data-acceptable-bundles:latest \
+              --output oci:quay.io/notexist/data-acceptable-bundles:1234567890"
               )
 
               for out in "${outs[@]}"; do
@@ -191,5 +195,15 @@ spec:
               done
               if ! $all_found; then
                 cat "$(params.dataDir)/mock_ec.txt"
+                exit 1
+              fi
+
+              # Expect 3 skopeo copy commands (one after each ec track bundle)
+              copy_cmd="copy --retry-times 3 docker://quay.io/notexist/data-acceptable-bundles:1234567890 \
+              docker://quay.io/notexist/data-acceptable-bundles:latest"
+              copy_count=$(grep -cF "$copy_cmd" "$(params.dataDir)/mock_skopeo.txt" || true)
+              if [ "$copy_count" != 3 ]; then
+                echo "Error: expected 3 skopeo copy commands, found $copy_count"
+                cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
@@ -158,8 +158,9 @@ spec:
               #!/bin/bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
-                echo Error: skopeo was expected to be called 1 times. Actual calls:
+              # Expect 2 skopeo calls: 1 for inspect, 1 for copy to tag as :latest
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 2 ]; then
+                echo Error: skopeo was expected to be called 2 times. Actual calls:
                 cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi
@@ -170,11 +171,21 @@ spec:
                 exit 1
               fi
 
+              # Expect ec track bundle to output to timestamp tag (1234567890 from mocked date)
               out="track bundle --bundle quay.io/notexist/task-echo:0.1@sha256:abcde \
-              --output oci:quay.io/notexist/data-acceptable-bundles:latest"
+              --output oci:quay.io/notexist/data-acceptable-bundles:1234567890"
 
               if ! grep -qF -- "$out" "$(params.dataDir)/mock_ec.txt"; then
                 echo "Error: $out was not found in the ec command"
                 cat "$(params.dataDir)/mock_ec.txt"
+                exit 1
+              fi
+
+              # Expect skopeo copy to tag the timestamp image as :latest
+              copy_cmd="copy --retry-times 3 docker://quay.io/notexist/data-acceptable-bundles:1234567890 \
+              docker://quay.io/notexist/data-acceptable-bundles:latest"
+              if ! grep -qF -- "$copy_cmd" "$(params.dataDir)/mock_skopeo.txt"; then
+                echo "Error: $copy_cmd was not found in the skopeo commands"
+                cat "$(params.dataDir)/mock_skopeo.txt"
                 exit 1
               fi

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -127,13 +127,18 @@ spec:
         set -eux
 
         SNAPSHOT_SPEC_FILE="$(params.dataDir)/$(params.snapshotPath)"
-        TAG="latest"
 
         # check if snapshot exsits
         if [ ! -f "${SNAPSHOT_SPEC_FILE}" ] ; then
             echo "No valid snapshot file was found."
             exit 1
         fi
+
+        # The OPA data bundle is tagged with the current timestamp. This has two main
+        # advantages. First, it prevents the image from accidentally not having any tags,
+        # and getting garbage collected. Second, it helps us create a timeline of the
+        # changes done to the data over time.
+        TIMESTAMP_TAG=$(date '+%s')
 
         # Extract the componentGroup from the snapshot
         componentGroup=$(jq -r '.componentGroup' "${SNAPSHOT_SPEC_FILE}")
@@ -165,6 +170,21 @@ spec:
                 ACCEPTABLE_BUNDLES=$(echo "${repository}" \
                   | awk -F'/' '{$NF="data-acceptable-bundles"; print $0}' OFS='/')
 
+                # Check once if :latest exists for this ACCEPTABLE_BUNDLES repo
+                # Use inspect instead of list-tags for efficiency as tag count grows
+                set +e
+                skopeo inspect --retry-times 3 --raw --no-tags docker://"${ACCEPTABLE_BUNDLES}:latest" &> /dev/null
+                RESULT=$?
+                set -e
+
+                if [ ${RESULT} -eq 0 ]; then
+                    echo "${ACCEPTABLE_BUNDLES}:latest exists - using it as an input"
+                    LATEST_EXISTS="true"
+                else
+                    echo "${ACCEPTABLE_BUNDLES}:latest does not exist"
+                    LATEST_EXISTS="false"
+                fi
+
                 # Get the number of tags from the repository
                 NUM_TAGS=$(jq --argjson j "$j" '.repositories[$j].tags | length' <<< "$component")
 
@@ -173,24 +193,25 @@ spec:
                 do
                     imageTag=$(jq -c -r --argjson j "$j" --argjson k "$k" '.repositories[$j].tags[$k]' <<< "$component")
 
-                    set +e
-                    # Check if ACCEPTABLE_BUNDLES OCI artifact has a latest tag
-                    skopeo list-tags docker://"${ACCEPTABLE_BUNDLES}" | jq -r '.Tags[]' | grep "^${TAG}$" &> /dev/null
-                    RESULT=$?
-                    set -e
-
-                    # If it has a latest tag, use it as an --input for the ec track bundle command
-                    if [ $RESULT -eq 0 ]; then
-                        echo "${ACCEPTABLE_BUNDLES}:${TAG} exists - using it as an input"
+                    # If :latest exists, use it as an --input for the ec track bundle command
+                    # Output to the timestamp tag to prevent garbage collection
+                    if [[ "${LATEST_EXISTS}" == "true" ]]; then
+                        echo "Adding ${repository}:${imageTag}${sha} to ${ACCEPTABLE_BUNDLES}:${TIMESTAMP_TAG}"
                         ec track bundle --bundle "${repository}:${imageTag}${sha}" \
-                        --input oci:"${ACCEPTABLE_BUNDLES}:${TAG}" --output oci:"${ACCEPTABLE_BUNDLES}:${TAG}"
-
-                    # Else - Do not use it as an --input
+                        --input oci:"${ACCEPTABLE_BUNDLES}:latest" --output oci:"${ACCEPTABLE_BUNDLES}:${TIMESTAMP_TAG}"
                     else
-                        echo "${ACCEPTABLE_BUNDLES}:${TAG} does not exist"
+                        echo "Creating ${ACCEPTABLE_BUNDLES}:${TIMESTAMP_TAG} with ${repository}:${imageTag}${sha}"
                         ec track bundle --bundle "${repository}:${imageTag}${sha}" \
-                        --output oci:"${ACCEPTABLE_BUNDLES}:${TAG}"
+                        --output oci:"${ACCEPTABLE_BUNDLES}:${TIMESTAMP_TAG}"
                     fi
+
+                    # Tag the timestamp-based image as :latest for the next iteration
+                    echo "Tagging ${ACCEPTABLE_BUNDLES}:${TIMESTAMP_TAG} as :latest"
+                    skopeo copy --retry-times 3 "docker://${ACCEPTABLE_BUNDLES}:${TIMESTAMP_TAG}" \
+                    "docker://${ACCEPTABLE_BUNDLES}:latest"
+
+                    # Now that we've created :latest, mark it as existing for subsequent tags
+                    LATEST_EXISTS="true"
                 done
             done
         done


### PR DESCRIPTION
## Describe your changes

The update-trusted-tasks task now creates timestamp-based tags for the data-acceptable-bundles OCI artifact to prevent garbage collection. This follows the pattern used in build-definitions.

The task now:
- Generates a timestamp at the start (unix epoch format)
- Outputs ec track bundle to the timestamp tag
- Copies the timestamp tag to :latest after each bundle is added
- Optimizes by checking :latest existence once per repository

This ensures that even when :latest moves to a new digest, the old digest remains tagged and won't be garbage collected, preventing breakage of digest-pinned references.

## Relevant Jira

RELEASE-2650

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
