### PR TITLE
fix(HUM-2609): remove oversized task results from filter-already-released-advisory-rpms

### DIFF
--- a/tasks/internal/filter-already-released-advisory-rpms-task/filter-already-released-advisory-rpms-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/filter-already-released-advisory-rpms-task.yaml
@@ -52,10 +52,6 @@ spec:
       description: The name of the InternalRequest TaskRun
     - name: filter_results_artifact
       description: OCI artifact reference containing filter results (unreleased_rpms, in_advisory_rpms JSON files)
-    - name: unreleased_rpms
-      description: RPMs not found in any advisory (gzipped base64 JSON array)
-    - name: in_advisory_rpms
-      description: RPMs found in advisories, need digest validation (gzipped base64 JSON array)
     - name: advisory_url
       description: URL of the latest matching advisory when all components are already released
     - name: advisory_internal_url
@@ -215,9 +211,6 @@ spec:
           ARTIFACT_REF=$(push_results_to_oci "$RESULTS_DIR")
           echo "Filter results artifact: ${ARTIFACT_REF}"
           echo -n "${ARTIFACT_REF}" > "$(results.filter_results_artifact.path)"
-          jq -c '.' "$RESULTS_DIR/unreleased_rpms.json" | gzip -c | base64 -w 0 \
-            > "$(results.unreleased_rpms.path)"
-          echo -n "[]" | gzip -c | base64 -w 0 > "$(results.in_advisory_rpms.path)"
           echo -n "" > "$(results.advisory_url.path)"
           echo -n "" > "$(results.advisory_internal_url.path)"
           echo -n "Success" > "$(results.result.path)"
@@ -308,8 +301,6 @@ spec:
         ARTIFACT_REF=$(push_results_to_oci "$RESULTS_DIR")
         echo "Filter results artifact: ${ARTIFACT_REF}"
         echo -n "${ARTIFACT_REF}" > "$(results.filter_results_artifact.path)"
-        jq -c '.' "$UNRELEASED_FILE" | gzip -c | base64 -w 0 > "$(results.unreleased_rpms.path)"
-        jq -c '.' "$IN_ADVISORY_FILE" | gzip -c | base64 -w 0 > "$(results.in_advisory_rpms.path)"
 
         # Set advisory URL only if ALL RPMs are in advisories AND they all came from the SAME SINGLE advisory
         if [[ "$UNRELEASED_COUNT" -eq 0 ]] && [[ "$ADVISORY_SET_COUNT" -eq 1 ]]; then

--- a/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-all-released.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-all-released.yaml
@@ -49,10 +49,6 @@ spec:
           value: "$(tasks.run-filter-task.results.result)"
         - name: filter_results_artifact
           value: "$(tasks.run-filter-task.results.filter_results_artifact)"
-        - name: unreleased_rpms
-          value: "$(tasks.run-filter-task.results.unreleased_rpms)"
-        - name: in_advisory_rpms
-          value: "$(tasks.run-filter-task.results.in_advisory_rpms)"
         - name: advisory_url
           value: "$(tasks.run-filter-task.results.advisory_url)"
       taskSpec:
@@ -60,10 +56,6 @@ spec:
           - name: result
             type: string
           - name: filter_results_artifact
-            type: string
-          - name: unreleased_rpms
-            type: string
-          - name: in_advisory_rpms
             type: string
           - name: advisory_url
             type: string
@@ -87,25 +79,6 @@ spec:
                 exit 1
               fi
               echo "Filter results artifact: $ARTIFACT"
-
-              UNRELEASED=$(base64 -d <<< "$(params.unreleased_rpms)" | gunzip)
-              IN_ADVISORY=$(base64 -d <<< "$(params.in_advisory_rpms)" | gunzip)
-
-              echo "Unreleased RPMs: $UNRELEASED"
-              echo "In-advisory RPMs: $IN_ADVISORY"
-
-              UNRELEASED_COUNT=$(jq 'length' <<< "$UNRELEASED")
-              IN_ADVISORY_COUNT=$(jq 'length' <<< "$IN_ADVISORY")
-
-              if [[ "$UNRELEASED_COUNT" -ne 0 ]]; then
-                echo "Expected 0 unreleased RPMs, but found $UNRELEASED_COUNT"
-                exit 1
-              fi
-
-              if [[ "$IN_ADVISORY_COUNT" -ne 2 ]]; then
-                echo "Expected 2 in-advisory RPMs, but found $IN_ADVISORY_COUNT"
-                exit 1
-              fi
 
               ADVISORY_URL="$(params.advisory_url)"
               if [[ -z "$ADVISORY_URL" ]]; then

--- a/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-no-advisories.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-no-advisories.yaml
@@ -48,19 +48,11 @@ spec:
           value: "$(tasks.run-filter-task.results.result)"
         - name: filter_results_artifact
           value: "$(tasks.run-filter-task.results.filter_results_artifact)"
-        - name: unreleased_rpms
-          value: "$(tasks.run-filter-task.results.unreleased_rpms)"
-        - name: in_advisory_rpms
-          value: "$(tasks.run-filter-task.results.in_advisory_rpms)"
       taskSpec:
         params:
           - name: result
             type: string
           - name: filter_results_artifact
-            type: string
-          - name: unreleased_rpms
-            type: string
-          - name: in_advisory_rpms
             type: string
         steps:
           - name: validate
@@ -82,24 +74,5 @@ spec:
                 exit 1
               fi
               echo "Filter results artifact: $ARTIFACT"
-
-              UNRELEASED=$(base64 -d <<< "$(params.unreleased_rpms)" | gunzip)
-              IN_ADVISORY=$(base64 -d <<< "$(params.in_advisory_rpms)" | gunzip)
-
-              echo "Unreleased RPMs: $UNRELEASED"
-              echo "In-advisory RPMs: $IN_ADVISORY"
-
-              UNRELEASED_COUNT=$(jq 'length' <<< "$UNRELEASED")
-              IN_ADVISORY_COUNT=$(jq 'length' <<< "$IN_ADVISORY")
-
-              if [[ "$UNRELEASED_COUNT" -ne 1 ]]; then
-                echo "Expected 1 unreleased RPM, but found $UNRELEASED_COUNT"
-                exit 1
-              fi
-
-              if [[ "$IN_ADVISORY_COUNT" -ne 0 ]]; then
-                echo "Expected 0 in-advisory RPMs, but found $IN_ADVISORY_COUNT"
-                exit 1
-              fi
 
               echo "Validation successful!"

--- a/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-partial-release.yaml
+++ b/tasks/internal/filter-already-released-advisory-rpms-task/tests/test-filter-partial-release.yaml
@@ -49,19 +49,11 @@ spec:
           value: "$(tasks.run-filter-task.results.result)"
         - name: filter_results_artifact
           value: "$(tasks.run-filter-task.results.filter_results_artifact)"
-        - name: unreleased_rpms
-          value: "$(tasks.run-filter-task.results.unreleased_rpms)"
-        - name: in_advisory_rpms
-          value: "$(tasks.run-filter-task.results.in_advisory_rpms)"
       taskSpec:
         params:
           - name: result
             type: string
           - name: filter_results_artifact
-            type: string
-          - name: unreleased_rpms
-            type: string
-          - name: in_advisory_rpms
             type: string
         steps:
           - name: validate
@@ -83,38 +75,5 @@ spec:
                 exit 1
               fi
               echo "Filter results artifact: $ARTIFACT"
-
-              UNRELEASED=$(base64 -d <<< "$(params.unreleased_rpms)" | gunzip)
-              IN_ADVISORY=$(base64 -d <<< "$(params.in_advisory_rpms)" | gunzip)
-
-              echo "Unreleased RPMs: $UNRELEASED"
-              echo "In-advisory RPMs: $IN_ADVISORY"
-
-              UNRELEASED_COUNT=$(jq 'length' <<< "$UNRELEASED")
-              IN_ADVISORY_COUNT=$(jq 'length' <<< "$IN_ADVISORY")
-
-              if [[ "$UNRELEASED_COUNT" -ne 1 ]]; then
-                echo "Expected 1 unreleased RPM, but found $UNRELEASED_COUNT"
-                exit 1
-              fi
-
-              if [[ "$IN_ADVISORY_COUNT" -ne 1 ]]; then
-                echo "Expected 1 in-advisory RPM, but found $IN_ADVISORY_COUNT"
-                exit 1
-              fi
-
-              # Verify the unreleased one is new-comp
-              UNRELEASED_NAME=$(jq -r '.[0].name' <<< "$UNRELEASED")
-              if [[ "$UNRELEASED_NAME" != "new-comp" ]]; then
-                echo "Expected unreleased to be 'new-comp' but got '$UNRELEASED_NAME'"
-                exit 1
-              fi
-
-              # Verify the in-advisory one is released-comp
-              IN_ADV_NAME=$(jq -r '.[0].name' <<< "$IN_ADVISORY")
-              if [[ "$IN_ADV_NAME" != "released-comp" ]]; then
-                echo "Expected in-advisory to be 'released-comp' but got '$IN_ADV_NAME'"
-                exit 1
-              fi
 
               echo "Validation successful!"


### PR DESCRIPTION
## Summary
- Remove `unreleased_rpms` and `in_advisory_rpms` results from the internal `filter-already-released-advisory-rpms-task` to fix Tekton's 4096-byte termination message limit being exceeded when the RPM list is large
- The same data is already passed via the OCI artifact (`filter_results_artifact`) which the managed task consumes
- Update unit tests to remove references to the removed results

## Jira
https://redhat.atlassian.net/browse/HUM-2609

## Test plan
- [ ] Unit tests pass for `tasks/internal/filter-already-released-advisory-rpms-task`

🤖 Generated with [Claude Code](https://claude.com/claude-code)