### PR TITLE
chore: add @ic-konflux-release ping to staging periodic pipeline

### DIFF
--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -286,7 +286,9 @@ spec:
               MESSAGE=$(jq -r '.' <<< "${TEST_RESULT}" | awk NF)
 
               # need 3 back-ticks around message for code-block
-              MESSAGE=$(echo -n "Catalog Nightly Staging test result: \`\`\`$MESSAGE\`\`\`" | jq -Rsa)
+              # ping @ic-konflux-release group
+              MESSAGE=$(echo -n "<!subteam^S09N535GS4E>"\
+                " Catalog Nightly Staging test result: \`\`\`$MESSAGE\`\`\`" | jq -Rsa)
 
               cat > /tmp/payload.json << EOF
               {"text": $MESSAGE}


### PR DESCRIPTION
## Describe your changes
Notify the release team group when nightly test results are posted to Slack.

docs: https://docs.slack.dev/messaging/formatting-message-text/#mentioning-groups

## Relevant Jira
https://redhat-internal.slack.com/archives/C04J47GL936/p1782134547106749?thread_ts=1782134140.299629&cid=C04J47GL936

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
