### PR TITLE
chore: update deprecated command

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -8,13 +8,13 @@ ignore_pr_authors = ["red-hat-konflux", "release-service-bot"]
 # Run review automatically when PRs are opened/reopened/ready.
 pr_commands = [
   "/review",
-  "/improve",
+  "/agentic_review",
 ]
 # Run review automatically when new commits are pushed to an open PR.
 handle_push_trigger = true
 push_commands = [
   "/review",
-  "/improve",
+  "/agentic_review",
 ]
 
 [pr_reviewer]


### PR DESCRIPTION
The /improve is deprecated in favor of /agentic_review.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
