### PR TITLE
test: fix invalid yq syntax in rh-advisories-idempotent PaC patch

### DIFF
--- a/integration-tests/rh-advisories-idempotent/test.sh
+++ b/integration-tests/rh-advisories-idempotent/test.sh
@@ -95,16 +95,10 @@ patch_component_source_before_merge() {
         work_dir=$(mktemp -d)
         nopath_file_name=$(basename "${file_name}")
         echo "${decoded_contents}" > "${work_dir}/${nopath_file_name}"
-        yq -i '
-          .spec.params //= [] |
-          (.spec.params[] | select(.name == "build-platforms") | .value) |=
-            ((. // []) + ["linux/arm64"] | unique) |
-          if any(.spec.params[]; .name == "build-source-image") then
-            (.spec.params[] | select(.name == "build-source-image") | .value) = "true"
-          else
-            .spec.params += [{"name": "build-source-image", "value": "true"}]
-          end
-        ' "${work_dir}/${nopath_file_name}"
+        yq -i '(.spec.params[] | select(.name == "build-platforms") | .value) += ["linux/arm64"]' \
+            "${work_dir}/${nopath_file_name}"
+        yq -i '.spec.params += [{"name": "build-source-image", "value": "true"}]' \
+            "${work_dir}/${nopath_file_name}"
         encoded_contents=$(base64 -w 0 < "${work_dir}/${nopath_file_name}")
         rm -rf "${work_dir}"
 


### PR DESCRIPTION
## Describe your changes
The rh-advisories-idempotent e2e test failed during setup because patch_component_source_before_merge() used an invalid yq v4 expression (if any(...) then ... else ... end after a pipe chain). 
Replace it with the same two-command pattern already used by the collectors test to add linux/arm64 and build-source-image: true to the PaC pipeline YAML.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
