### PR TITLE
fix(RELEASE-12379): fix FBC manifest unknown via TARGET inspection 

### DIFF
--- a/integration-tests/fbc-release/test.sh
+++ b/integration-tests/fbc-release/test.sh
@@ -537,19 +537,13 @@ verify_multi_component_release() {
             return $failures
         fi
 
-        # we can't reach the image in registry-proxy, so we need to resolve it to quay.io
-        # a conditional is not necessary because the test optin index image is only
-        # available in quay.io/redhat/redhat----preview-operator-index.
-        image_sha="${index_image_resolved#*@}"
-        index_image="quay.io/redhat/redhat----preview-operator-index@${image_sha}"
-
         # generate the authentication config for skopeo
         managed_secrets_yaml="${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
         registry_authenticate $managed_secrets_yaml "konflux-fbc-preview-"
 
         # making sure the produced indexes versions matches with the requested ones
         index_build_version="$(skopeo \
-            inspect "docker://${index_image}" | jq -r '.Env[] | select(test("BUILD_VERSION.*")) | split("=")[1]')"
+            inspect "docker://${target_index}" | jq -r '.Env[] | select(test("BUILD_VERSION.*")) | split("=")[1]')"
         if [[ "${index_build_version}" =~ ^${ocp_version} ]]; then
             echo "✅️ Opt-in index-image's BUILD_VERSION matches the required OCP_VERSION ($ocp_version)"
         else

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -523,8 +523,6 @@ spec:
           value: "$(tasks.collect-data.results.data)"
         - name: internalRequestResultsFile
           value: $(tasks.add-fbc-contribution-to-index-image.results.internalRequestResultsFile)
-        - name: buildTimestamp
-          value: $(tasks.add-fbc-contribution-to-index-image.results.buildTimestamp)
         - name: retries
           value: "3"
         - name: pipelineRunUid
@@ -559,8 +557,6 @@ spec:
           - name: pathInRepo
             value: tasks/managed/collect-index-images/collect-index-images.yaml
       params:
-        - name: buildTimestamp
-          value: $(tasks.add-fbc-contribution-to-index-image.results.buildTimestamp)
         - name: internalRequestResultsFile
           value: $(tasks.add-fbc-contribution-to-index-image.results.internalRequestResultsFile)
         - name: ociStorage
@@ -622,8 +618,8 @@ spec:
           values: ["true"]
       runAfter:
         - collect-task-params
-        - collect-index-images
         - publish-index-image
+        - collect-index-images
     - name: update-cr-status
       params:
         - name: resource

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -113,6 +113,7 @@ spec:
 
         echo "Getting target image digest: $(params.targetIndex)"
         if TARGET_DIGEST=$(skopeo inspect \
+            --creds "${TARGET_INDEX_CREDENTIAL}" \
             "docker://$(params.targetIndex)" \
             --format '{{.Digest}}' \
             --retry-times "$(params.retries)"); then
@@ -120,7 +121,8 @@ spec:
             echo "DEBUG: Source Digest - $SOURCE_DIGEST"
             echo "DEBUG: Target Digest - $TARGET_DIGEST"
             if [ "$SOURCE_DIGEST" == "$TARGET_DIGEST" ]; then
-                echo "Image already exists with the same digest, skipping copy." | tee "$(results.requestMessage.path)"
+                echo -n "Image already exists with the same digest, skipping copy." \
+                  | tee "$(results.requestMessage.path)"
                 exit 0
             else
                 echo "Image exists in target registry but digests do not match." \
@@ -134,7 +136,7 @@ spec:
         targetOcpVersion="$(params.targetOcpVersion)"
         sourceVer=$(getIndexVersion "${SOURCE_AUTH_ARGS[@]}" "docker://$(params.sourceIndex)")
         if [[ "${sourceVer}" != "${targetOcpVersion}" ]]; then
-            echo -n "The source index does not match its targetOcpVersion ($sourceVer != $targetOcpVersion)" \
+            echo -n "Error: source index does not match targetOcpVersion (${sourceVer} != ${targetOcpVersion})" \
               | tee "$(results.requestMessage.path)"
             exit 0
         fi
@@ -145,7 +147,7 @@ spec:
             targetVer=$(getIndexVersion "${TARGET_AUTH_ARGS[@]}" "docker://$(params.targetIndex)")
             # check if both indexes are of the same OCP version and exit in case they mismatch.
             if [ "${sourceVer}" != "${targetVer}" ]; then
-              echo -n "The indexes versions does not match ($sourceVer != $targetVer)" \
+              echo -n "Error: The indexes versions does not match (${sourceVer} != ${targetVer})" \
               | tee "$(results.requestMessage.path)"
               exit 0
             fi

--- a/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail-mismatch-ver.yaml
+++ b/tasks/internal/publish-index-image-task/tests/test-publish-index-image-fail-mismatch-ver.yaml
@@ -37,7 +37,7 @@ spec:
               set -ex
 
               ACTUAL_RESULT="$(echo -n "$(params.requestMessage)" | tr -d '\n' | xargs)"
-              EXPECTED_RESULT="The indexes versions does not match (v4.12 != v4.13)"
+              EXPECTED_RESULT="Error: The indexes versions does not match (v4.12 != v4.13)"
 
               if [[ "$ACTUAL_RESULT" != "$EXPECTED_RESULT" ]]; then
                 echo "Error: requestMessage task result is not correct"

--- a/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
+++ b/tasks/managed/add-fbc-contribution/add-fbc-contribution.yaml
@@ -100,8 +100,6 @@ spec:
       description: The name of the key in the ConfigMap that contains the CA bundle data
       default: ca-bundle.crt
   results:
-    - name: buildTimestamp
-      description: Build timestamp used in the tag
     - name: requestResultsFile
       description: Internal Request results file
     - name: internalRequestResultsFile
@@ -211,9 +209,6 @@ spec:
         mustPublishIndexImage="$(params.mustPublishIndexImage)"
         mustOverwriteFromIndexImage="$(params.mustOverwriteFromIndexImage)"
 
-        timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' "${DATA_FILE}")
-        timestamp=$(date "+${timestamp_format}")
-
         # Extract OCP versions from snapshot (ocpVersion is JSON array)
         # Components can have multiple versions: ["v4.17", "v4.18", "v4.19"]
         # Fallback to empty array if ocpVersion is absent or null for backward compatibility
@@ -225,8 +220,6 @@ spec:
         echo "  - mustOverwriteFromIndexImage: ${mustOverwriteFromIndexImage}"
         echo "  - iibServiceAccountSecret: ${iib_service_account_secret}"
 
-        # Initialize results file for multi-OCP processing
-        echo -n "$timestamp" > "$(results.buildTimestamp.path)"
         jq -n '{"components": []}' | tee "$RESULTS_FILE"
 
         # Snapshot validation for multi-OCP processing
@@ -497,10 +490,43 @@ spec:
                 # Process results for each fragment in this batch
                 local decompressed_json_build_info
                 decompressed_json_build_info="$(jq -r '.jsonBuildInfo' <<< "${results}" | base64 -d | gunzip)"
+
+                # Extract and validate completion_time from IIB build info
                 local completion_time_raw
                 completion_time_raw="$(jq -r '.updated' <<< "${decompressed_json_build_info}")"
+
+                if [[ -z "${completion_time_raw}" || "${completion_time_raw}" == "null" ]]; then
+                    echo "ERROR: completion_time not found in IIB build info"
+                    return 1
+                fi
+
+                echo "INFO: Extracting completion_time from IIB build info"
+                echo "  Raw value: ${completion_time_raw}"
+
                 local completion_time
-                completion_time=$(date +"${timestamp_format}" -d "${completion_time_raw}")
+                if ! completion_time=$(date +"%s" -d "${completion_time_raw}"); then
+                    echo "ERROR: Failed to parse completion_time: ${completion_time_raw}"
+                    echo "Date conversion error: ${completion_time}"
+                    return 1
+                fi
+                echo "  Epoch timestamp: ${completion_time}"
+
+                # Ensure completion_time contains ten digits
+                if [[ ! "${completion_time}" =~ ^[0-9]{10}$ ]]; then
+                    echo "ERROR: Invalid completion_time format (expected 10 digits): ${completion_time}"
+                    return 1
+                fi
+
+                # timestamped_target_index is the target_index with completion_time, unless
+                # for hotfix or pre-ga which already has it and can be the same.
+                # For staged releases, target_index is empty, so target_index_with_timestamp is also empty.
+                if [[ -z "${group_target_index}" ]]; then
+                    target_index_with_timestamp=""
+                elif [[ "${group_target_index}" =~ .*[0-9]{10}$ ]]; then
+                    target_index_with_timestamp="${group_target_index}"
+                else
+                    target_index_with_timestamp="${group_target_index}-${completion_time}"
+                fi
 
                 # Process fragments in batch
                 local fragment_index=0
@@ -512,17 +538,19 @@ spec:
                     local build_results
                     build_results=$(jq \
                       --arg fragment "$fragment" \
-                      --arg target_index "$group_target_index" \
+                      --arg target_index "${group_target_index}" \
+                      --arg target_index_with_timestamp "${target_index_with_timestamp}" \
                       --arg ocp_version "$group_ocp_version" \
                       --arg completion_time "$completion_time" \
                       --argjson decompressed_json "${decompressed_json_build_info}" \
                     '{
                       "fbc_fragment": $fragment,
                       "target_index": $target_index,
+                      "target_index_with_timestamp": $target_index_with_timestamp,
                       "ocp_version": $ocp_version,
                       "image_digests": (.indexImageDigests | split(" ") | del(.[] | select(. == ""))),
                       "index_image": $decompressed_json.index_image,
-                      "index_image_resolved": $decompressed_json.index_image_resolved,
+                      "index_image_resolved": $decompressed_json.internal_index_image_copy_resolved,
                       "completion_time": $completion_time,
                       "iibLog": .iibLog
                     }' <<< "${results}")

--- a/tasks/managed/add-fbc-contribution/tests/mocks.sh
+++ b/tasks/managed/add-fbc-contribution/tests/mocks.sh
@@ -133,7 +133,7 @@ function date() {
       "+%Y-%m-%dT%H:%M:%SZ")
           echo "2023-10-10T15:00:00Z" |tee $(params.dataDir)/mock_date_iso_format.txt
           ;;
-      "+%s")
+      "+%s"*)
           echo "1696946200" | tee $(params.dataDir)/mock_date_epoch.txt
           ;;
       "-u +%Hh%Mm%Ss -d @"*)

--- a/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
+++ b/tasks/managed/add-fbc-contribution/tests/test-add-fbc-contribution-hotfix.yaml
@@ -2,9 +2,9 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-prepare-fbc-snapshot-hotfix
+  name: test-add-fbc-contribution-hotfix
 spec:
-  description: Test prepare-fbc-snapshot task with hotfix mode
+  description: Test add-fbc-contribution task for hotfix releases
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -32,8 +32,6 @@ spec:
   tasks:
     - name: setup
       params:
-        - name: snapshotPath
-          value: snapshot.json
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
         - name: dataDir
@@ -46,9 +44,6 @@ spec:
           - name: dataDir
             type: string
             description: The location where data will be stored
-          - name: snapshotPath
-            type: string
-            description: Path to the JSON string of the mapped Snapshot spec in the data workspace
         results:
           - name: sourceDataArtifact
             type: string
@@ -67,7 +62,7 @@ spec:
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
         steps:
-          - name: setup-hotfix-data
+          - name: setup-test-data
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
@@ -76,33 +71,47 @@ spec:
               # Ensure data directory exists
               mkdir -p "$(params.dataDir)"
 
-              # Create snapshot with FBC components
-              cat > "$(params.dataDir)/$(params.snapshotPath)" << 'EOF'
+              # Create snapshot with prepared FBC components (already processed by prepare-fbc-snapshot)
+              # Note: In hotfix mode, prepare-fbc-snapshot would have already replaced {{timestamp}}
+              # with an actual timestamp. We use a fixed timestamp for test reproducibility.
+              cat > "$(params.dataDir)/snapshot.json" << 'EOF'
               {
                 "components": [
                   {
-                    "name": "test-fbc-component",
-                    "ocpVersion": ["v4.12"],
+                    "name": "fbc-target-index-testing",
                     "containerImage": "quay.io/hacbs-release-tests/test-ocp-version/test-fbc-component@sha256:f6e744662e342c1321deddb92469b55197002717a15f8c0b1bb2d9440aac2297",
-                    "repository": "quay.io/test/test-fbc-component"
+                    "repository": "quay.io/scoheb/fbc-target-index-testing",
+                    "ocpVersion": ["v4.12"],
+                    "ocpVersionMetadata": [
+                      {
+                        "version": "v4.12",
+                        "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.12",
+                        "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12-KONFLUX-123-1234567890"
+                      }
+                    ],
+                    "updatedFromIndex": "quay.io/redhat/redhat-operator-index:v4.12",
+                    "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12-KONFLUX-123-1234567890"
                   }
                 ]
               }
               EOF
 
-              # Create FBC data configuration with hotfix mode
+              # Create FBC data configuration for staged release
               cat > "$(params.dataDir)/data.json" << 'EOF'
               {
                 "fbc": {
                   "fromIndex": "quay.io/redhat/redhat-operator-index:{{ OCP_VERSION }}",
-                  "targetIndex": "quay.io/test/target-index:{{ OCP_VERSION }}",
+                  "targetIndex": "quay.io/scoheb/fbc-target-index-testing:v4.12-KONFLUX-123-1234567890",
                   "hotfix": true,
-                  "issueId": "RELEASE-1234"
+                  "issueId": "KONFLUX-123"
                 }
               }
               EOF
 
-              echo "Hotfix test data created"
+              # Create mock results directory structure
+              mkdir -p "$(params.dataDir)/results"
+
+              echo "Staged test data created for add-fbc-contribution"
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -116,12 +125,16 @@ spec:
 
     - name: run-task
       taskRef:
-        name: prepare-fbc-snapshot
+        name: add-fbc-contribution
       params:
         - name: snapshotPath
           value: snapshot.json
         - name: dataPath
           value: data.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: results
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
@@ -136,17 +149,23 @@ spec:
           value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: taskGitRevision
           value: "development"
+        - name: maxBatchSize
+          value: "5"
+        - name: mustPublishIndexImage
+          value: "false"
+        - name: mustOverwriteFromIndexImage
+          value: "false"
+        - name: iibServiceAccountSecret
+          value: "iib-services-config"
       runAfter:
         - setup
 
-    - name: verify-hotfix-suffix
+    - name: verify-results
       params:
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: dataDir
           value: $(params.dataDir)
-        - name: snapshotPath
-          value: snapshot.json
       taskSpec:
         params:
           - name: sourceDataArtifact
@@ -155,9 +174,6 @@ spec:
           - name: dataDir
             type: string
             description: The location where data will be stored
-          - name: snapshotPath
-            type: string
-            description: Path to the JSON string of the mapped Snapshot spec in the data workspace
         results:
           - name: sourceDataArtifact
             type: string
@@ -186,40 +202,54 @@ spec:
                 value: $(params.sourceDataArtifact)
               - name: orasOptions
                 value: $(params.orasOptions)
-          - name: verify-hotfix
+          - name: verify-hotfix-processing
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
               set -eux
 
-              echo "=== HOTFIX SUFFIX VERIFICATION ==="
+              echo "=== HOTFIX RELEASE VERIFICATION ==="
 
-              SNAPSHOT_PATH="$(params.dataDir)/$(params.snapshotPath)"
-              echo "Updated snapshot contents:"
-              jq . "$SNAPSHOT_PATH"
-
-              # Get the target index from the updated snapshot (from ocpVersionMetadata)
-              TARGET_INDEX=$(jq -r '.components[0].ocpVersionMetadata[0].targetIndex' "${SNAPSHOT_PATH}")
-              echo "Target index: ${TARGET_INDEX}"
-
-              # Verify hotfix suffix pattern: v4.12-RELEASE-1234-<10-digit-timestamp>
-              if [[ "${TARGET_INDEX}" =~ v[0-9]+\.[0-9]+-RELEASE-1234-[0-9]{10}$ ]]; then
-                echo "✅ Hotfix suffix correctly applied with 10-digit timestamp"
+              # Verify results file was created
+              RESULTS_FILE="$(params.dataDir)/results/internal-requests-results.json"
+              if [[ -f "${RESULTS_FILE}" ]]; then
+                echo "Results file exists"
+                echo "Results contents:"
+                jq . "${RESULTS_FILE}"
               else
-                echo "❌ Hotfix suffix not found or incorrect format"
-                echo "Expected pattern: v4.12-RELEASE-1234-<10-digit-timestamp>"
-                echo "Actual: $TARGET_INDEX"
+                echo "Results file missing at ${RESULTS_FILE}"
                 exit 1
               fi
 
-              # Verify OCP version is still present
-              if [[ "$TARGET_INDEX" == *"v4.12"* ]]; then
-                echo "✅ OCP version preserved in target index"
+              # Verify components were processed despite empty targetIndex
+              COMPONENTS_COUNT=$(jq '.components | length' "${RESULTS_FILE}")
+              if [[ "${COMPONENTS_COUNT}" -gt 0 ]]; then
+                echo "Components were processed successfully: ${COMPONENTS_COUNT}"
               else
-                echo "❌ OCP version missing from target index"
+                echo "No components processed"
                 exit 1
               fi
 
-              echo "✅ All hotfix suffix verifications passed"
+              # Verify hotfix release specific behavior
+              FIRST_COMPONENT_TARGET=$(jq -r '.components[0].target_index' "${RESULTS_FILE}")
+              FIRST_COMPONENT_TARGET_TS=$(jq -r '.components[0].target_index_with_timestamp' "${RESULTS_FILE}")
+              if [[ "${FIRST_COMPONENT_TARGET}" =~ v4\.12-KONFLUX-123-[0-9]{10}$ ]]; then
+                echo "Target index matches hotfix pattern with 10-digit timestamp"
+              else
+                echo "Unexpected target index format, got: ${FIRST_COMPONENT_TARGET}"
+                exit 1
+              fi
+
+              # Verify that for hotfix, target_index and target_index_with_timestamp are the same
+              if [[ "${FIRST_COMPONENT_TARGET}" == "${FIRST_COMPONENT_TARGET_TS}" ]]; then
+                echo "Hotfix: target_index equals target_index_with_timestamp (no duplication)"
+              else
+                echo "Hotfix should have same target_index and target_index_with_timestamp"
+                echo "   target_index: ${FIRST_COMPONENT_TARGET}"
+                echo "   target_index_with_timestamp: ${FIRST_COMPONENT_TARGET_TS}"
+                exit 1
+              fi
+
+              echo "=== HOTFIX RELEASE TEST PASSED ==="
       runAfter:
         - run-task

--- a/tasks/managed/collect-index-images/README.md
+++ b/tasks/managed/collect-index-images/README.md
@@ -6,7 +6,6 @@ Tekton task that generates a JSON file to be used to create pyxis image for inde
 
 | Name                       | Description                                                                                                                | Optional | Default value        |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|----------------------|
-| buildTimestamp             | Build timestamp for the index image                                                                                        | No       | -                    |
 | internalRequestResultsFile | Path to the results file of the InternalRequest build result                                                               | No       | -                    |
 | ociStorage                 | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
 | ociArtifactExpiresAfter    | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |

--- a/tasks/managed/collect-index-images/collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/collect-index-images.yaml
@@ -10,9 +10,6 @@ spec:
   description: >-
     Tekton task that generates a JSON file to be used to create pyxis image for index images.
   params:
-    - name: buildTimestamp
-      type: string
-      description: Build timestamp for the index image
     - name: internalRequestResultsFile
       type: string
       description: Path to the results file of the InternalRequest build result
@@ -111,7 +108,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: collect-index-images
-      image: quay.io/konflux-ci/release-service-utils@sha256:dc31fa7e0aeb8d316fc7498797b01aeeb08a25078bf3b2e3ab2dc1789b33278c
+      image: quay.io/konflux-ci/release-service-utils@sha256:7b8128d385ed3ec6b2792a43b9dbdaf6963e57385b41284495df731687891d50
       computeResources:
         limits:
           memory: 128Mi
@@ -123,8 +120,6 @@ spec:
           value: $(params.dataDir)
         - name: PARAM_INTERNAL_REQUEST_RESULTS_FILE
           value: $(params.internalRequestResultsFile)
-        - name: PARAM_BUILD_TIMESTAMP
-          value: $(params.buildTimestamp)
         - name: RESULT_INDEX_IMAGE_SNAPSHOT_PATH
           value: $(results.indexImageSnapshot.path)
       command: ["/home/scripts/python/tasks/managed/collect_index_images.py"]

--- a/tasks/managed/collect-index-images/tests/test-collect-index-images.yaml
+++ b/tasks/managed/collect-index-images/tests/test-collect-index-images.yaml
@@ -59,6 +59,8 @@ spec:
                 "components": [
                   {
                     "target_index": "quay.io/redhat/redhat----fbc-target-index:v4.12",
+                    "target_index_with_timestamp": "quay.io/redhat/redhat----fbc-target-index:v4.12-1234567890",
+                    "index_image": "redhat.com/rh-stage/iib:v4.12",
                     "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk"
                   }
                 ]
@@ -80,8 +82,6 @@ spec:
       params:
         - name: internalRequestResultsFile
           value: "internal-requests-results.json"
-        - name: buildTimestamp
-          value: "2468"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -148,14 +148,20 @@ spec:
               fi
 
               if [ "$(jq -c '.components[0].repositories[0].tags' < "${SNAPSHOT_FILE}")" != \
-                "[\"v4.12\",\"v4.12-2468\"]" ]; then
+                "[\"v4.12\"]" ]; then
+                echo "tags do not match"
+                exit 1
+              fi
+
+              if [ "$(jq -c '.components[1].repositories[0].tags' < "${SNAPSHOT_FILE}")" != \
+                "[\"v4.12-1234567890\"]" ]; then
                 echo "tags do not match"
                 exit 1
               fi
 
               component_count="$(jq '.components | length' < "${SNAPSHOT_FILE}")"
-              if [ "${component_count}" != "1" ]; then
-                echo "expected exactly one component, got ${component_count}"
+              if [ "${component_count}" != "2" ]; then
+                echo "expected exactly two components, got ${component_count}"
                 exit 1
               fi
       runAfter:

--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -265,8 +265,19 @@ spec:
                 REPOSITORY_OBJECT=$(jq -c ".components[${component_index}].repositories[${i}]" "${SNAPSHOT_SPEC_FILE}")
                 REPOSITORY=$(jq -r '.url' <<< "$REPOSITORY_OBJECT")
                 REPOSITORY=${REPOSITORY%:*} # strip tag just in case - it should not be there
-                PULLSPEC="${REPOSITORY}@${DIGEST}"
                 TAGS=$(jq -r ".tags | join(\" \")" <<< "$REPOSITORY_OBJECT")
+
+                # FBC index images: inspect by tag instead of digest.
+                # The digest may differ between SOURCE and TARGET registries after
+                # publish-index-image, and floating tags can be overwritten by parallel
+                # IIB builds. Tag-based inspection always resolves correctly on TARGET.
+                if [[ "${REPOSITORY}" =~ /(preview-operator-index|redhat-operator-index)$ ]]; then
+                    FIRST_TAG=$(jq -r '.tags[0]' <<< "${REPOSITORY_OBJECT}")
+                    PULLSPEC="${REPOSITORY}:${FIRST_TAG}"
+                else
+                    PULLSPEC="${REPOSITORY}@${DIGEST}"
+                fi
+
                 MEDIA_TYPE=$(skopeo inspect --retry-times 3 --raw "docker://${PULLSPEC}" | jq -r .mediaType)
 
                 select-oci-auth "${REPOSITORY}" > "$AUTH_FILE"

--- a/tasks/managed/extract-index-image/README.md
+++ b/tasks/managed/extract-index-image/README.md
@@ -1,6 +1,9 @@
 # extract-index-image
 
-Extract the index image fields from the internalRequestResultsFile
+Extract the index image fields from the internalRequestResultsFile.
+
+The internalRequestResultsFile is a result from another task that contains the result of a finished
+internal-request.
 
 ## Parameters
 

--- a/tasks/managed/extract-index-image/extract-index-image.yaml
+++ b/tasks/managed/extract-index-image/extract-index-image.yaml
@@ -8,7 +8,10 @@ metadata:
     tekton.dev/tags: release
 spec:
   description: |-
-    Extract the index image fields from the internalRequestResultsFile
+    Extract the index image fields from the internalRequestResultsFile.
+
+    The internalRequestResultsFile is a result from another task that contains the result of a finished
+    internal-request.
   params:
     - name: resultsDirPath
       type: string

--- a/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
+++ b/tasks/managed/prepare-fbc-snapshot/prepare-fbc-snapshot.yaml
@@ -287,8 +287,9 @@ spec:
         }
 
         # Generate common suffix for hotfix/pre-GA modes
-        timestamp_format=$(jq -r '.fbc.timestampFormat // "%s"' "${DATA_FILE}")
-        timestamp=$(date "+${timestamp_format}")
+        # this timestamp is arbitrary as "completion_time" is only available
+        # after building the index.
+        timestamp=$(date "+%s")
         common_suffix=""
         max_tag_length=128
         timestamp_length=${#timestamp}

--- a/tasks/managed/publish-index-image/README.md
+++ b/tasks/managed/publish-index-image/README.md
@@ -10,7 +10,6 @@ Publish a built FBC index image using skopeo
 | internalRequestResultsFile | File containing the results of the build                                                                                   | No       | -                    |
 | retries                    | Number of skopeo retries                                                                                                   | Yes      | 0                    |
 | requestTimeout             | Max seconds waiting for the status update                                                                                  | Yes      | 360                  |
-| buildTimestamp             | Build timestamp for the publishing image                                                                                   | No       | -                    |
 | pipelineRunUid             | The uid of the current pipelineRun. Used as a label value when creating internal requests                                  | No       | -                    |
 | ociStorage                 | The OCI repository where the Trusted Artifacts are stored                                                                  | Yes      | empty                |
 | ociArtifactExpiresAfter    | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes      | 1d                   |

--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -24,9 +24,6 @@ spec:
       type: string
       default: "360"
       description: Max seconds waiting for the status update
-    - name: buildTimestamp
-      type: string
-      description: Build timestamp for the publishing image
     - name: pipelineRunUid
       type: string
       description: The uid of the current pipelineRun. Used as a label value when creating internal requests
@@ -148,22 +145,27 @@ spec:
 
         LENGTH="$(jq -r '.components | length' "$(params.dataDir)/$(params.internalRequestResultsFile)")"
         for((i=0; i<LENGTH; i++)); do
-          targetIndex=$(jq -r --argjson i "$i" \
+          targetIndex=$(jq -r --argjson i "${i}" \
             '.components[$i].target_index' "$(params.dataDir)/$(params.internalRequestResultsFile)")
+          targetIndexWithTimestamp=$(jq -r --argjson i "${i}" \
+            '.components[$i].target_index_with_timestamp' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
-          sourceIndex="$(jq -r  --argjson i "$i" \
+          sourceIndex="$(jq -r --argjson i "${i}" \
             '.components[$i].index_image' "$(params.dataDir)/$(params.internalRequestResultsFile)")"
+          sourceIndexResolved="$(jq -r --argjson i "${i}" \
+            '.components[$i].index_image_resolved' "$(params.dataDir)/$(params.internalRequestResultsFile)")"
 
-          targetOcpVersion=$(jq -r --argjson i "$i" \
+          targetOcpVersion=$(jq -r --argjson i "${i}" \
             '.components[$i].ocp_version' "$(params.dataDir)/$(params.internalRequestResultsFile)")
 
-          buildTimestamp=$(jq -r --argjson i "$i" '.components[$i].completion_time' \
-            "$(params.dataDir)/$(params.internalRequestResultsFile)")
-
-          publishingImages=("$targetIndex")
-          # only publish the extra timestamp-based tag if the targetIndex does not have it already
-          if [[ ! "$targetIndex" =~ .*"$buildTimestamp"$ ]]; then
-            publishingImages+=("${targetIndex}-${buildTimestamp}")
+          publishingImages=("${targetIndex}")
+          publishingSources=("${sourceIndex}")
+          # only publish the extra tag when it does not contain a timestamp already
+          # which is the case for pre-ga and hotfix
+          if [ "${targetIndex}" != "${targetIndexWithTimestamp}" ]; then
+            publishingImages+=("${targetIndexWithTimestamp}")
+            # Use resolved digest for timestamped tag to avoid race with parallel IIB builds
+            publishingSources+=("${sourceIndexResolved}")
           fi
 
           requestTimeout=$(params.requestTimeout)
@@ -176,12 +178,12 @@ spec:
           for((x=0; x<${#publishingImages[@]}; x++ )); do
               echo "=== Creating internal request to publish image:"
               echo ""
-              echo "- from: ${sourceIndex}"
-              echo "- to: ${publishingImages[$x]}"
+              echo "- from: ${publishingSources[${x}]}"
+              echo "- to: ${publishingImages[${x}]}"
 
               internal-request --pipeline "${request}" \
-                  -p sourceIndex="${sourceIndex}" \
-                  -p targetIndex="${publishingImages[$x]}" \
+                  -p sourceIndex="${publishingSources[${x}]}" \
+                  -p targetIndex="${publishingImages[${x}]}" \
                   -p targetOcpVersion="${targetOcpVersion}" \
                   -p publishingCredentials="${credentials}" \
                   -p retries="$(params.retries)" \
@@ -201,11 +203,11 @@ spec:
               requestMessage=$(echo "${results}" | jq -r '.requestMessage // ""')
 
               if echo "${requestMessage}" | grep -qi "error"; then
-                echo "ERROR: Publish to ${publishingImages[$x]} failed"
+                echo "ERROR: Publish to ${publishingImages[${x}]} failed"
                 echo "requestMessage: ${requestMessage}"
                 exit 1
               fi
-              echo "=== published successfully (${publishingImages[$x]})"
+              echo "=== published successfully (${publishingImages[${x}]})"
 
               echo ""
               echo ""

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-with-timestamp.yaml
@@ -69,6 +69,7 @@ spec:
                   {
                     "fbc_fragment": "registry.io/image0@sha256:0000",
                     "target_index": "quay.io/scoheb/fbc-target-index-testing:v4.12",
+                    "target_index_with_timestamp": "quay.io/scoheb/fbc-target-index-testing:v4.12-1678118351",
                     "ocp_version": "v4.12",
                     "index_image": "redhat.com/rh-stage/iib:01",
                     "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
@@ -98,8 +99,6 @@ spec:
       params:
         - name: internalRequestResultsFile
           value: "internal-requests-results.json"
-        - name: buildTimestamp
-          value: 11111111111
         - name: retries
           value: 2
         - name: pipelineRunUid
@@ -165,34 +164,72 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
-                sed 's/[[:space:]]*$//' |head -1)"
-              pipeline="$(kubectl get internalrequest "${internalRequest}" -o \
-              jsonpath="{.spec.pipeline.pipelineRef.params[2].value}")"
-
-              params=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
-
-              if [ "$pipeline" != \
-                "pipelines/internal/publish-index-image-pipeline/publish-index-image-pipeline.yaml" ]; then
-                echo "pipeline does not match"
+              # Verify that TWO InternalRequests were created (one for v4.12, one for v4.12-timestamp)
+              irCount=$(kubectl get internalrequest --no-headers | wc -l)
+              if [ "${irCount}" != "2" ]; then
+                echo "Expected 2 InternalRequests, got ${irCount}"
+                kubectl get internalrequest
                 exit 1
               fi
 
-              if [ "$(jq -r '.retries' <<< "${params}")" != "2" ]; then
-                echo "number of retries does not match"
-                exit 1
-              fi
+              # Check both InternalRequests
+              for i in 0 1; do
+                internalRequest="$(kubectl get internalrequest --sort-by=.metadata.creationTimestamp --no-headers | \
+                  sed 's/[[:space:]]*$//' | sed -n "$((i+1))p")"
 
-              if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "redhat.com/rh-stage/iib:01" ]; then
-                echo "sourceIndex image does not match"
-                exit 1
-              fi
+                pipeline="$(kubectl get internalrequest "${internalRequest}" -o \
+                  jsonpath="{.spec.pipeline.pipelineRef.params[2].value}")"
 
-              targetIndex=$(jq -r '.targetIndex' <<< "${params}")
-              if [ "$targetIndex" != "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
-                echo "targetIndex image does not match"
-                exit 1
-              fi
+                params=$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")
+
+                if [ "${pipeline}" != \
+                  "pipelines/internal/publish-index-image-pipeline/publish-index-image-pipeline.yaml" ]; then
+                  echo "pipeline does not match for IR ${i}"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.retries' <<< "${params}")" != "2" ]; then
+                  echo "number of retries does not match for IR ${i}"
+                  exit 1
+                fi
+
+                sourceIndex=$(jq -r '.sourceIndex' <<< "${params}")
+                if [ "${i}" = 0 ]; then
+                  # Floating tag uses index_image (tag)
+                  if [ "${sourceIndex}" != "redhat.com/rh-stage/iib:01" ]; then
+                    echo "sourceIndex image does not match for IR ${i}"
+                    echo "Expected: redhat.com/rh-stage/iib:01"
+                    echo "Got: ${sourceIndex}"
+                    exit 1
+                  fi
+                else
+                  # Timestamped tag uses index_image_resolved (digest)
+                  if [ "${sourceIndex}" != "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+                    echo "sourceIndex image does not match for IR ${i}"
+                    echo "Expected: redhat.com/rh-stage/iib@sha256:abcdefghijk"
+                    echo "Got: ${sourceIndex}"
+                    exit 1
+                  fi
+                fi
+
+                targetIndex=$(jq -r '.targetIndex' <<< "${params}")
+                if [ "${i}" = 0 ]; then
+                  if [ "${targetIndex}" != "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
+                    echo "targetIndex image does not match for IR 0"
+                    echo "Expected: quay.io/scoheb/fbc-target-index-testing:v4.12"
+                    echo "Got: ${targetIndex}"
+                    exit 1
+                  fi
+                else
+                  expectedTargetIndex="quay.io/scoheb/fbc-target-index-testing:v4.12-1678118351"
+                  if [ "${targetIndex}" != "${expectedTargetIndex}" ]; then
+                    echo "targetIndex image does not match for IR 1"
+                    echo "Expected: ${expectedTargetIndex}"
+                    echo "Got: ${targetIndex}"
+                    exit 1
+                  fi
+                fi
+              done
 
               if [ "$(jq -r '.taskGitUrl' <<< "${params}")" != "http://localhost" ]; then
                 echo "taskGitUrl image does not match"

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image.yaml
@@ -69,6 +69,7 @@ spec:
                   {
                     "fbc_fragment": "registry.io/image0@sha256:0000",
                     "target_index": "quay.io/scoheb/fbc-target-index-testing:v4.12",
+                    "target_index_with_timestamp": "quay.io/scoheb/fbc-target-index-testing:v4.12-1678118351",
                     "ocp_version": "v4.12",
                     "index_image": "redhat.com/rh-stage/iib:01",
                     "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
@@ -96,8 +97,6 @@ spec:
       taskRef:
         name: publish-index-image
       params:
-        - name: buildTimestamp
-          value: 11111111111
         - name: internalRequestResultsFile
           value: "internal-requests-results.json"
         - name: retries
@@ -178,7 +177,7 @@ spec:
                   pipeline=$(jq -r ".[$i] | .spec.pipeline.pipelineRef.params[2].value" <<< "${internalRequests}")
                   params=$(jq -r ".[$i] | .spec.params" <<< "${internalRequests}")
 
-                  if [ "$pipeline" != \
+                  if [ "${pipeline}" != \
                     "pipelines/internal/publish-index-image-pipeline/publish-index-image-pipeline.yaml" ]; then
                     echo "pipeline does not match"
                     exit 1
@@ -189,21 +188,37 @@ spec:
                     exit 1
                   fi
 
-                  if [ "$(jq -r '.sourceIndex' <<< "${params}")" != "redhat.com/rh-stage/iib:01" ]; then
-                    echo "sourceIndex image does not match"
-                    exit 1
+                  sourceIndex=$(jq -r '.sourceIndex' <<< "${params}")
+                  if [ "${i}" = 0 ]; then
+                    # Floating tag uses index_image (tag)
+                    if [ "${sourceIndex}" != "redhat.com/rh-stage/iib:01" ]; then
+                      echo "sourceIndex image does not match for IR ${i}"
+                      echo "Expected: redhat.com/rh-stage/iib:01"
+                      echo "Got: ${sourceIndex}"
+                      exit 1
+                    fi
+                  else
+                    # Timestamped tag uses index_image_resolved (digest)
+                    if [ "${sourceIndex}" != "redhat.com/rh-stage/iib@sha256:abcdefghijk" ]; then
+                      echo "sourceIndex image does not match for IR ${i}"
+                      echo "Expected: redhat.com/rh-stage/iib@sha256:abcdefghijk"
+                      echo "Got: ${sourceIndex}"
+                      exit 1
+                    fi
                   fi
 
                   targetIndex=$(jq -r '.targetIndex' <<< "${params}")
-                  if [ $i = 0 ]; then
-                      if [ "$targetIndex" != "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
+                  if [ "${i}" = 0 ]; then
+                      if [ "${targetIndex}" != "quay.io/scoheb/fbc-target-index-testing:v4.12" ]; then
                         echo "targetIndex image does not match"
                         exit 1
                       fi
                   else
-                      expectedTargetIndex="quay.io/scoheb/fbc-target-index-testing:v4.12-2023-03-06T16:39:11.314092Z"
-                      if [ "$targetIndex" != "$expectedTargetIndex" ]; then
+                      expectedTargetIndex="quay.io/scoheb/fbc-target-index-testing:v4.12-1678118351"
+                      if [ "${targetIndex}" != "${expectedTargetIndex}" ]; then
                         echo "targetIndex image does not match"
+                        echo "Expected: ${expectedTargetIndex}"
+                        echo "Got: ${targetIndex}"
                         exit 1
                       fi
                   fi


### PR DESCRIPTION
Fix "manifest unknown" errors in FBC release pipelines
caused by parallel IIB builds overwriting floating tags
between publish-index-image and create-pyxis-image.

Changes:

- add-fbc-contribution: extract completion_time from
  IIB build info as epoch timestamp with validation,
  compute target_index_with_timestamp per release type
  (regular vs hotfix/pre-GA), remove buildTimestamp
  result and timestampFormat param, map
  internal_index_image_copy_resolved to
  index_image_resolved

- publish-index-image: use tag-based sourceIndex for
  floating tags and digest-based sourceIndexResolved
  for timestamped tags, remove buildTimestamp param

- create-pyxis-image: inspect FBC operator-index
  repos by tag instead of digest, anchored regex on
  path segment boundary

- collect-index-images: create two snapshot components
  per index (floating + timestamped), remove
  buildTimestamp param, pin image by digest

- publish-index-image-task: add creds to target
  inspect, use -n on digest-match message, prefix
  version mismatch messages with Error:

- prepare-fbc-snapshot: use epoch timestamp, remove
  timestampFormat dependency

- fbc-release pipeline: remove buildTimestamp wiring,
  reorder create-pyxis-image runAfter

Signed-Off-By: Leandro Mendes <lmendes@redhat.com>
Assisted-by: Claude