### PR TITLE
fix(RELEASE-2552): Update artifact pipeline image

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -179,7 +179,7 @@ spec:
 
   steps:
     - name: extract-artifacts
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       securityContext:
         runAsUser: 1001
       computeResources:
@@ -402,7 +402,7 @@ spec:
           fi
         done
     - name: push-unsigned-using-oras
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       computeResources:
         limits:
           memory: 512Mi
@@ -652,7 +652,7 @@ spec:
           fi
         done
     - name: sign-mac-binaries
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       computeResources:
         limits:
           memory: 512Mi
@@ -829,7 +829,7 @@ spec:
           fi
         done
     - name: sign-windows-binaries
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       computeResources:
         limits:
           memory: 512Mi
@@ -1000,7 +1000,7 @@ spec:
           fi
         done
     - name: compress-artifacts
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       computeResources:
         limits:
           memory: 512Mi
@@ -1221,7 +1221,7 @@ spec:
         echo "$SNAPSHOT_JSON" > /shared/snapshot.json
 
     - name: generate-checksums
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       computeResources:
         limits:
           memory: 512Mi
@@ -1392,7 +1392,7 @@ spec:
         ssh $SSH_OPTS "${checksum_user}@${checksum_host}" "rm -rf ~/${REMOTE_DIR}"
 
     - name: push-artifacts
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       computeResources:
         limits:
           memory: 512Mi
@@ -1736,7 +1736,7 @@ spec:
         fi
 
     - name: build-advisory-checksum-map
-      image: quay.io/konflux-ci/release-service-utils@sha256:e2578e2c0ec60a9729783b51b6b5968b92e6b16d1d0351fdba54d131b11d8ccb
+      image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-exdous-rsync-push.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-extra-files-in-container.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-extra-files-in-container.yaml
@@ -70,7 +70,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-exdous-rsync-push.yaml
@@ -78,7 +78,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductcode.yaml
@@ -76,7 +76,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductname.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-cgwproductversionname.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-containerimage.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-filessource.yaml
@@ -81,7 +81,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-name.yaml
@@ -76,7 +76,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stageddestination.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-no-stagedversion.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-pulp-push.yaml
@@ -89,7 +89,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-skopeo-copy.yaml
@@ -81,7 +81,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-windows-signing.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-fail-windows-signing.yaml
@@ -82,7 +82,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-multiple-components.yaml
@@ -114,7 +114,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-no-filesfilename.yaml
@@ -81,7 +81,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             env:
               - name: "RESULT"
                 value: '$(params.result)'

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-non-binary-files-in-archive.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-non-binary-files-in-archive.yaml
@@ -83,7 +83,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-only-cdn.yaml
@@ -76,7 +76,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-no-files-component.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-skip-no-files-component.yaml
@@ -93,7 +93,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-staged-files.yaml
@@ -82,7 +82,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:ada350d0170351c4f8ce5f57e52bb287ad9fb8418a8c5f6ca1d2e2683cb697ea
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-tar-input.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-tar-input.yaml
@@ -81,7 +81,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b62e2fef45c84259c60c7097f5a572a4c32f957ffeee3eed53eb0b7d560e5234
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-unsafe-filenames.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn-unsafe-filenames.yaml
@@ -84,7 +84,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -80,7 +80,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:b62e2fef45c84259c60c7097f5a572a4c32f957ffeee3eed53eb0b7d560e5234
+            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
             script: |
               #!/usr/bin/env bash
               set -ex


### PR DESCRIPTION
From [release-service-utils](https://github.com/konflux-ci/release-service-utils/pull/820) update to to always clean up the checksum host. PR 820
Use a finally block to ensure the checksum host is always cleaned up rather than only on the successful path.
https://github.com/konflux-ci/release-service-utils/pull/820

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
