### PR TITLE
feat(ISV-7220): switch pipelines to rh-direct-sign-image

### DIFF
--- a/integration-tests/rh-advisories-idempotent/README.md
+++ b/integration-tests/rh-advisories-idempotent/README.md
@@ -57,7 +57,7 @@ This test validates idempotent re-release behavior for the `rh-advisories` pipel
 ## Acceptance Criteria
 
 - Second release: all major tasks (`create-advisory`, `push-snapshot`, `verify-conforma`,
-  `rh-sign-image`, etc.) appear in `skippedTasks`
+  `rh-direct-sign-image`, etc.) appear in `skippedTasks`
 - `advisory.url` present in second release `status.artifacts` (written by
   `update-cr-status-skipped` from filter result, not `create-advisory`)
 

--- a/integration-tests/rh-advisories-idempotent/test.sh
+++ b/integration-tests/rh-advisories-idempotent/test.sh
@@ -276,7 +276,7 @@ verify_release_contents() {
         "populate-release-notes"
         "embargo-check"
         "set-advisory-severity"
-        "rh-sign-image"
+        "rh-direct-sign-image"
         "rh-sign-image-cosign"
         "push-snapshot"
         "create-pyxis-image"

--- a/integration-tests/rh-advisories-large-snapshot/README.md
+++ b/integration-tests/rh-advisories-large-snapshot/README.md
@@ -122,7 +122,7 @@ The `test-report` finally task always runs and actively diagnoses failures:
 
 - **Pre-pipeline failures** (e.g. `generate-large-snapshot.sh` errors): the
   failed component, step, command, and exit code are shown.
-- **Managed pipeline failures** (e.g. `apply-mapping`, `rh-sign-image`): the
+- **Managed pipeline failures** (e.g. `apply-mapping`, `rh-direct-sign-image`): the
   `test-report` task queries the cluster directly and shows the failed task
   name, TaskRun name, Tekton condition message, and — if the pod has not yet
   been garbage-collected — the last matching error lines from the pod log

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -593,8 +593,8 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - rh-sign-image
-    - name: rh-sign-image
+        - rh-direct-sign-image
+    - name: rh-direct-sign-image
       timeout: "6h00m0s"
       when:
         - input: "$(tasks.filter-already-released-advisory-images.results.skip_release)"
@@ -609,19 +609,15 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/managed/rh-sign-image/rh-sign-image.yaml
+            value: tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
       params:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
-        - name: releasePlanAdmissionPath
-          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: requestTimeout
-          # The RADAS timeout when it fails to receive a response is 5 mins.
-          # Give RADAS enough time to retry its request.
           value: 1800
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
@@ -1052,7 +1048,7 @@ spec:
         - embargo-check
         - push-rpm-data-to-pyxis
         - run-file-updates
-        - rh-sign-image
+        - rh-direct-sign-image
         - rh-sign-image-cosign
         - set-advisory-severity
     - name: close-advisory-issues

--- a/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
@@ -424,8 +424,8 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - rh-sign-image
-    - name: rh-sign-image
+        - rh-direct-sign-image
+    - name: rh-direct-sign-image
       timeout: "6h00m0s"
       retries: 3
       taskRef:
@@ -436,19 +436,15 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/managed/rh-sign-image/rh-sign-image.yaml
+            value: tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
       params:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
-        - name: releasePlanAdmissionPath
-          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: requestTimeout
-          # The RADAS timeout when it fails to receive a response is 5 mins.
-          # Give RADAS enough time to retry its request.
           value: 1800
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -395,8 +395,8 @@ spec:
         - name: taskGitRevision
           value: "$(params.taskGitRevision)"
       runAfter:
-        - rh-sign-image
-    - name: rh-sign-image
+        - rh-direct-sign-image
+    - name: rh-direct-sign-image
       timeout: "6h00m0s"
       retries: 3
       taskRef:
@@ -407,19 +407,15 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/managed/rh-sign-image/rh-sign-image.yaml
+            value: tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
       params:
         - name: snapshotPath
           value: "$(tasks.collect-data.results.snapshotSpec)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
-        - name: releasePlanAdmissionPath
-          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: requestTimeout
-          # The RADAS timeout when it fails to receive a response is 5 mins.
-          # Give RADAS enough time to retry its request.
           value: 1800
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)

--- a/tasks/managed/publish-pyxis-repository/README.md
+++ b/tasks/managed/publish-pyxis-repository/README.md
@@ -21,7 +21,7 @@ requires_terms=true), one repository string per line, e.g. "rhtas/cosign-rhel9".
 Only standard (non-flatpak) repositories are included; flatpak repos are never added.
 
 Note: This task runs quite early on in the pipeline, because we need the result it produces
-for the signing tasks (and `rh-sign-image` runs quite early to begin with). So this means
+for the signing tasks (and `rh-direct-sign-image` runs quite early to begin with). So this means
 that if you're releasing to a repo for the first time, the repository might get published
 even before the actual image is pushed and published. But we checked with RHEC team and this
 shouldn't cause any problems, because RHEC will ignore repos with no published images.

--- a/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
+++ b/tasks/managed/publish-pyxis-repository/publish-pyxis-repository.yaml
@@ -29,7 +29,7 @@ spec:
     Only standard (non-flatpak) repositories are included; flatpak repos are never added.
 
     Note: This task runs quite early on in the pipeline, because we need the result it produces
-    for the signing tasks (and `rh-sign-image` runs quite early to begin with). So this means
+    for the signing tasks (and `rh-direct-sign-image` runs quite early to begin with). So this means
     that if you're releasing to a repo for the first time, the repository might get published
     even before the actual image is pushed and published. But we checked with RHEC team and this
     shouldn't cause any problems, because RHEC will ignore repos with no published images.


### PR DESCRIPTION
Replaces rh-sign-image with rh-direct-sign-image across the three managed release pipelines:

  - rh-advisories
  - rh-push-to-registry-redhat-io
  - rh-push-helm-chart-to-registry-redhat-io

  The new task calls the signing script directly as a command (it is now on PATH) instead of going through RADAS. The releasePlanAdmissionPath parameter, which
   is not used by rh-direct-sign-image, has been removed from all three pipeline task invocations.

  References in integration test assertions, READMEs, and task description prose have been updated to match the new task name.

  This PR depends on ISV-7115 which introduces the rh-direct-sign-image task.

  JIRA: ISV-7220, ISV-7219

  Test plan

  - rh-advisories-large-snapshot integration test passes with rh-direct-sign-image
  - rh-advisories-idempotent integration test: second release correctly skips rh-direct-sign-image
  - rh-push-to-registry-redhat-io pipeline signs images successfully
  - rh-push-helm-chart-to-registry-redhat-io pipeline signs images successfully

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
