### PR TITLE
fix(KFLUXSPRT-8173): use taskGitRevision SHA for pipeline metadata

### DIFF
--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -286,7 +286,13 @@ spec:
           org=$(echo "${orgrepo}" | cut -f1 -d/)
           repo=$(echo "${orgrepo}" | cut -f2 -d/ | cut -d. -f1)
 
-          sha=$(curl -s "https://api.github.com/repos/${org}/${repo}/commits/${revision}" | jq -r '.sha // ""')
+          # taskGitRevision is resolved to a SHA by the release-service operator,
+          # fall back to the revision from the pipeline ref if it is not a SHA
+          sha="$(params.taskGitRevision)"
+          if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            sha=$(curl-with-retry -s "https://api.github.com/repos/${org}/${repo}/commits/${revision}" \
+              | jq -r '.sha // ""' || true)
+          fi
 
         fi
 

--- a/tasks/managed/collect-data/tests/mocks.sh
+++ b/tasks/managed/collect-data/tests/mocks.sh
@@ -2,9 +2,12 @@
 set -eux
 
 # mocks to be injected into task step scripts
-curl() {
-  # Output the call to stderr
-  echo "Mock curl called with:" "$@" >&2
+curl-with-retry() {
+  echo "Mock curl-with-retry called with:" "$@" >&2
   echo "$@" >> "$(params.dataDir)/mock_curl.txt"
+  if [[ "$*" =~ fail-catalog ]]; then
+    echo "API rate limit exceeded" >&2
+    return 1
+  fi
   echo '{ "sha": "12345"}'
 }

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-api-fail.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-api-fail.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-data-print-pipeline-ref
+  name: test-collect-data-print-pipeline-ref-api-fail
 spec:
   description: |
-    Run the collect-data task with a non SHA taskGitRevision and verify that the pipeline ref
-    info is resolved via the GitHub API fallback
+    Run the collect-data task with a non-SHA taskGitRevision and a failing GitHub API call,
+    verify that the task does not fail and sha defaults to unknown
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -92,7 +92,7 @@ spec:
                   pipelineRef:
                     params:
                       - name: url
-                        value: 'https://github.com/some-catalog/some-service-catalog.git'
+                        value: 'https://github.com/fail-catalog/some-service-catalog.git'
                       - name: revision
                         value: development
                       - name: pathInRepo
@@ -154,7 +154,7 @@ spec:
         - name: taskGitUrl
           value: "http://localhost"
         - name: taskGitRevision
-          value: "main"
+          value: "development"
       runAfter:
         - setup
     - name: check-result
@@ -223,11 +223,11 @@ spec:
               pathinrepo=$(jq -r '.pathinrepo' <<< "$PIPELINE_METADATA")
               sha=$(jq -r '.sha' <<< "$PIPELINE_METADATA")
 
-              test "${org}" == 'some-catalog'
+              test "${org}" == 'fail-catalog'
               test "${repo}" == 'some-service-catalog'
               test "${revision}" == 'development'
               test "${pathinrepo}" == 'pipelines/rh-advisories/rh-advisories.yaml'
-              test "${sha}" == '12345'
+              test "${sha}" == 'unknown'
 
   finally:
     - name: cleanup

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-sha.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-sha.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-data-print-pipeline-ref
+  name: test-collect-data-print-pipeline-ref-sha
 spec:
   description: |
-    Run the collect-data task with a non SHA taskGitRevision and verify that the pipeline ref
-    info is resolved via the GitHub API fallback
+    Run the collect-data task and verify that when taskGitRevision is already a SHA,
+    it is used directly without calling the GitHub API
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -154,7 +154,7 @@ spec:
         - name: taskGitUrl
           value: "http://localhost"
         - name: taskGitRevision
-          value: "main"
+          value: "abcdef1234567890abcdef1234567890abcdef12"
       runAfter:
         - setup
     - name: check-result
@@ -211,8 +211,10 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                echo Error: curl-with-retry was expected to be called 1 time. Actual calls:
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              touch "$(params.dataDir)/mock_curl.txt"
+              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 0 ]; then
+                echo Error: curl-with-retry was expected to be called 0 times. Actual calls:
                 cat "$(params.dataDir)/mock_curl.txt"
                 exit 1
               fi
@@ -227,7 +229,7 @@ spec:
               test "${repo}" == 'some-service-catalog'
               test "${revision}" == 'development'
               test "${pathinrepo}" == 'pipelines/rh-advisories/rh-advisories.yaml'
-              test "${sha}" == '12345'
+              test "${sha}" == 'abcdef1234567890abcdef1234567890abcdef12'
 
   finally:
     - name: cleanup


### PR DESCRIPTION

## Describe your changes
The operator already resolves the pipeline ref revision to a SHA via ResolveBranchToSHA and passes it as taskGitRevision. Use that directly instead of calling the GitHub API. Fail back to curl-with-retry if taskGitRevision is not a SHA. The curl will not fail the task since it is only metadata.

## Relevant Jira
https://redhat.atlassian.net/browse/KFLUXSPRT-8173
https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1781612224952519?thread_ts=1781610891.776909&cid=C04PZ7H0VA8
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
