### PR TITLE
feat(RELEASE-2463): replace appstudio-utils with release-service-utils

### DIFF
--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-ec.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -126,7 +126,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-fail-no-snapshot.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -100,7 +100,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-latest.yaml
@@ -52,7 +52,7 @@ spec:
             runAsUser: 1001
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -158,7 +158,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/bin/bash
               set -eux

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-components.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -189,7 +189,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-multiple-tags.yaml
@@ -48,7 +48,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -153,7 +153,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
+++ b/tasks/managed/update-trusted-tasks/tests/test-update-trusted-tasks-success-no-latest.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -152,7 +152,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
             workingDir: $(params.dataDir)
             script: |
               #!/bin/bash

--- a/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
+++ b/tasks/managed/update-trusted-tasks/update-trusted-tasks.yaml
@@ -115,7 +115,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-trusted-tasks
-      image: quay.io/konflux-ci/appstudio-utils@sha256:a975a1a2825a36af8ec445cb83cff7480587e5b0650ce131bf8af4df31483336
+      image: quay.io/konflux-ci/release-service-utils@sha256:9662fe3a1cea0cac79c4504abbaa13b6366b5ec5b9aadeaff0395da574c5ac72
       computeResources:
         limits:
           memory: 1Gi


### PR DESCRIPTION
## Describe your changes

The appstudio-utils image is being deprecated, so replace it with our own release-service-utils image that we use in most places.

For this to work, we had to add ec cli to our image: https://github.com/konflux-ci/release-service-utils/pull/789

## Relevant Jira

RELEASE-2463

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
