### PR TITLE
chore: bump verify-conforma-konflux-ta task revision

### DIFF
--- a/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
@@ -192,7 +192,7 @@ spec:
     #      - name: url
     #        value: https://github.com/conforma/tekton-catalog
     #      - name: revision
-    #        value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+    #        value: "2c1963225e8563194a8dce7f659c71bd866da426"
     #      - name: pathInRepo
     #        value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
     #

--- a/pipelines/managed/e2e/e2e.yaml
+++ b/pipelines/managed/e2e/e2e.yaml
@@ -107,7 +107,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -236,7 +236,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -240,7 +240,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
+++ b/pipelines/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
@@ -203,7 +203,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -230,7 +230,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -236,7 +236,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -308,7 +308,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -203,7 +203,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -329,7 +329,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -266,7 +266,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -267,7 +267,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -316,7 +316,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -227,7 +227,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
@@ -206,7 +206,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/release-to-nrrc/release-to-nrrc.yaml
+++ b/pipelines/managed/release-to-nrrc/release-to-nrrc.yaml
@@ -206,7 +206,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -380,7 +380,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
@@ -328,7 +328,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -333,7 +333,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -299,7 +299,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-rpm-advisories/rh-rpm-advisories.yaml
+++ b/pipelines/managed/rh-rpm-advisories/rh-rpm-advisories.yaml
@@ -223,7 +223,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -275,7 +275,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "2c1963225e8563194a8dce7f659c71bd866da426"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:


### PR DESCRIPTION
## Summary
- Update the conforma tekton-catalog revision for the `verify-conforma-konflux-ta` task across all 22 managed pipelines
- Revision: `f20c7a8c15a71c9462b11e5a28f8907a29c7075a` → `2c1963225e8563194a8dce7f659c71bd866da426`

This change contains a patch to help teams switch to the new trusted_task_rules schema.

## Test plan
- [ ] CI pipelines pass with the updated task revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)