### PR TITLE
feat(RELEASE-2641): add intention label to signing requests

### DIFF
--- a/tasks/managed/rh-sign-image/rh-sign-image.yaml
+++ b/tasks/managed/rh-sign-image/rh-sign-image.yaml
@@ -193,12 +193,15 @@ spec:
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
         TASK_ID=$(context.taskRun.uid)
         PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
+        INTENTION_LABEL="internal-services.appstudio.openshift.io/intention"
 
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No valid data file was provided."
             exit 1
         fi
+
+        INTENTION=$(jq -r '.intention // "unknown"' "${DATA_FILE}")
         RPA_FILE="$(params.dataDir)/$(params.releasePlanAdmissionPath)"
         if [ ! -f "${RPA_FILE}" ] ; then
             echo "No valid rpa file was provided."
@@ -587,6 +590,7 @@ spec:
                 -p taskGitRevision="$(params.taskGitRevision)" \
                 -l ${TASK_LABEL}="${TASK_ID}" \
                 -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+                -l ${INTENTION_LABEL}="${INTENTION}" \
                 -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
                 "${EXTRA_ARGS[@]}" -s true &
                 ((++REQUEST_COUNT))
@@ -638,6 +642,7 @@ spec:
               -p taskGitRevision="$(params.taskGitRevision)" \
               -l ${TASK_LABEL}="${TASK_ID}" \
               -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+              -l ${INTENTION_LABEL}="${INTENTION}" \
               -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
               "${EXTRA_ARGS[@]}" -s true &
               ((++REQUEST_COUNT))
@@ -675,6 +680,7 @@ spec:
             -p taskGitRevision="$(params.taskGitRevision)" \
             -l ${TASK_LABEL}="${TASK_ID}" \
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+            -l ${INTENTION_LABEL}="${INTENTION}" \
             -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
             "${EXTRA_ARGS[@]}" -s true &
           jobs_spawned=$((jobs_spawned + 1))

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-multiple-components.yaml
@@ -283,6 +283,14 @@ spec:
                   echo "requester does not match"
                   exit 1
                 fi
+
+                labels=$(jq -r ".items[$ir].metadata.labels" <<< "${internalRequests}")
+                intention=$(jq -r '.["internal-services.appstudio.openshift.io/intention"]' \
+                  <<< "${labels}")
+                if [ "${intention}" != "unknown" ]; then
+                  echo "intention label does not match expected default value 'unknown'"
+                  exit 1
+                fi
               done
 
               differenceReferences=$(echo "${expectedReferences[@]}" "${foundReferences[@]}" | tr ' ' '\n' | \

--- a/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
+++ b/tasks/managed/rh-sign-image/tests/test-rh-sign-image-single-component.yaml
@@ -83,6 +83,7 @@ spec:
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
+                "intention": "staging",
                 "mapping": {
                   "defaults": {
                     "pushSourceContainer": "true"
@@ -255,6 +256,14 @@ spec:
 
                 if [ "$(jq -r '.requester' <<< "${params}")" != "testuser-single" ]; then
                   echo "requester does not match"
+                  exit 1
+                fi
+
+                labels=$(jq -r ".items[$ir].metadata.labels" <<< "${internalRequests}")
+                intention=$(jq -r '.["internal-services.appstudio.openshift.io/intention"]' \
+                  <<< "${labels}")
+                if [ "${intention}" != "staging" ]; then
+                  echo "intention label does not match expected value 'staging'"
                   exit 1
                 fi
               done

--- a/tasks/managed/sign-index-image/sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/sign-index-image.yaml
@@ -210,12 +210,15 @@ spec:
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
         TASK_ID=$(context.taskRun.uid)
         PIPELINERUN_LABEL="internal-services.appstudio.openshift.io/pipelinerun-uid"
+        INTENTION_LABEL="internal-services.appstudio.openshift.io/intention"
 
         DATA_FILE="$(params.dataDir)/$(params.dataPath)"
         if [ ! -f "${DATA_FILE}" ] ; then
             echo "No valid data file was provided."
             exit 1
         fi
+
+        INTENTION=$(jq -r '.intention // "unknown"' "${DATA_FILE}")
 
         RESULTS_FILE="$(params.dataDir)/$(params.fbcResultsPath)"
         if [ ! -f "${RESULTS_FILE}" ] ; then
@@ -487,6 +490,7 @@ spec:
               -p taskGitRevision="$(params.taskGitRevision)" \
               -l ${TASK_LABEL}="${TASK_ID}" \
               -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+              -l ${INTENTION_LABEL}="${INTENTION}" \
               -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
               "${EXTRA_ARGS[@]}" -s true &
               ((++REQUEST_COUNT))
@@ -540,6 +544,7 @@ spec:
             -p taskGitRevision="$(params.taskGitRevision)" \
             -l ${TASK_LABEL}="${TASK_ID}" \
             -l ${PIPELINERUN_LABEL}="$(params.pipelineRunUid)" \
+            -l ${INTENTION_LABEL}="${INTENTION}" \
             -t "$(params.requestTimeout)" --pipeline-timeout "0h30m0s" --task-timeout "0h25m0s" \
             "${EXTRA_ARGS[@]}" -s true &
           ((++REQUEST_COUNT))

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image-multicomponent.yaml
@@ -57,6 +57,7 @@ spec:
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
+                "intention": "production",
                 "sign": {
                   "configMapName": "signing-config-map"
                 }
@@ -176,7 +177,9 @@ spec:
               )
               for internalRequest in ${internalRequests};
               do
-                params=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+                irJson=$(kubectl get internalrequest "${internalRequest}" -o json)
+                params=$(jq -r '.spec.params' <<< "${irJson}")
+                labels=$(jq -r '.metadata.labels' <<< "${irJson}")
 
                 if [[ "$(jq -r '.references' <<< "${params}")" \
                     != $(echo "${expected_references}" | tr '\n' ' ') ]]; then
@@ -192,6 +195,13 @@ spec:
                 if [ "$(jq -r '.requester' <<< "${params}")" != "testuser" ]
                 then
                   echo "requester does not match"
+                  exit 1
+                fi
+
+                intention=$(jq -r '.["internal-services.appstudio.openshift.io/intention"]' \
+                  <<< "${labels}")
+                if [ "${intention}" != "production" ]; then
+                  echo "intention label does not match expected value 'production'"
                   exit 1
                 fi
               done

--- a/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
+++ b/tasks/managed/sign-index-image/tests/test-sign-index-image.yaml
@@ -55,6 +55,7 @@ spec:
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
               {
+                "intention": "staging",
                 "sign": {
                   "configMapName": "signing-config-map"
                 }
@@ -166,7 +167,9 @@ spec:
 
               for internalRequest in ${internalRequests};
               do
-                params=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+                irJson=$(kubectl get internalrequest "${internalRequest}" -o json)
+                params=$(jq -r '.spec.params' <<< "${irJson}")
+                labels=$(jq -r '.metadata.labels' <<< "${irJson}")
 
                 if [ "$(jq -r '.references' <<< "${params}")" != \
                      "$(echo "$expected_references" | tr '\n' ' ')" ]; then
@@ -182,6 +185,13 @@ spec:
                 if [ "$(jq -r '.requester' <<< "${params}")" != "testuser" ]
                 then
                   echo "requester does not match"
+                  exit 1
+                fi
+
+                intention=$(jq -r '.["internal-services.appstudio.openshift.io/intention"]' \
+                  <<< "${labels}")
+                if [ "${intention}" != "staging" ]; then
+                  echo "intention label does not match expected value 'staging'"
                   exit 1
                 fi
               done


### PR DESCRIPTION
## Describe your changes
Add internal-services.appstudio.openshift.io/intention label to signing requests created by rh-sign-image and sign-index-image tasks. The value is taken from the intention field in the data file, defaulting to "unknown" if not present.

Test coverage includes verification of staging, production, and default unknown values across multiple test scenarios.

Related internal-services PR: https://github.com/konflux-ci/internal-services/pull/809 (but there is no dependency, both can be merged at any time)

## Relevant Jira

RELEASE-2641

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
