### PR TITLE
fix: add contentGateway to push-artifacts-to-cdn

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -306,6 +306,7 @@ spec:
           value: |
             [
               {"systemName": "cdn", "dynamic": false},
+              {"systemName": "contentGateway", "dynamic": false},
               {"systemName": "intention", "dynamic": false},
               {"systemName": "releaseNotes", "dynamic": false}
             ]


### PR DESCRIPTION
## Describe your changes
Add contentGateway system to check-data-keys to require productName, productCode, productVersionName and contentType.

## Relevant Jira
User Ticket: KFLUXSPRT-8171
https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1781614370588939?thread_ts=1781608892.441589&cid=C04PZ7H0VA8

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
