### PR TITLE
fix: give push-artifacts-to-cdn its own ec-policy

### DIFF
--- a/integration-tests/push-artifacts-to-cdn/resources/managed/ec-policy.yaml
+++ b/integration-tests/push-artifacts-to-cdn/resources/managed/ec-policy.yaml
@@ -1,1 +1,26 @@
-../../../push-rpms-to-pulp/resources/managed/ec-policy.yaml
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: standard-${component_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  description: >-
+    Includes rules for levels 1, 2 & 3 of SLSA v0.1.
+  publicKey: "k8s://openshift-pipelines/public-key"
+  sources:
+    - name: Release Policies
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+      volatileConfig:
+        exclude:
+          - value: cve.cve_blockers
+            effectiveUntil: "2025-02-01T00:00:00Z"
+      config:
+        exclude: []
+        include:
+          - '@slsa3'


### PR DESCRIPTION
The ec-policy.yaml was a symlink to push-rpms-to-pulp's policy, which was recently updated to use @redhat_rpms with
allowed_target_branch_patterns restricted to ^push-rpms-to-pulp.*$. This caused conforma violations for push-artifacts-to-cdn component branches that don't match that pattern.

Replace the symlink with a dedicated ec-policy.yaml using @slsa3 and conforma/release-policy:konflux, which is appropriate for binary artifact releases.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
