### PR TITLE
fix(RELEASE-2679): support binary staged.files in release notes

### DIFF
--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -306,7 +306,7 @@ spec:
           value: |
             [
               {"systemName": "cdn", "dynamic": false},
-              {"systemName": "contentGateway", "dynamic": false},
+              {"systemName": "contentGateway", "dynamic": true},
               {"systemName": "intention", "dynamic": false},
               {"systemName": "releaseNotes", "dynamic": false}
             ]

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -321,9 +321,13 @@ spec:
                     continue
                   fi
                 else
-                  # Binary/generic files have arch/os matching
+                  # Binary/generic files have arch/os matching, falling back to staged.files
+                  # for teams that use the CDN staged structure instead of a top-level files array
                   FILENAME=$(jq -r --arg arch "$ARCH" --arg os "$OS" \
-                    '.files[] | select(.arch == $arch and .os == $os) | .source' <<< "$component")
+                    '((.files // []) as $f
+                       | if ($f|length) > 0 then $f else (.staged.files // []) end)[]
+                       | select(.arch == $arch and .os == $os) | .source' \
+                    <<< "$component")
                 fi
 
                 FILENAME_BASENAME=$(basename "$FILENAME")

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-binary-staged-files.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-binary-staged-files.yaml
@@ -1,0 +1,325 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-advisory-update-purl-binary-staged-files
+spec:
+  description: |
+    Assert that the update-purl step correctly resolves filenames and constructs PURLs for
+    binary components that use staged.files (no top-level .files array, no contentGateway).
+    These components push only to the customer portal / Pulp, so the PURL download_url should
+    use the CDN base URL rather than the developer portal URL.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+          - name: checksum_map
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: create-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -euxo pipefail
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" << EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["odf"],
+                  "policy": "policy",
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {"name": "url", "value": "github.com"},
+                        {"name": "revision", "value": "main"},
+                        {"name": "pathInRepo", "value": "pipeline.yaml"}
+                      ]
+                    },
+                    "serviceAccountName": "sa"
+                  },
+                  "origin": "rhodf-tenant"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << EOF
+              {
+                "application": "odf",
+                "components": [
+                  {
+                    "name": "odf-cli",
+                    "repository": "quay.io/redhat-prod/odf4----odf-cli-rhel9"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "cdn": {
+                  "env": "production"
+                },
+                "intention": "production",
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "odf-cli",
+                      "contentType": "binary",
+                      "staged": {
+                        "destination": "rh-odf-4-for-rhel-9-x86_64-files",
+                        "version": "4.21",
+                        "files": [
+                          {
+                            "source": "/releases/odf-cli-linux-amd64.tar.gz",
+                            "filename": "odf-cli-4.21-linux-amd64.tar.gz",
+                            "arch": "amd64",
+                            "os": "linux"
+                          },
+                          {
+                            "source": "/releases/odf-cli-windows-amd64.zip",
+                            "filename": "odf-cli-4.21-windows-amd64.zip",
+                            "arch": "amd64",
+                            "os": "windows"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "releaseNotes": {
+                  "product_id": [547],
+                  "product_name": "Red Hat OpenShift Data Foundation",
+                  "product_version": "4.21",
+                  "synopsis": "ODF 4.21 CLI update",
+                  "topic": "ODF 4.21 CLI update",
+                  "description": "ODF 4.21 CLI update",
+                  "solution": "Update your CLI.",
+                  "content": {
+                    "artifacts": [
+                      {
+                        "architecture": "amd64",
+                        "os": "linux",
+                        "component": "odf-cli",
+                        "purl": "placeholder"
+                      },
+                      {
+                        "architecture": "amd64",
+                        "os": "windows",
+                        "component": "odf-cli",
+                        "purl": "placeholder"
+                      }
+                    ]
+                  }
+                },
+                "sign": {
+                  "configMapName": "cm"
+                }
+              }
+              EOF
+
+              # Create checksum_map mock — keys are the source basenames
+              jq -nc '[
+                {
+                  "component": "odf-cli",
+                  "files": {
+                    "odf-cli-linux-amd64.tar.gz":
+                      "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222",
+                    "odf-cli-windows-amd64.zip":
+                      "sha256:1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff1111aaaa2222bbbb"
+                  }
+                }
+              ]' > "$(params.dataDir)/mock_checksum_map.json"
+              echo -n "mock-registry/checksum-map@sha256:mock" | tee "$(results.checksum_map.path)"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: create-advisory
+      params:
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: environment
+          value: production
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: checksum_map
+          value: "$(tasks.setup.results.checksum_map)"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -exo pipefail
+
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+              if [ "$requestsCount" -ne 1 ]; then
+                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+                exit 1
+              fi
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              if [[ "$(echo "$internalRequest" | jq -r '.spec.pipeline.pipelineRef.params[2].value')" != \
+              "pipelines/internal/create-advisory"* ]]; then
+                echo "InternalRequest doesn't reference 'create-advisory' pipeline"
+                exit 1
+              fi
+
+              advisoryJson=$(echo "$internalRequest" | jq -r '.spec.params.advisory_json' | base64 -d | gunzip -c)
+              artifacts=$(echo "$advisoryJson" | jq -c '.content.artifacts')
+
+              artifactCount=$(echo "$artifacts" | jq 'length')
+              if [ "$artifactCount" -ne 2 ]; then
+                echo "Expected 2 artifacts, found $artifactCount"
+                echo "$artifacts" | jq
+                exit 1
+              fi
+
+              # No contentGateway → download_url must use the CDN (customer portal) base URL
+              expectedLinuxPurl="pkg:generic/odf-cli@4.21?filename=odf-cli-linux-amd64.tar.gz&checksum=sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222&download_url=https://access.redhat.com/downloads"
+              expectedWindowsPurl="pkg:generic/odf-cli@4.21?filename=odf-cli-windows-amd64.zip&checksum=sha256:1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff1111aaaa2222bbbb&download_url=https://access.redhat.com/downloads"
+
+              linuxPurl=$(echo "$artifacts" | jq -r '.[] | select(.os == "linux") | .purl')
+              windowsPurl=$(echo "$artifacts" | jq -r '.[] | select(.os == "windows") | .purl')
+
+              if [ "$linuxPurl" != "$expectedLinuxPurl" ]; then
+                echo "Unexpected PURL for linux artifact"
+                echo "  expected: $expectedLinuxPurl"
+                echo "  got:      $linuxPurl"
+                exit 1
+              fi
+
+              if [ "$windowsPurl" != "$expectedWindowsPurl" ]; then
+                echo "Unexpected PURL for windows artifact"
+                echo "  expected: $expectedWindowsPurl"
+                echo "  got:      $windowsPurl"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -euxo pipefail
+
+              kubectl delete internalrequests --all

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -500,18 +500,20 @@ spec:
             done
 
             if [ "$content_type" = "binary" ]; then
-                # Get the number of files for this component (binaries use files structure)
+                # Get the number of files for this component (binaries use files structure,
+                # falling back to staged.files for teams that use the CDN staged structure)
                 FILES_LENGTH=$(jq --arg name "$name" \
                   '[.mapping.components[]
                     | select(.name == $name)
-                    | .files
+                    | ((.files // []) as $f | if ($f|length) > 0 then $f else (.staged.files // []) end)
                     | length][0]' "$DATA_FILE")
 
                 for ((k = 0; k < FILES_LENGTH; k++)); do
                     file=$(jq -c --arg name "$name" --argjson k "$k" \
                         '.mapping.components[]
                           | select(.name == $name)
-                          | .files[$k]' "$DATA_FILE")
+                          | ((.files // []) as $f
+                             | if ($f|length) > 0 then $f else (.staged.files // []) end)[$k]' "$DATA_FILE")
                     arch=$(jq -r '.arch' <<< "$file")
                     os=$(jq -r '.os' <<< "$file")
 

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-binary-staged-files.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-binary-staged-files.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-binary-staged-files
+spec:
+  description: |
+    Run the populate-release-notes task with a binary component that has its files nested under
+    staged.files (no top-level .files array, no contentGateway). This covers teams that push only
+    to the customer portal / Pulp and must use the staged structure for destination routing.
+    Asserts that releaseNotes.content.artifacts is populated correctly for each staged file.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -euxo pipefail
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "components": [
+                    {
+                      "name": "odf-cli",
+                      "contentType": "binary",
+                      "staged": {
+                        "destination": "rh-odf-4-for-rhel-9-x86_64-files",
+                        "version": "4.21",
+                        "files": [
+                          {
+                            "source": "/releases/odf-cli-linux-amd64.tar.gz",
+                            "filename": "odf-cli-4.21-linux-amd64.tar.gz",
+                            "arch": "amd64",
+                            "os": "linux"
+                          },
+                          {
+                            "source": "/releases/odf-cli-darwin-amd64.tar.gz",
+                            "filename": "odf-cli-4.21-darwin-amd64.tar.gz",
+                            "arch": "amd64",
+                            "os": "darwin"
+                          },
+                          {
+                            "source": "/releases/odf-cli-windows-amd64.zip",
+                            "filename": "odf-cli-4.21-windows-amd64.zip",
+                            "arch": "amd64",
+                            "os": "windows"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "releaseNotes": {
+                  "product_id": [547],
+                  "product_name": "Red Hat OpenShift Data Foundation",
+                  "product_version": "4.21",
+                  "cpe": "cpe:/a:redhat:openshift_data_foundation:4.21::el9",
+                  "synopsis": "ODF 4.21 CLI binaries update",
+                  "topic": "ODF 4.21 CLI binaries update",
+                  "description": "ODF 4.21 CLI binaries update",
+                  "solution": "Update your CLI.",
+                  "issues": {
+                    "fixed": []
+                  }
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "odf",
+                "components": [
+                  {
+                    "name": "odf-cli",
+                    "containerImage": "registry.io/image@sha256:abc123"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -euxo pipefail
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+
+              # releaseNotes.content.artifacts must exist with one entry per staged file
+              artifactCount=$(jq '.releaseNotes.content.artifacts | length' "$DATA_FILE")
+              if [ "$artifactCount" -ne 3 ]; then
+                echo "Expected 3 artifacts, got $artifactCount"
+                jq '.releaseNotes.content.artifacts' "$DATA_FILE"
+                exit 1
+              fi
+
+              # Each entry must have architecture, os, component, and a placeholder purl
+              for i in 0 1 2; do
+                test "$(jq -e --argjson i "$i" \
+                  '.releaseNotes.content.artifacts[$i] | has("architecture")' "$DATA_FILE")" == "true"
+                test "$(jq -e --argjson i "$i" \
+                  '.releaseNotes.content.artifacts[$i] | has("os")' "$DATA_FILE")" == "true"
+                test "$(jq -r --argjson i "$i" \
+                  '.releaseNotes.content.artifacts[$i].component' "$DATA_FILE")" == "odf-cli"
+                test "$(jq -r --argjson i "$i" \
+                  '.releaseNotes.content.artifacts[$i].purl' "$DATA_FILE")" == "placeholder"
+              done
+
+              # Verify all three expected arch/os combinations are present
+              linuxCount=$(jq '[.releaseNotes.content.artifacts[]
+                | select(.architecture == "amd64" and .os == "linux")] | length' "$DATA_FILE")
+              darwinCount=$(jq '[.releaseNotes.content.artifacts[]
+                | select(.architecture == "amd64" and .os == "darwin")] | length' "$DATA_FILE")
+              windowsCount=$(jq '[.releaseNotes.content.artifacts[]
+                | select(.architecture == "amd64" and .os == "windows")] | length' "$DATA_FILE")
+
+              test "$linuxCount" -eq 1
+              test "$darwinCount" -eq 1
+              test "$windowsCount" -eq 1
+      runAfter:
+        - run-task


### PR DESCRIPTION
Binary components that push only to the customer portal must nest their files under staged.files to drive Pulp destination routing. The binary code path in populate-release-notes only looked at .files directly on the component, so FILES_LENGTH evaluated to 0 and releaseNotes.content was never written, causing check-data-keys to fail schema validation.

The binary path in create-advisory had the same gap when resolving filenames for PURL construction.

Both tasks now fall back to staged.files when .files is absent. Existing behaviour for components with a top-level .files array is unchanged.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
