### PR TITLE
docs(RELEASE-2015): add usage guidance for component-incrementer(demo-test-PR)

### DIFF
--- a/integration-tests/push-to-external-registry/test.sh
+++ b/integration-tests/push-to-external-registry/test.sh
@@ -3,6 +3,34 @@
 # --- Global Script Variables (Defaults) ---
 CLEANUP="true"
 
+# Hook: runs after Kubernetes resources are created, before the release triggers.
+# Pre-seeds repo A with 3 existing tags to simulate divergent history between
+# repo A and repo B, demonstrating {{ component-incrementer }} uniformity.
+post_create_kubernetes_resources() {
+    echo "── [demo] Pre-seeding repo A with divergent tag history ──"
+    local auth_file
+    auth_file=$(mktemp)
+    chmod 600 "${auth_file}"
+    trap 'rm -f "${auth_file}"' RETURN
+    yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
+        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" \
+        | base64 -d > "${auth_file}"
+
+    local repo_a="quay.io/hacbs-release-tests/${component_name}"
+    local source_image="docker://quay.io/libpod/alpine:latest"
+    for tag in v1.0.0-1 v1.0.0-2 v1.0.0-3; do
+        echo "  → seeding ${repo_a}:${tag}"
+        skopeo copy --retry-times 3 \
+            --override-os linux --override-arch amd64 \
+            --dest-authfile "${auth_file}" \
+            "${source_image}" \
+            "docker://${repo_a}:${tag}"
+    done
+    echo "  ✅ Repo A pre-seeded: v1.0.0-1, v1.0.0-2, v1.0.0-3"
+    echo "  ℹ️  Repo B (${component_name}-b) is empty — divergent state ready"
+    echo "── [demo] Pre-seeding complete ──"
+}
+
 # Function to verify Release contents
 # Relies on global variables: RELEASE_NAME, RELEASE_NAMESPACE, SUITE_DIR, managed_namespace
 verify_release_contents() {

--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -31,6 +31,11 @@ This task supports variable expansion in tag values from the mapping. The curren
 
 You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
 
+Use "{{ incrementer }}" when pushing to a single registry. Use "{{ component-incrementer }}"
+when pushing to multiple registries to guarantee every registry receives the same sequential tag.
+Example: if repo-a has v1.0.0-3 and repo-b has v1.0.0-1, the next release will push v1.0.0-4
+to both.
+
 ## Parameters
 
 | Name                    | Description                                                                                                                                                                                                                                | Optional | Default value                 |

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -38,6 +38,11 @@ spec:
       to OCI image labels if not present in annotations (converts + to _ for tag compliance)
 
     You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
+
+    Use "{{ incrementer }}" when pushing to a single registry. Use "{{ component-incrementer }}"
+    when pushing to multiple registries to guarantee every registry receives the same sequential tag.
+    Example: if repo-a has v1.0.0-3 and repo-b has v1.0.0-1, the next release will push v1.0.0-4
+    to both.
   params:
     - name: snapshotPath
       type: string


### PR DESCRIPTION
## Describe your changes
> **⚠️ Demo/test PR — will remain draft and be closed after demo recording.**
This PR is used to trigger the `push-to-external-registry` e2e test to demonstrate
the `{{ component-incrementer }}` feature in action on real Konflux infrastructure.
## What this shows
- `{{ component-incrementer }}` computing the global max tag across multiple repos
- Both repositories receiving the same sequential tag in a single release run
- Cache behavior (each repo queried only once per prefix)## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
