### PR TITLE
fix: restore scoped Release cleanup and fix app name collisions

### DIFF
--- a/integration-tests/collectors-no-cve/test.env
+++ b/integration-tests/collectors-no-cve/test.env
@@ -14,7 +14,7 @@ export tenant_namespace=dev-release-team-tenant
 #
 export managed_namespace=managed-release-team-tenant
 
-export application_name=e2eapp-${uuid}
+export application_name=e2eapp-nocve-${uuid}
 export component_type=collectors-no-cve
 export component_name=${component_type}-${uuid}
 export component_branch=${component_name}

--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -169,7 +169,7 @@ cleanup_resources() {
     # Clean up component repository
     echo "Deleting Github repository ${component_repo_name} ..." >> "${cleanup_log_file}"
     "${SUITE_DIR}/../scripts/delete-repository.sh" "${component_repo_name}"
-    
+
     # Clean up component2 repository if it exists and is different from component repo
     if [ -n "${component2_repo_name}" ] && [ "${component2_repo_name}" != "${component_repo_name}" ]; then
       echo "Deleting Github repository ${component2_repo_name} ..." >> "${cleanup_log_file}"
@@ -195,12 +195,13 @@ cleanup_resources() {
         echo "tmpDir not set or not a directory, skipping k8s resource cleanup." | tee -a "${cleanup_log_file}"
     fi
 
-    # Clean up Release CRs created by this specific test run
-    # Use uuid (from test.env) to support concurrent test execution
-    if [ -n "$uuid" ] && [ -n "$tenant_namespace" ]; then
-        echo "Deleting Release CRs with test-run-uuid=${uuid} in namespace ${tenant_namespace}..." | tee -a "${cleanup_log_file}"
+    # Clean up Release CRs created by this specific test suite
+    # Use both uuid and originating-tool labels to avoid deleting Release CRs
+    # belonging to other parallel test suites that share the same uuid
+    if [ -n "$uuid" ] && [ -n "$tenant_namespace" ] && [ -n "$originating_tool" ]; then
+        echo "Deleting Release CRs with test-run-uuid=${uuid},originating-tool=${originating_tool} in namespace ${tenant_namespace}..." | tee -a "${cleanup_log_file}"
         kubectl delete release -n "${tenant_namespace}" \
-            -l test-run-uuid="${uuid}" \
+            -l "test-run-uuid=${uuid},originating-tool=${originating_tool}" \
             --ignore-not-found >> "${cleanup_log_file}" 2>&1 || \
             echo "Warning: Failed to delete some Release CRs" | tee -a "${cleanup_log_file}"
     else

--- a/integration-tests/rh-push-helm-chart-to-registry-redhat-io/test.env
+++ b/integration-tests/rh-push-helm-chart-to-registry-redhat-io/test.env
@@ -8,7 +8,7 @@ export originating_tool="rh-push-helm-chart-to-registry-redhat-io-e2e-test"
 export tenant_namespace=dev-release-team-tenant
 export managed_namespace=managed-release-team-tenant
 
-export application_name=rh-redhat-app-${uuid}
+export application_name=rh-helm-app-${uuid}
 export component_type=rh-push-helm-chart-to-registry-redhat-io
 
 # Image basename must stay fixed — validate-helm-chart-snapshot checks


### PR DESCRIPTION

## Describe your changes

Bring this change that is already in Development #2277 to Stage.
PR #2237 accidentally reverted the scoped cleanup from PR #2223.

Cleanup went back to deleting Release CRs by uuid only, so when any test finishes it deletes all Releases with the same UID. This only affects the staging periodic pipeline since all tests run in one PR and share the same UID.

Restore originating-tool label in the cleanup.

Fix two application_name collisions which share the same base and clash when running together in the same PR.

## Relevant Jira
Development PR: https://github.com/konflux-ci/release-service-catalog/pull/2277
Slack: https://redhat-internal.slack.com/archives/C04J47GL936/p1780931268029169

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
