### PR TITLE
fix: use digest for skopeo multi-arch verify to avoid tag race

### DIFF
--- a/integration-tests/rh-push-to-external-registry/test.sh
+++ b/integration-tests/rh-push-to-external-registry/test.sh
@@ -30,10 +30,11 @@ verify_release_contents() {
     echo "Restored artifact ${ociArtifact} to ${oci_artifact_dir}"
 
     local failures=0
-    local image_url image_arches
+    local image_url image_arches image_shasum
 
     image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
     image_arches=$(jq -r '.status.artifacts.images[0]?.arches // [] | sort | join(" ")' <<< "${release_json}")
+    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
 
     echo "Checking Image URL..."
     if [ -n "${image_url}" ]; then
@@ -51,17 +52,20 @@ verify_release_contents() {
         failures=$((failures+1))
     fi
 
-    echo "Verifying multi-arch image pullability with skopeo..."
+    # Use digest instead of tag, tag can be overwritten by concurrent tests
+    local image_pullspec="${image_url%:*}@${image_shasum}"
+
+    echo "Verifying multi-arch image pullability with skopeo (${image_pullspec})..."
     AUTH_FILE="$(mktemp)"
     yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
         "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" | base64 -d > "${AUTH_FILE}"
 
     for arch in amd64 arm64; do
         if skopeo inspect --authfile "${AUTH_FILE}" --override-arch "${arch}" --tls-verify=true \
-                "docker://${image_url}" > /dev/null 2>&1; then
-            echo "✅️ skopeo inspect --override-arch ${arch} succeeded for ${image_url}"
+                "docker://${image_pullspec}" > /dev/null 2>&1; then
+            echo "✅️ skopeo inspect --override-arch ${arch} succeeded for ${image_pullspec}"
         else
-            echo "🔴 skopeo inspect --override-arch ${arch} failed for ${image_url}"
+            echo "🔴 skopeo inspect --override-arch ${arch} failed for ${image_pullspec}"
             failures=$((failures+1))
         fi
     done


### PR DESCRIPTION
## Describe your changes
The multi-arch skopeo check added in 820af7c4 verifies the pushed image using the :latest tag directly. Both therh-push-to-external-registry and its multi-component test push to the same quay repo with :latest and run at the same time in stage so when one test overwrites :latest the other test's skopeo inspect fails for arm64 because its pointing at a different manifest.
Switch to using the image digest from release artifacts instead of the tag.

Assisted-by: Claude
## Relevant Jira
https://redhat-internal.slack.com/archives/C063GB7130U/p1781249725720749
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
