### PR TITLE
feat(RELEASE-2314): multiarch verification for push-to-external-registry-idempotent

### DIFF
--- a/integration-tests/collectors-no-cve/test.env
+++ b/integration-tests/collectors-no-cve/test.env
@@ -33,3 +33,6 @@ export release_plan_name=collector-no-cve-rp-${uuid}
 
 export managed_sa_name=collector-no-cve-sa-${uuid}
 export release_plan_admission_name=collector-no-cve-rpa-${uuid}
+
+# TODO: move to ITS config
+export PTSV_EXPECTED_ARCHES="amd64 arm64"

--- a/integration-tests/collectors/test.env
+++ b/integration-tests/collectors/test.env
@@ -33,3 +33,6 @@ export release_plan_name=collector-rp-${uuid}
 
 export managed_sa_name=collector-sa-${uuid}
 export release_plan_admission_name=collector-rpa-${uuid}
+
+# TODO: move to ITS config
+export PTSV_EXPECTED_ARCHES="amd64 arm64"

--- a/integration-tests/collectors/test.sh
+++ b/integration-tests/collectors/test.sh
@@ -98,16 +98,11 @@ verify_release_contents() {
     advisory_internal_url=$(jq -r '.status.artifacts.advisory.internal_url // ""' <<< "${release_json}")
     catalog_url=$(jq -r '.status.artifacts.catalog_urls[]?.url // ""' <<< "${release_json}")
     cve=$(jq -r '.status.collectors.tenant.cve.releaseNotes.cves[]? | select(.key == "CVE-2024-8260") | .key // ""' <<< "${release_json}")
-    image_arches=$(jq -r '.status.artifacts.images[0].arches | sort | join(" ") // ""' <<< "${release_json}")
     sboms=$(jq -r '.status.artifacts.sboms // ""' <<< "${release_json}")
 
-    echo "Checking image arches..."
-    if [ "$image_arches" = "amd64 arm64" ]; then
-      echo "✅️ Found required image arches: amd64 arm64"
-    else
-      echo "🔴 Some required image arches were NOT found: expected: amd64 arm64, found: ${image_arches}"
-      failures=$((failures+1))
-    fi
+    # Verify container images using shared helper
+    local failed_releases=""
+    check_container_images
 
     if [ -z "$advisory_internal_url" ]; then
         echo "Warning: advisory_internal_url is empty. Skipping advisory content check."

--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -1389,3 +1389,81 @@ wait_for_multi_component_snapshot() {
 
     echo "$snapshot_name"
 }
+
+check_container_images() {
+    local expected_count image_count
+
+    image_count=$(jq -r '.status.artifacts.images | length' <<< "${release_json}")
+    expected_count=$(echo "${PTSV_COMPONENTS}" | wc -w)
+
+    echo "Checking image count (expected ${expected_count} components)..."
+    if [ "${image_count}" -ge "${expected_count}" ]; then
+        echo "✅️ Found ${image_count} image entries (expected at least ${expected_count})"
+    else
+        echo "🔴 Found only ${image_count} image entries, expected at least ${expected_count}"
+        failures=$((failures+1))
+    fi
+
+    echo "Verifying each image artifact..."
+
+    for ((i = 0; i < image_count; i++)); do
+        local failures=0
+        local image_url image_arch image_shasum
+        image_url=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.urls[0] // ""' <<< "${release_json}")
+        image_arches=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.arches // ""' <<< "${release_json}")
+        image_shasum=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.shasum // ""' <<< "${release_json}")
+
+        echo "Checking Image URL..."
+        if [ -n "${image_url}" ]; then
+            echo "✅️ image_url: ${image_url}"
+        else
+            echo "🔴 image_url was empty"
+            failures=$((failures+1))
+        fi
+
+        str_image_arches=$(echo "${image_arches}" |  jq -r '. | sort | unique | join(" ")')
+        echo "Checking image arches..."
+        if [ "${str_image_arches}" = "$PTSV_EXPECTED_ARCHES" ]; then
+            echo "✅️ Found required image arches: $PTSV_EXPECTED_ARCHES"
+        else
+            echo "🔴 Expected image arches: '$PTSV_EXPECTED_ARCHES', found: '${image_arches}'"
+            failures=$((failures+1))
+        fi
+
+        echo "Checking Image Shasum..."
+        if [ -n "${image_shasum}" ]; then
+            echo "✅️ image_shasum: ${image_shasum}"
+        else
+            echo "🔴 image_shasum was empty"
+            failures=$((failures+1))
+        fi
+
+        # Use digest instead of tag, tag can be overwritten by concurrent tests
+        local image_pullspec="${image_url%:*}@${image_shasum}"
+
+        echo "Verifying multi-arch image pullability with skopeo (${image_pullspec})..."
+        AUTH_FILE="$(mktemp)"
+        yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
+            "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" | base64 -d > "${AUTH_FILE}"
+
+        for arch in $PTSV_EXPECTED_ARCHES; do
+            if skopeo inspect --authfile "${AUTH_FILE}" --override-arch "${arch}" --tls-verify=true --retry-times 3 \
+                    "docker://${image_pullspec}" > /dev/null 2>&1; then
+                echo "✅️ skopeo inspect --override-arch ${arch} succeeded for ${image_pullspec}"
+            else
+                echo "🔴 skopeo inspect --override-arch ${arch} failed for ${image_pullspec}"
+                failures=$((failures+1))
+            fi
+        done
+
+        if [ "${failures}" -gt 0 ]; then
+          echo "🔴 Test has FAILED with ${failures} failure(s)!"
+          failed_releases="${RELEASE_NAME} ${failed_releases}"
+        else
+          echo "✅️ All release checks passed. Success!"
+        fi
+    done
+    if [ -f "${AUTH_FILE}" ]; then
+        rm -f "${AUTH_FILE}"
+    fi
+}

--- a/integration-tests/push-to-addons-registry/test.env
+++ b/integration-tests/push-to-addons-registry/test.env
@@ -30,3 +30,7 @@ export release_plan_name=push-to-addons-registry-rp-${uuid}
 
 export managed_sa_name=push-to-addons-registry-sa-${uuid}
 export release_plan_admission_name=push-to-addons-registry-rpa-${uuid}
+
+
+# TODO: move to ITS config
+export PTSV_EXPECTED_ARCHES="amd64 arm64"

--- a/integration-tests/push-to-addons-registry/test.sh
+++ b/integration-tests/push-to-addons-registry/test.sh
@@ -166,25 +166,14 @@ verify_release_contents() {
       fi
 
       local failures=0
-      local image_url mergerequest_url image_arches image_shasum released_status
+      local mergerequest_url released_status
 
-      image_url=$(jq -r '.status.artifacts.images[0]?.urls[0]? // ""' <<< "${release_json}")
       mergerequest_url=$(jq -r '.status.artifacts.merge_requests[0]?.url? // ""' <<< "${release_json}")
-      # Release may list one arch per manifest/index entry (e.g. duplicate amd64); compare distinct sets.
-      # Strip optional linux/ prefix (e.g. linux/amd64 -> amd64). Default null/missing .arches to [].
-      image_arches=$(jq -r '(.status.artifacts.images[0]?.arches? // [])
-        | map((tostring | split("/") | .[-1]))
-        | unique
-        | join(" ")' <<< "${release_json}")
-      image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum? // ""' <<< "${release_json}")
       released_status=$(jq -r '([.status.conditions[]? | select(.type=="Released") | .status] | first) // ""' <<< "${release_json}")
 
       echo "Release fields under validation:"
       echo "  Released: ${released_status}"
-      echo "  image_url: ${image_url}"
       echo "  mergerequest_url: ${mergerequest_url}"
-      echo "  image_arches: ${image_arches}"
-      echo "  image_shasum: ${image_shasum}"
 
       echo "Checking Released=True..."
       if [ "${released_status}" = "True" ]; then
@@ -194,13 +183,6 @@ verify_release_contents() {
         failures=$((failures+1))
       fi
 
-      echo "Checking image_url..."
-      if [ -n "${image_url}" ]; then
-        echo "✅️ image_url: ${image_url}"
-      else
-        echo "🔴 image_url was empty!"
-        failures=$((failures+1))
-      fi
       echo "Checking mergerequest_url..."
       if [ -n "${mergerequest_url}" ]; then
         echo "✅️ mergerequest_url: ${mergerequest_url}"
@@ -209,38 +191,9 @@ verify_release_contents() {
         failures=$((failures+1))
       fi
 
-      echo "Checking image arches include amd64 and arm64..."
-      if [[ " ${image_arches} " == *" amd64 "* && " ${image_arches} " == *" arm64 "* ]]; then
-        echo "✅️ Found required arches: ${image_arches}"
-      else
-        echo "🔴 Missing required arches (need: amd64 and arm64), found: '${image_arches}'"
-        failures=$((failures+1))
-      fi
-
-      echo "Checking image shasum (manifest list digest) is present..."
-      if [[ "${image_shasum}" == sha256:* ]]; then
-        echo "✅️ image_shasum: ${image_shasum}"
-      else
-        echo "🔴 image_shasum missing or invalid: '${image_shasum}'"
-        failures=$((failures+1))
-      fi
-
-      echo "Checking skopeo inspect succeeds for both arches (digest pull + registry auth)..."
-      if [ -n "${image_url}" ] && [[ "${image_shasum}" == sha256:* ]]; then
-        set +e
-        "${SCRIPT_DIR}/scripts/skopeo-verify-image.sh" \
-          "${image_url}" "${image_shasum}" \
-          "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" \
-          "amd64 arm64"
-        skopeo_rc=$?
-        set -e
-        if [ "${skopeo_rc}" -ne 0 ]; then
-          failures=$((failures+1))
-        fi
-      elif [ -n "${image_url}" ]; then
-        echo "🔴 Skipping skopeo multi-arch check: image_shasum missing or not sha256:*"
-        failures=$((failures+1))
-      fi
+      # Verify container images using shared helper
+      local failed_releases=""
+      check_container_images
 
       if [ "${failures}" -gt 0 ]; then
         echo "🔴 Test has FAILED with ${failures} failure(s)!"

--- a/integration-tests/push-to-external-registry-idempotent/test.sh
+++ b/integration-tests/push-to-external-registry-idempotent/test.sh
@@ -33,72 +33,20 @@ verify_single_release() {
         log_error "Could not retrieve Release JSON for ${release_name}"
     fi
 
+    # Set RELEASE_NAME for check_container_images (it expects this global)
+    local RELEASE_NAME="${release_name}"
     local failures=0
-    local expected_count
-    expected_count=$(echo "${PTSV_COMPONENTS}" | wc -w)
+    local failed_releases=""
 
-    local image_count
-    image_count=$(jq -r '.status.artifacts.images | length' <<< "${release_json}")
-
-    echo "Checking image count (expected ${expected_count} components)..."
-    if [ "${image_count}" -ge "${expected_count}" ]; then
-        echo "✅️ Found ${image_count} image entries (expected at least ${expected_count})"
-    else
-        echo "🔴 Found only ${image_count} image entries, expected at least ${expected_count}"
-        failures=$((failures+1))
-    fi
-
-    echo ""
-    echo "Verifying each image artifact..."
-    for ((i = 0; i < image_count; i++)); do
-        local image_url image_arch image_shasum
-        image_url=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.urls[0] // ""' <<< "${release_json}")
-        image_arch=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.arches[0] // ""' <<< "${release_json}")
-        image_shasum=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.shasum // ""' <<< "${release_json}")
-
-        echo "Image ${i}:"
-        if [ -n "${image_url}" ]; then
-            echo "  ✅️ url: ${image_url}"
-        else
-            echo "  🔴 url was empty"
-            failures=$((failures+1))
-        fi
-
-        if [ -n "${image_arch}" ]; then
-            echo "  ✅️ arch: ${image_arch}"
-        else
-            echo "  🔴 arch was empty"
-            failures=$((failures+1))
-        fi
-
-        if [ -n "${image_shasum}" ]; then
-            echo "  ✅️ shasum: ${image_shasum}"
-        else
-            echo "  🔴 shasum was empty"
-            failures=$((failures+1))
-        fi
-
-        if [ -n "${image_url}" ] && [ -n "${image_shasum}" ]; then
-            echo "  Verifying image pullability with skopeo..."
-            set +e
-            "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
-                "${image_url}" "${image_shasum}" \
-                "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
-            local skopeo_return_code=$?
-            set -e
-            if [ "${skopeo_return_code}" -ne 0 ]; then
-                echo "  🔴 skopeo verification failed"
-                failures=$((failures+1))
-            else
-                echo "  ✅️ image is pullable"
-            fi
-        fi
-    done
+    # Verify container images using shared helper (single-arch)
+    check_container_images
 
     if [ "${failures}" -gt 0 ]; then
         echo "🔴 Release verification FAILED with ${failures} failure(s)!"
         return 1
     else
+        local image_count
+        image_count=$(jq -r '.status.artifacts.images | length' <<< "${release_json}")
         echo "✅️ All release checks passed for ${image_count} image(s)."
         return 0
     fi

--- a/integration-tests/push-to-external-registry/test.sh
+++ b/integration-tests/push-to-external-registry/test.sh
@@ -14,45 +14,10 @@ verify_release_contents() {
     fi
 
     local failures=0
-    local image_url image_arch
+    local failed_releases=""
 
-    image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
-    image_arch=$(jq -r '.status.artifacts.images[0]?.arches[0] // ""' <<< "${release_json}")
-    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
-
-    echo "Checking Image URL..."
-    if [ -n "${image_url}" ]; then
-        echo "✅️ image_url: ${image_url}"
-    else
-        echo "🔴 image_url was empty"
-        failures=$((failures+1))
-    fi
-    echo "Checking Image Arch..."
-    if [ -n "${image_arch}" ]; then
-        echo "✅️ image_arch: ${image_arch}"
-    else
-        echo "🔴 image_arch was empty"
-        failures=$((failures+1))
-    fi
-
-    echo "Checking Image Shasum..."
-    if [ -n "${image_shasum}" ]; then
-        echo "✅️ image_shasum: ${image_shasum}"
-    else
-        echo "🔴 image_shasum was empty"
-        failures=$((failures+1))
-    fi
-
-    echo "Verifying image pullability with skopeo..."
-    set +e
-    "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
-        "${image_url}" "${image_shasum}" \
-        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
-    skopeo_return_code=$?
-    set -e
-    if [ "${skopeo_return_code}" -ne 0 ]; then
-        failures=$((failures+1))
-    fi
+    # Verify container images using shared helper (single-arch)
+    check_container_images
 
     # Verify componentTags combination with defaults.tags and repository tags
     echo "Verifying tag combination from all sources..."

--- a/integration-tests/rh-push-helm-chart-to-registry-redhat-io/test.sh
+++ b/integration-tests/rh-push-helm-chart-to-registry-redhat-io/test.sh
@@ -44,12 +44,8 @@ verify_release_contents() {
     fi
 
     local failures=0
-    local image_url image_arch image_shasum
     local catalog_url file_update_mr_url
 
-    image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
-    image_arch=$(jq -r '.status.artifacts.images[0]?.arches[0] // ""' <<< "${release_json}")
-    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
     catalog_url=$(jq -r '.status.artifacts.catalog_urls[]?.url // ""' <<< "${release_json}")
     file_update_mr_url=$(jq -r '.status.artifacts.merge_requests[0]?.url // ""' <<< "${release_json}")
 
@@ -69,19 +65,16 @@ verify_release_contents() {
         failures=$((failures+1))
     fi
 
+    # Extract image details for Helm OCI artifact verification
+    local image_url image_shasum
+    image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
+    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
+
     echo "Checking Image URL..."
     if [ -n "${image_url}" ]; then
         echo "✅️ image_url: ${image_url}"
     else
         echo "🔴 image_url was empty"
-        failures=$((failures+1))
-    fi
-
-    echo "Checking Image Arch..."
-    if [ -n "${image_arch}" ]; then
-        echo "✅️ image_arch: ${image_arch}"
-    else
-        echo "🔴 image_arch was empty"
         failures=$((failures+1))
     fi
 
@@ -93,7 +86,8 @@ verify_release_contents() {
         failures=$((failures+1))
     fi
 
-    echo "Verifying image pullability with skopeo..."
+    # Helm OCI artifact verification (special handling for Helm charts)
+    echo "Verifying Helm OCI artifact pullability with skopeo..."
     ORIGINAL_PULLSPEC="${image_url}"
     if [[ "$ORIGINAL_PULLSPEC" == *":"* && "$ORIGINAL_PULLSPEC" != *"@"* ]]; then
         STRIPPED_PULLSPEC="${ORIGINAL_PULLSPEC%:*}"

--- a/integration-tests/rh-push-to-external-registry-multi-component/test.sh
+++ b/integration-tests/rh-push-to-external-registry-multi-component/test.sh
@@ -57,20 +57,16 @@ verify_release_contents() {
     fi
 
     local failures=0
+    local failed_releases=""
 
+    # Verify multi-component images using shared helper
+    check_container_images
+
+    # Additional verification: ensure distinct URLs and shasums for multi-component test
     echo ""
-    echo "Checking for 2 image entries with distinct URLs and shasums..."
-
+    echo "Verifying distinct URLs and shasums for each component..."
     local image_count
     image_count=$(jq -r '.status.artifacts.images | length' <<< "${release_json}")
-
-    echo "Found ${image_count} image entries in status.artifacts.images"
-    if [ "${image_count}" -ge 2 ]; then
-        echo "✅️ Found ${image_count} image entries (expected at least 2)"
-    else
-        echo "🔴 Found only ${image_count} image entries, expected at least 2"
-        failures=$((failures+1))
-    fi
 
     local image0_url image0_shasum image1_url image1_shasum
     image0_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
@@ -80,20 +76,6 @@ verify_release_contents() {
 
     echo "Image 0: url=${image0_url}, shasum=${image0_shasum}"
     echo "Image 1: url=${image1_url}, shasum=${image1_shasum}"
-
-    if [ -n "${image0_url}" ] && [ -n "${image1_url}" ]; then
-        echo "✅️ Both image URLs are non-empty"
-    else
-        echo "🔴 One or both image URLs are empty"
-        failures=$((failures+1))
-    fi
-
-    if [ -n "${image0_shasum}" ] && [ -n "${image1_shasum}" ]; then
-        echo "✅️ Both image shasums are non-empty"
-    else
-        echo "🔴 One or both image shasums are empty"
-        failures=$((failures+1))
-    fi
 
     if [ "${image0_url}" != "${image1_url}" ]; then
         echo "✅️ Image URLs are distinct"
@@ -108,35 +90,6 @@ verify_release_contents() {
         echo "🔴 Image shasums are identical: ${image0_shasum}"
         failures=$((failures+1))
     fi
-
-    echo ""
-    echo "Verifying both images are pullable via skopeo..."
-
-    for i in 0 1; do
-        local img_url img_shasum
-        img_url=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.urls[0] // ""' <<< "${release_json}")
-        img_shasum=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.shasum // ""' <<< "${release_json}")
-
-        if [ -z "${img_url}" ] || [ -z "${img_shasum}" ]; then
-            echo "🔴 Image ${i}: missing url or shasum, skipping skopeo check"
-            failures=$((failures+1))
-            continue
-        fi
-
-        echo "Verifying image ${i} pullability with skopeo: ${img_url}"
-        set +e
-        "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
-            "${img_url}" "${img_shasum}" \
-            "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
-        local skopeo_rc=$?
-        set -e
-        if [ "${skopeo_rc}" -ne 0 ]; then
-            echo "🔴 Image ${i} skopeo verification failed"
-            failures=$((failures+1))
-        else
-            echo "✅️ Image ${i} is pullable"
-        fi
-    done
 
     echo ""
     echo "Verifying Pyxis image IDs..."

--- a/integration-tests/rh-push-to-external-registry/test.env
+++ b/integration-tests/rh-push-to-external-registry/test.env
@@ -30,3 +30,5 @@ export release_plan_name=rh-push-to-external-registry-rp-${uuid}
 
 export managed_sa_name=rh-push-to-external-registry-sa-${uuid}
 export release_plan_admission_name=rh-push-to-external-registry-rpa-${uuid}
+
+export PTSV_EXPECTED_ARCHES="amd64 arm64"

--- a/integration-tests/rh-push-to-external-registry/test.sh
+++ b/integration-tests/rh-push-to-external-registry/test.sh
@@ -30,46 +30,10 @@ verify_release_contents() {
     echo "Restored artifact ${ociArtifact} to ${oci_artifact_dir}"
 
     local failures=0
-    local image_url image_arches image_shasum
+    local failed_releases=""
 
-    image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
-    image_arches=$(jq -r '.status.artifacts.images[0]?.arches // [] | sort | join(" ")' <<< "${release_json}")
-    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
-
-    echo "Checking Image URL..."
-    if [ -n "${image_url}" ]; then
-        echo "✅️ image_url: ${image_url}"
-    else
-        echo "🔴 image_url was empty"
-        failures=$((failures+1))
-    fi
-
-    echo "Checking image arches..."
-    if [ "${image_arches}" = "amd64 arm64" ]; then
-        echo "✅️ Found required image arches: amd64 arm64"
-    else
-        echo "🔴 Expected image arches: amd64 arm64, found: ${image_arches}"
-        failures=$((failures+1))
-    fi
-
-    # Use digest instead of tag, tag can be overwritten by concurrent tests
-    local image_pullspec="${image_url%:*}@${image_shasum}"
-
-    echo "Verifying multi-arch image pullability with skopeo (${image_pullspec})..."
-    AUTH_FILE="$(mktemp)"
-    yq '. | select(.metadata.name | contains("push-")) | .data.".dockerconfigjson"' \
-        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" | base64 -d > "${AUTH_FILE}"
-
-    for arch in amd64 arm64; do
-        if skopeo inspect --authfile "${AUTH_FILE}" --override-arch "${arch}" --tls-verify=true --retry-times 3 \
-                "docker://${image_pullspec}" > /dev/null 2>&1; then
-            echo "✅️ skopeo inspect --override-arch ${arch} succeeded for ${image_pullspec}"
-        else
-            echo "🔴 skopeo inspect --override-arch ${arch} failed for ${image_pullspec}"
-            failures=$((failures+1))
-        fi
-    done
-    rm -f "${AUTH_FILE}"
+    # Verify container images using shared helper
+    check_container_images
 
     echo "Checking Image IDs..."
     pyxisDataFile=$(find ${oci_artifact_dir} -name "pyxis.json")

--- a/integration-tests/rh-push-to-registry-redhat-io/test.sh
+++ b/integration-tests/rh-push-to-registry-redhat-io/test.sh
@@ -18,12 +18,9 @@ verify_release_contents() {
 
     local catalog_url
     local failures=0
-    local image_url image_arch image_shasum
+    local failed_releases=""
     local file_update_mr_url
 
-    image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
-    image_arch=$(jq -r '.status.artifacts.images[0]?.arches[0] // ""' <<< "${release_json}")
-    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
     catalog_url=$(jq -r '.status.artifacts.catalog_urls[]?.url // ""' <<< "${release_json}")
     file_update_mr_url=$(jq -r '.status.artifacts.merge_requests[0]?.url // ""' <<< "${release_json}")
 
@@ -43,39 +40,8 @@ verify_release_contents() {
         failures=$((failures+1))
     fi
 
-    echo "Checking Image URL..."
-    if [ -n "${image_url}" ]; then
-        echo "✅️ image_url: ${image_url}"
-    else
-        echo "🔴 image_url was empty"
-        failures=$((failures+1))
-    fi
-    echo "Checking Image Arch..."
-    if [ -n "${image_arch}" ]; then
-        echo "✅️ image_arch: ${image_arch}"
-    else
-        echo "🔴 image_arch was empty"
-        failures=$((failures+1))
-    fi
-
-    echo "Checking Image Shasum..."
-    if [ -n "${image_shasum}" ]; then
-        echo "✅️ image_shasum: ${image_shasum}"
-    else
-        echo "🔴 image_shasum was empty"
-        failures=$((failures+1))
-    fi
-
-    echo "Verifying image pullability with skopeo..."
-    set +e
-    "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
-        "${image_url}" "${image_shasum}" \
-        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
-    skopeo_return_code=$?
-    set -e
-    if [ "${skopeo_return_code}" -ne 0 ]; then
-        failures=$((failures+1))
-    fi
+    # Verify container images using shared helper (single-arch)
+    check_container_images
 
     if [ "${failures}" -gt 0 ]; then
       echo "🔴 Test has FAILED with ${failures} failure(s)!"

--- a/integration-tests/rhtap-service-push/test.sh
+++ b/integration-tests/rhtap-service-push/test.sh
@@ -36,41 +36,9 @@ verify_release_contents() {
       echo "Revision: ${revision}"
 
       local failures=0
-      local image_url image_shasum
 
-      image_url=$(jq -r '.status.artifacts.images[0].urls[0] // ""' <<< "${release_json}")
-      image_shasum=$(jq -r '.status.artifacts.images[0].shasum // ""' <<< "${release_json}")
-
-      echo "Checking image_url..."
-      if [ -n "${image_url}" ]; then
-        echo "✅️ image_url: ${image_url}"
-      else
-        echo "🔴 image_url was empty!"
-        failures=$((failures+1))
-      fi
-
-      echo "Checking image_shasum..."
-      if [ -n "${image_shasum}" ]; then
-        echo "✅️ image_shasum: ${image_shasum}"
-      else
-        echo "🔴 image_shasum was empty!"
-        failures=$((failures+1))
-      fi
-
-      echo "Verifying image pullability with skopeo..."
-      if [ -n "${image_url}" ] && [ -n "${image_shasum}" ]; then
-        set +e
-        "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
-          "${image_url}" "${image_shasum}" \
-          "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
-        skopeo_return_code=$?
-        set -e
-        if [ "${skopeo_return_code}" -ne 0 ]; then
-          failures=$((failures+1))
-        fi
-      else
-        echo "⚠️  Skipping skopeo check: image_url or image_shasum is empty."
-      fi
+      # Verify container images using shared helper (single-arch)
+      check_container_images
 
       set +e
       "${SUITE_DIR}/../scripts/find-pr-with-sha-and-file.sh" "hacbs-release/infra-deployments" "${revision}" "components/release/development/kustomization.yaml"

--- a/integration-tests/run-test.sh
+++ b/integration-tests/run-test.sh
@@ -169,6 +169,10 @@ if [[ -n "${PTSV_BUILD_PIPELINE}" ]]; then
     )
 fi
 
+if [ -z "$PTSV_EXPECTED_ARCHES" ]; then
+    PTSV_EXPECTED_ARCHES="amd64"
+fi
+
 # --- Main Script Execution ---
 
 # Trap EXIT signal to call cleanup function


### PR DESCRIPTION
Added support to verify multiarch images for push-to-external-registry-idempotent

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
