### PR TITLE
feat(RELEASE-2419): add appendTags support

### DIFF
--- a/schema/dataKeys.json
+++ b/schema/dataKeys.json
@@ -432,6 +432,10 @@
         "includeLayers": {
           "type": "boolean",
           "description": "When creating ContainerImage in Pyxis, include details about layers"
+        },
+        "appendTags": {
+          "type": "boolean",
+          "description": "When updating existing ContainerImage in Pyxis, preserve existing tags and add new ones instead of replacing them"
         }
       }
     },

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -159,7 +159,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+      image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
       computeResources:
         limits:
           memory: 3Gi
@@ -223,6 +223,7 @@ spec:
 
         # Default to false
         includeLayers="$(jq -r ".pyxis.includeLayers // false" "${DATA_FILE}")"
+        appendTags="$(jq -r ".pyxis.appendTags // false" "${DATA_FILE}")"
 
         # Function to process a single component in parallel
         process_component() {
@@ -381,6 +382,7 @@ spec:
                       --architecture-digest "$ARCH_DIGEST" \
                       --architecture "$ARCH" \
                       --rh-push "$(params.rhPush)" \
+                      --append-tags "$appendTags" \
                       --dockerfile "${DOCKERFILE_PATH}" | tee "/tmp/output_${component_index}_${index}"
                     # The rh-push-to-external-registry e2e test depends on this line being in the task log
                     IMAGEID=$(awk '/The image id is/{print $NF}' "/tmp/output_${component_index}_${index}" | head -1)

--- a/tasks/managed/create-pyxis-image/tests/mocks.sh
+++ b/tasks/managed/create-pyxis-image/tests/mocks.sh
@@ -43,7 +43,7 @@ function create_container_image() {
     printf "The image id is %04d\n" "$image_id"
   fi
 
-  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tags "*" --is-latest false --verbose --oras-manifest-fetch "*" --name "*" --media-type "*" --digest "*" --architecture-digest "*" --architecture "*" --rh-push "* ]]
+  if [[ "$*" != "--pyxis-url https://pyxis.preprod.api.redhat.com/ --certified false --tags "*" --is-latest false --verbose --oras-manifest-fetch "*" --name "*" --media-type "*" --digest "*" --architecture-digest "*" --architecture "*" --rh-push "*" --append-tags "*" --dockerfile "* ]]
   then
     echo Error: Unexpected call
     echo Mock create_container_image called with: $*

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-append-tags.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-append-tags.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-pyxis-image-one-containerimage-one-arch
+  name: test-create-pyxis-image-append-tags
 spec:
-  description: |
-    Run the create-pyxis-image task with a single containerImage in the snapshot.
+  description: >
+    Run the create-pyxis-image task with appendTags set to true in the data file.
+    Check that --append-tags true is propagated to the create_container_image call.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -63,18 +64,10 @@ spec:
                     "containerImage": "source@sha256:mydigest",
                     "repositories": [
                       {
-                        "url": "registry.io/image1",
+                        "url": "quay.io/redhat-prod/myproduct----myimage",
                         "tags": [
-                          "testtag",
-                          "testtag2"
-                        ]
-                      },
-                      {
-                        "url": "registry.io/image2",
-                        "tags": [
-                          "a",
-                          "b",
-                          "c"
+                          "v4.13.0",
+                          "v4.14.0"
                         ]
                       }
                     ]
@@ -85,6 +78,9 @@ spec:
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
               {
+                "pyxis": {
+                  "appendTags": true
+                }
               }
               EOF
           - name: create-trusted-artifact
@@ -127,16 +123,12 @@ spec:
         - setup
     - name: check-result
       params:
-        - name: pyxisDataPath
-          value: $(tasks.run-task.results.pyxisDataPath)
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
       taskSpec:
         params:
-          - name: pyxisDataPath
-            type: string
           - name: sourceDataArtifact
             type: string
           - name: dataDir
@@ -170,68 +162,29 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)"/mock_create_container_image.txt)" \
-                != 2 ]; then
-                echo Error: create_container_image was expected to be called 2 time. Actual calls:
+              if [ "$(wc -l < \
+                "$(params.dataDir)/mock_create_container_image.txt")" != 1 ]; then
+                echo Error: create_container_image was expected to be called 1 time. Actual calls:
                 cat "$(params.dataDir)/mock_create_container_image.txt"
                 exit 1
               fi
 
-              if [ -f "$(params.dataDir)"/mock_cleanup_tags.txt ]; then
-                echo Error: cleanup_tags was not expected to be called. Actual calls:
-                cat "$(params.dataDir)/mock_cleanup_tags.txt"
-                exit 1
-              fi
-
-              if ! grep -- "--tags testtag" < \
-                "$(params.dataDir)/mock_create_container_image.txt" 2> /dev/null
+              if ! grep -- "--append-tags true" \
+                < "$(params.dataDir)"/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: create_container_image call was expected to include "--tags testtag". Actual call:
+                echo Error: create_container_image call was expected to include "--append-tags true".
+                echo Actual call:
                 cat "$(params.dataDir)/mock_create_container_image.txt"
                 exit 1
               fi
 
-              if ! grep -- "--rh-push false" < \
-                "$(params.dataDir)/mock_create_container_image.txt" 2> /dev/null
+              if ! grep -- "--tags v4.13.0 v4.14.0" \
+                < "$(params.dataDir)"/mock_create_container_image.txt 2> /dev/null
               then
-                echo Error: create_container_image call was expected to include "--rh-push false". Actual call:
+                echo Error: create_container_image call was expected to include "--tags v4.13.0 v4.14.0".
+                echo Actual call:
                 cat "$(params.dataDir)/mock_create_container_image.txt"
                 exit 1
               fi
-
-              if [ "$(wc -l < "$(params.dataDir)"/mock_oras.txt)" != 3 ]; then
-                echo Error: oras was expected to be called 3 times. Actual calls:
-                cat "$(params.dataDir)/mock_oras.txt"
-                exit 1
-              fi
-
-              cat > "$(params.dataDir)/skopeo_expected_calls.txt" << EOF
-              inspect --retry-times 3 --raw docker://registry.io/image1@sha256:mydigest
-              inspect --retry-times 3 --raw docker://registry.io/image2@sha256:mydigest
-              EOF
-
-              mock_skopeo_calls="$(sort < "$(params.dataDir)/mock_skopeo.txt" | md5sum)"
-              # check that the actual calls match the expected calls
-              if [ "$(md5sum < "$(params.dataDir)/skopeo_expected_calls.txt")" \
-                != "${mock_skopeo_calls}" ]
-              then
-                echo "Error: Actual skopeo calls do not match expected calls."
-                echo Expected calls:
-                cat "$(params.dataDir)/skopeo_expected_calls.txt"
-                echo Actual calls:
-                echo "${mock_skopeo_calls}"
-                exit 1
-              fi
-
-              # check if the correct arch and image id are set in the json file
-              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0002" )
-                and ( .os == "linux" )' "$(params.dataDir)/$(params.pyxisDataPath)"
-
-              if [ "$(wc -l < "$(params.dataDir)"/mock_select-oci-auth.txt)" != 3 ]; then
-                echo Error: select-oci-with was expected to be called 3 times. Actual calls:
-                cat "$(params.dataDir)/mock_select-oci-auth.txt"
-                exit 1
-              fi
-
       runAfter:
         - run-task

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-containerimage-no-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dockerfile-not-found.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-duplicate-digest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -241,7 +241,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-dockerfile-not-pulled.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-get-image-architectures.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-invalid-server.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fail-no-snapshot-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-helm-chart-processed.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-helm-chart-processed.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-include-layers-false.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-mixed-helm-containers.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -191,7 +191,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -181,7 +181,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-multi-containerimages-one-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -194,7 +194,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-oci-artifact.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-one-containerimage-multi-arch.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-rhpush-and-commontag.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -156,7 +156,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-with-gzipped-layers.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:24cac01e7e3541779e28eaf9e860224615d9068982e8d8d8be4ee38f85f58e38
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION
## Describe your changes

Add .pyxis.appendTags field to allow preserving existing tags when updating container images in Pyxis. This enables releasing the same image for multiple product versions while maintaining all version tags.

- Add appendTags to pyxis schema in dataKeys.json
- Update create-pyxis-image task to pass --append-tags flag
- Update test mocks to include new parameter
- Add test for appendTags functionality
- Update all release-service-utils image references to new version with append-tags support

Related utils PR: https://github.com/konflux-ci/release-service-utils/pull/780

## Relevant Jira

RELEASE-2419

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
