### PR TITLE
fix: use yq v4.34 compatible syntax in rh-advisories-idempotent

### DIFF
--- a/integration-tests/rh-advisories-idempotent/test.sh
+++ b/integration-tests/rh-advisories-idempotent/test.sh
@@ -95,16 +95,10 @@ patch_component_source_before_merge() {
         work_dir=$(mktemp -d)
         nopath_file_name=$(basename "${file_name}")
         echo "${decoded_contents}" > "${work_dir}/${nopath_file_name}"
-        yq -i '
-          .spec.params //= [] |
-          (.spec.params[] | select(.name == "build-platforms") | .value) |=
-            ((. // []) + ["linux/arm64"] | unique) |
-          if any(.spec.params[]; .name == "build-source-image") then
-            (.spec.params[] | select(.name == "build-source-image") | .value) = "true"
-          else
-            .spec.params += [{"name": "build-source-image", "value": "true"}]
-          end
-        ' "${work_dir}/${nopath_file_name}"
+        yq -i '(.spec.params[] | select(.name == "build-platforms") | .value) += ["linux/arm64"]' \
+            "${work_dir}/${nopath_file_name}"
+        yq -i '.spec.params += [{"name": "build-source-image", "value": "true"}]' \
+            "${work_dir}/${nopath_file_name}"
         encoded_contents=$(base64 -w 0 < "${work_dir}/${nopath_file_name}")
         rm -rf "${work_dir}"
 


### PR DESCRIPTION
## Describe your changes
The patch_component_source_before_merge yq uses any() with semicolon syntax which needs yq >= 4.40.0 but the test image only has v4.34.1 so this test was broke in 77b54fc5.

Replaced with two simple yq -i calls same as
collectors/test.sh does. The null guards and duplicate checks from the original aren't needed since test repos are created fresh each run.
## Relevant Jira
* https://redhat-internal.slack.com/archives/C063GB7130U/p1781595394556389
* https://github.com/konflux-ci/release-service-catalog/commit/77b54fc558fb8ae07560c1a1321bfee6211045ec
* https://github.com/konflux-ci/release-service-utils/commit/279102923b560e087f789bf3741305a4b9842907

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
