### PR TITLE
fix: rename multi-component component_type to avoid collision

### DIFF
--- a/integration-tests/rh-push-to-external-registry-multi-component/test.env
+++ b/integration-tests/rh-push-to-external-registry-multi-component/test.env
@@ -13,7 +13,7 @@ export tenant_namespace=dev-release-team-tenant
 export managed_namespace=managed-release-team-tenant
 
 export application_name=rh-external-mc-app-${uuid}
-export component_type=rh-push-to-external-registry
+export component_type=rh-push-to-external-registry-mc
 export component_name=${component_type}-${uuid}
 export component_branch=${component_name}
 ## do not change this. it is a known branch created by Konflux


### PR DESCRIPTION
## Describe your changes
component_branch and component_repo_name come from component_type. Both rh-push-to-external-registry and rh-push-to-external-registry-multi-component used the same component_type so they created the same branch and repo when running together in the periodic pipeline since all tests share the same PR UID.

Development PR: https://github.com/konflux-ci/release-service-catalog/pull/2281
## Relevant Jira
https://redhat-internal.slack.com/archives/C04J47GL936/p1780931268029169
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
