### PR TITLE
docs: add notes about adding new e2e tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -262,3 +262,6 @@ When adding new integration tests:
 4. Store secrets in ansible vault files
 5. Update this README with test-specific information
 6. Add test-specific documentation to the individual test README
+7. Sym link resource files to existing tests where applicable (like `application.yaml` files)
+8. Add an IntegrationTestScenario to `konflux-release-data` to trigger the test. Following existing examples, add the test for release-service-utils as well
+9. After the test has proven stable for 7 days, mark it as required in the GitHub UI branch settings


### PR DESCRIPTION
This commit updates the integration-tests README file to include notes about adding the ITS, adding it for the utils repo too, and when to mark it as required.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
