### PR TITLE
feat(RELEASE-2466): replace Jira script with automation webhook

### DIFF
--- a/.github/scripts/promote_branch.sh
+++ b/.github/scripts/promote_branch.sh
@@ -263,10 +263,14 @@ add_to_parsed_tickets_json() {
         pr_url="$pr_url_input"
     fi
 
-    # Append the ticket and PR URL (if present) to the parsed JSON
-    PARSED_TICKETS_JSON="$(jq --arg ticket "$ticket" --arg pr_url "$pr_url" \
-        '. += [ {"ticket": $ticket} + (if $pr_url != "" then {"pr_url": $pr_url} else {} end) ]' \
-        <<<"$PARSED_TICKETS_JSON")"
+    # Upsert: if ticket exists, append PR to its prs array; otherwise add new entry
+    PARSED_TICKETS_JSON="$(jq --arg ticket "${ticket}" --arg pr_url "${pr_url}" '
+        if any(.[]; .ticket == $ticket) then
+            map(if .ticket == $ticket and $pr_url != "" then .prs = ((.prs + [$pr_url]) | unique) else . end)
+        else
+            . + [{ticket: $ticket, prs: (if $pr_url != "" then [$pr_url] else [] end)}]
+        end
+    ' <<<"${PARSED_TICKETS_JSON}")"
 }
 
 if [ -z "${PROMOTION_TYPE}" ]; then

--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -200,14 +200,48 @@ jobs:
         if: |
           steps.promote.outcome == 'success' && 
           inputs.update-jira-tickets == true &&
+          inputs.dry-run == false &&
           steps.promote.outputs.parsed_tickets_file != ''
-        uses: konflux-ci/release-service-automations/jira-ci@87615e00a3a699a7cc473ed93d3203624e3b86f0  # main
-        with:
-          jira_url: "https://redhat.atlassian.net"
-          promotion_type: ${{ inputs.promotion-type }}
-          metadata_file: ${{ steps.promote.outputs.parsed_tickets_file }}
-          jira_token: ${{ secrets.JIRA_TOKEN }}
-          dry_run: ${{ inputs.dry-run }}
+        env:
+          JIRA_WEBHOOK_URL: ${{ secrets.JIRA_AUTOMATION_WEBHOOK_URL }}
+          JIRA_WEBHOOK_TOKEN: ${{ secrets.JIRA_AUTOMATION_WEBHOOK_TOKEN }}
+          PARSED_TICKETS_FILE: ${{ steps.promote.outputs.parsed_tickets_file }}
+          PROMOTION_TYPE: ${{ inputs.promotion-type }}
+        run: |
+          SOURCE="${PROMOTION_TYPE%-to-*}"
+          ENVIRONMENT="${PROMOTION_TYPE#*-to-}"
+
+          PAYLOAD=$(jq --arg env "${ENVIRONMENT}" --arg src "${SOURCE}" \
+            '{tickets: ., environment: $env, source: $src}' "${PARSED_TICKETS_FILE}")
+
+          TICKET_COUNT="$(jq '.tickets | length' <<< "${PAYLOAD}")"
+          if [ "${TICKET_COUNT}" -eq 0 ]; then
+            echo "No tickets to update, skipping webhook call"
+            exit 0
+          fi
+
+          echo "Calling Jira Automation webhook for ${SOURCE} -> ${ENVIRONMENT}"
+          echo "Tickets: $(jq -r '.[].ticket' "${PARSED_TICKETS_FILE}" | tr '\n' ' ')"
+
+          set +e
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            --retry 3 --max-time 30 \
+            -X POST "${JIRA_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            -H "X-Automation-Webhook-Token: ${JIRA_WEBHOOK_TOKEN}" \
+            -d "${PAYLOAD}")
+          CURL_RC=$?
+          set -e
+
+          if [ "${CURL_RC}" -ne 0 ]; then
+            echo "WARNING: curl failed with exit code ${CURL_RC}"
+            echo "Promotion was successful but Jira update may have failed."
+          elif [ "${HTTP_CODE}" -eq 200 ]; then
+            echo "Jira Automation webhook called successfully (HTTP ${HTTP_CODE})"
+          else
+            echo "WARNING: Jira Automation webhook returned HTTP ${HTTP_CODE}"
+            echo "Promotion was successful but Jira update may have failed."
+          fi
           
       - name: Set up Python
         if: |


### PR DESCRIPTION
## Describe your changes
The jira_ci.py script no longer works after the Jira migration. Replace it with a call to a Jira Automation webhook that handles ticket updates (label swaps,
comments, transitions) via an automation rule.

The parsed tickets payload format has changed to group PRs by ticket, as Jira Automation's smart values cannot correlate individual entries back to the current issue being processed.

Requires JIRA_AUTOMATION_WEBHOOK_URL and
JIRA_AUTOMATION_WEBHOOK_TOKEN repository secrets.
## Relevant Jira
https://redhat.atlassian.net/browse/RELEASE-2466
## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
