### PR TITLE
fix: generate catalog URLs regardless of publishing state

### DIFF
--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -231,7 +231,7 @@ spec:
         do
             COMPONENT=$(jq -c --argjson i "$i" '.components[$i]' "${SNAPSHOT_SPEC_FILE}")
             PAYLOAD='{"published":true}'
-            COMPONENT_NAME=$(jq -r '.name' <<< "$COMPONENT")
+            COMPONENT_NAME=$(jq -r '.name // ""' <<< "$COMPONENT")
 
             # Set source_container_image_enabled based on pushSourceContainer value in components or use default if
             # it is not set in the component
@@ -272,39 +272,42 @@ spec:
                   echo "$PYXIS_REPOSITORY" >> "$SIGN_REGISTRY_ACCESS_PATH"
                 fi
 
-                # Default to false
+                PYXIS_REPOSITORY_PUBLISHED=$(jq -r '.published // "false"' <<< "$PYXIS_REPOSITORY_JSON")
+                PYXIS_REPOSITORY_PUBLISH_ON_PUSH=$(jq -r '.publish_on_push // "false"' <<< "$PYXIS_REPOSITORY_JSON")
+
+                SHOULD_PATCH=true
                 if [ "$skipRepoPublishing" = true ] ; then
                     echo "skipRepoPublishing is set to true, skipping publishing..."
-                    continue
+                    SHOULD_PATCH=false
+                elif [ "${PYXIS_REPOSITORY_PUBLISH_ON_PUSH}" != "true" ] ; then
+                    echo "WARNING: repository ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY}" \
+                      "is marked as publish_on_push = false"
+                    echo "Skipping the setting of the published flag."
+                    SHOULD_PATCH=false
                 fi
 
-                # verify that publish_on_push is set to true.
-                # otherwise, do not publish the image.
-                PYXIS_REPOSITORY_PUBLISH_ON_PUSH=$(jq -r '.publish_on_push // "false"' <<< "$PYXIS_REPOSITORY_JSON")
-                if [ "${PYXIS_REPOSITORY_PUBLISH_ON_PUSH}" != "true" ] ; then
-                  echo "WARNING: repository ${PYXIS_REGISTRY}/${PYXIS_REPOSITORY} is marked as publish_on_push = false"
-                  echo "Skipping the setting of the published flag."
-                  continue
-                fi
-
-                curl --retry 5 --key /tmp/key --cert /tmp/crt "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
+                if [ "$SHOULD_PATCH" = true ]; then
+                  curl --retry 5 --key /tmp/key --cert /tmp/crt \
+                    "${PYXIS_URL}/v1/repositories/id/${PYXIS_REPOSITORY_ID}" \
                     -X PATCH -H 'Content-Type: application/json' --data-binary "${PAYLOAD}"
-
-                # Determine the correct CATALOG_BASE_URL based on the repository prefix
-                if [[ "$REPOSITORY" == quay.io/redhat-prod/* || "$REPOSITORY" == quay.io/rh-flatpaks-prod/* ]]
-                then
-                  CATALOG_BASE_URL="https://catalog.redhat.com/software/containers"
-                elif [[ "$REPOSITORY" == quay.io/redhat-pending/* || "$REPOSITORY" == quay.io/rh-flatpaks-stage/* ]]
-                then
-                  CATALOG_BASE_URL="https://catalog.stage.redhat.com/software/containers"
-                else
-                  echo "Unknown repository prefix. Exiting..."
-                  exit 1
                 fi
 
-                URL="${CATALOG_BASE_URL}/${PYXIS_REPOSITORY}/${PYXIS_REPOSITORY_ID}"
-                RESULTS_JSON=$(jq --arg name "$COMPONENT_NAME" --arg url "$URL" \
-                  '.catalog_urls += [{"name": $name, "url": $url}]' <<< "$RESULTS_JSON")
+                if [ "${PYXIS_REPOSITORY_PUBLISHED}" = "true" ] || [ "$SHOULD_PATCH" = true ]; then
+                  if [[ "$REPOSITORY" == quay.io/redhat-prod/* || "$REPOSITORY" == quay.io/rh-flatpaks-prod/* ]]
+                  then
+                    CATALOG_BASE_URL="https://catalog.redhat.com/software/containers"
+                  elif [[ "$REPOSITORY" == quay.io/redhat-pending/* || "$REPOSITORY" == quay.io/rh-flatpaks-stage/* ]]
+                  then
+                    CATALOG_BASE_URL="https://catalog.stage.redhat.com/software/containers"
+                  else
+                    echo "Unknown repository prefix. Exiting..."
+                    exit 1
+                  fi
+
+                  URL="${CATALOG_BASE_URL}/${PYXIS_REPOSITORY}/${PYXIS_REPOSITORY_ID}"
+                  RESULTS_JSON=$(jq --arg name "$COMPONENT_NAME" --arg url "$URL" \
+                    '.catalog_urls += [{"name": $name, "url": $url}]' <<< "$RESULTS_JSON")
+                fi
             done
         done
 

--- a/tasks/managed/publish-pyxis-repository/tests/mocks.sh
+++ b/tasks/managed/publish-pyxis-repository/tests/mocks.sh
@@ -21,7 +21,7 @@ function curl() {
       elif [[ "$*" == *"my-image"[56]* ]]; then
         echo '{"_id": "'$CALL_ID'", "publish_on_push": true, "requires_terms": false}'
       else
-        echo '{"_id": "'$CALL_ID'", "publish_on_push": true, "requires_terms": true}'
+        echo '{"_id": "'$CALL_ID'", "publish_on_push": true, "published": true, "requires_terms": true}'
       fi
     fi
   elif [[ "$*" == '--retry 5 --key /tmp/key --cert /tmp/crt https://pyxis.api.redhat.com/v1/repositories/id/'?' -X PATCH -H Content-Type: application/json --data-binary {"published":true}' ]]

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-marked-as-not-pub-on-push.yaml
@@ -61,6 +61,7 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
+                    "name": "component0",
                     "repositories": [
                       {
                         "url": "quay.io/redhat-prod/my-product----my-image0"
@@ -164,5 +165,24 @@ spec:
 
               [[ "$(head -n 1 "$(params.dataDir)/mock_curl.txt")" \
                   == *"/my-product/my-image0 "* ]]
+
+              RESULTS_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/results/publish-pyxis-repository-results.json"
+
+              if [ ! -f "$RESULTS_FILE" ]; then
+                  echo "Error: Results file not found."
+                  exit 1
+              fi
+
+              EXPECTED_RESULTS='{
+                "catalog_urls": []
+              }'
+
+              if ! echo "$EXPECTED_RESULTS" | jq --slurpfile actual "$RESULTS_FILE" -e '. == $actual[0]' > /dev/null
+              then
+                  echo "Error: Results do not match expected output."
+                  echo "Expected: $EXPECTED_RESULTS"
+                  echo "Actual: $(cat "$RESULTS_FILE")"
+                  exit 1
+              fi
       runAfter:
         - run-task

--- a/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
+++ b/tasks/managed/publish-pyxis-repository/tests/test-publish-pyxis-repository-skip-publishing.yaml
@@ -61,6 +61,7 @@ spec:
                 "application": "my-app",
                 "components": [
                   {
+                    "name": "component1",
                     "repositories": [
                       {
                         "url": "quay.io/redhat-prod/my-product----my-image1"
@@ -160,6 +161,30 @@ spec:
               if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
                   echo Error: curl was expected to be called once. Actual calls:
                   cat "$(params.dataDir)/mock_curl.txt"
+                  exit 1
+              fi
+
+              RESULTS_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/results/publish-pyxis-repository-results.json"
+
+              if [ ! -f "$RESULTS_FILE" ]; then
+                  echo "Error: Results file not found."
+                  exit 1
+              fi
+
+              EXPECTED_RESULTS='{
+                "catalog_urls": [
+                  {
+                    "name": "component1",
+                    "url": "https://catalog.redhat.com/software/containers/my-product/my-image1/1"
+                  }
+                ]
+              }'
+
+              if ! echo "$EXPECTED_RESULTS" | jq --slurpfile actual "$RESULTS_FILE" -e '. == $actual[0]' > /dev/null
+              then
+                  echo "Error: Results do not match expected output."
+                  echo "Expected: $EXPECTED_RESULTS"
+                  echo "Actual: $(cat "$RESULTS_FILE")"
                   exit 1
               fi
       runAfter:


### PR DESCRIPTION
## Summary

- Catalog URLs were only generated after the Pyxis PATCH in `publish-pyxis-repository`, so they were skipped when `skipRepoPublishing` was `true` or `publish_on_push` was `false`
- This left the Release CR with empty `catalog_urls`, even though images were successfully pushed to the registry
- Moves catalog URL generation before the skip/publish guards so Release artifacts always show where the image can be found

## Details

The `publish-pyxis-repository` task conflated two concerns: publishing the repository in Pyxis and recording where the image lives. The catalog URL is derived from the repository location and Pyxis ID, both of which are available before any publishing decision. By generating the URL first, downstream consumers (including the Konflux UI and integration tests) always have the catalog link.

The Pyxis PATCH remains gated behind `skipRepoPublishing` and `publish_on_push` — only the URL generation is moved.

## Test plan

- [x] Updated `test-publish-pyxis-repository-marked-as-not-pub-on-push` to verify catalog URL is present even when `publish_on_push` is `false`
- [x] Updated `test-publish-pyxis-repository-skip-publishing` to verify catalog URL is present even when `skipRepoPublishing` is `true`
- [x] Existing tests (`test-publish-pyxis-repository`, `test-publish-pyxis-repository-flatpak-no-sign-registry-access`, etc.) are unaffected