### PR TITLE
feat(RELEASE-2460): add disk-image support to push-artifacts-to-cdn

### DIFF
--- a/integration-tests/push-artifacts-to-cdn/README.md
+++ b/integration-tests/push-artifacts-to-cdn/README.md
@@ -1,6 +1,6 @@
 # push-artifacts-to-cdn Test
 
-This test validates the `push-artifacts-to-cdn` pipeline with two components:
+This test validates the `push-artifacts-to-cdn` pipeline with three components:
 
 - **Component 1** (`push-artifacts-cdn-<uuid>`): releases 3 binary files (Windows, Linux, macOS)
   to both the **Customer Portal (Pulp/CDN)** and the **Content Gateway (CGW)**.
@@ -10,8 +10,13 @@ This test validates the `push-artifacts-to-cdn` pipeline with two components:
   to the **Content Gateway (CGW) only** (no Pulp push).
   It has a `contentGateway` section but no `staged` section in the RPA mapping.
 
-Auto-release is disabled. The test waits for both component builds to complete, then manually creates
-a Release against the multi-component Snapshot. After the release pipeline succeeds:
+- **Component 3** (`push-artifacts-cdn-comp3-<uuid>`): releases 1 disk-image file (QCOW2)
+  to both the **Customer Portal (Pulp/CDN)** and the **Content Gateway (CGW)**, using
+  `contentGateway.contentType: disk-image`. It has both a `staged` section (for Pulp) and a
+  `contentGateway` section in the RPA mapping.
+
+Auto-release is disabled. The test waits for all three component builds to complete, then manually
+creates a Release against the multi-component Snapshot. After the release pipeline succeeds:
 
 1. Asserts the `push-artifacts-to-cdn` TaskRun succeeded.
 2. Prints the current file list from the CGW staging API for this product/version.
@@ -23,7 +28,7 @@ In addition to the [common dependencies](../README.md#dependencies), this test r
 
 ### GitHub Repository Branches
 
-Two base branches must exist in `https://github.com/hacbs-release-tests/e2e-base`:
+Three base branches must exist in `https://github.com/hacbs-release-tests/e2e-base`:
 
 #### `push-artifacts-to-cdn-comp1-base`
 Contains a `Dockerfile` and 3 `.tar.gz` archives for Component 1 (Pulp + CGW).
@@ -43,9 +48,16 @@ Each archive wraps one **jq 1.6** binary from https://github.com/jqlang/jq/relea
 /releases/e2e-cdn-comp2-darwin-amd64.tar.gz   ← contains jq-osx-amd64 (Mach-O x86_64)
 ```
 
-> **Important**: The Windows and Mac binaries inside the archives must be real PE/Mach-O
-> executables because the pipeline extracts and submits them to production signing hosts.
-> The pipeline re-packages the output: Windows → `.zip`, Linux/macOS → `.tar.gz`.
+#### `push-artifacts-to-cdn-comp3-base`
+Contains a `Dockerfile` and one small QCOW2 disk image for Component 3 (Pulp + CGW):
+```
+/releases/e2e-cdn-comp3-rhel10-x86_64.qcow2  ← small QCOW2 image, os: linux only
+```
+Disk images are passed straight through the pipeline (no signing, no compression).
+
+> **Important**: The Windows and Mac binaries inside the comp1/comp2 archives must be real
+> PE/Mach-O executables because the pipeline extracts and submits them to production signing
+> hosts. The pipeline re-packages the output: Windows → `.zip`, Linux/macOS → `.tar.gz`.
 
 ### Required Secrets in `managed-release-team-tenant` (stg-rh01)
 
@@ -120,19 +132,21 @@ With debug (skip cleanup on failure):
 
 ## Test Workflow
 
-1. **GitHub Setup** — Creates component GitHub repos from the two base branches in e2e-base.
-2. **Konflux Onboarding** — Creates Application, 2 Components, ReleasePlan, and ReleasePlanAdmission.
-3. **Component Builds** — Waits for both components' Konflux build PipelineRuns to complete.
-   Each component builds a container image containing the test binary files.
-4. **Multi-Component Snapshot** — Waits for a Snapshot containing both components.
+1. **GitHub Setup** — Creates component GitHub repos from the three base branches in e2e-base.
+2. **Konflux Onboarding** — Creates Application, 3 Components, ReleasePlan, and ReleasePlanAdmission.
+3. **Component Builds** — Waits for all three components' Konflux build PipelineRuns to complete.
+   Each component builds a container image containing the test binary/disk-image files.
+4. **Multi-Component Snapshot** — Waits for a Snapshot containing all three components.
 5. **Manual Release** — Creates a Release CR against the multi-component Snapshot.
 6. **Pipeline Execution** — Monitors the `push-artifacts-to-cdn` managed pipeline:
    - `collect-data`, `reduce-snapshot`, `apply-mapping` run first.
    - `push-artifacts-to-cdn` (managed task) creates an InternalRequest.
    - InternalRequest triggers the internal pipeline on the internal services cluster.
-   - Internal pipeline: extracts binaries → pushes unsigned to Quay (ORAS) →
-     signs via Mac/Windows signing hosts → compresses → generates checksums →
-     pushes to Pulp (comp1 only) → pushes to CGW (both comps) → pushes checksum file to CGW.
+   - Internal pipeline: extracts binaries/disk-images → pushes unsigned to Quay (ORAS) →
+     signs binaries via Mac/Windows signing hosts (disk images pass through unsigned) →
+     compresses binaries (disk images pass through uncompressed) → generates checksums →
+     pushes to Pulp (comp1 and comp3) → pushes to CGW (all three comps) →
+     pushes checksum file to CGW.
 7. **Verification**:
    - Asserts the `push-artifacts-to-cdn` TaskRun succeeded.
    - Prints the current file list from the CGW staging API (informational).

--- a/integration-tests/push-artifacts-to-cdn/resources/managed/rpa.yaml
+++ b/integration-tests/push-artifacts-to-cdn/resources/managed/rpa.yaml
@@ -79,6 +79,33 @@ spec:
             productVersionName: "1.0"
             contentType: "binary"
           pushSourceContainer: false
+        # Component 3: releases a disk image file to BOTH Pulp AND CGW.
+        # contentGateway.contentType: disk-image drives the disk-image code path in
+        # extract_artifacts.py (pass-through, no compression) and push_unsigned.py.
+        # Disk images must always use os: linux — see _validate_disk_image_components.
+        - name: ${component3_name}
+          files:
+            # Path inside the container image (built from e2e-base
+            # push-artifacts-to-cdn-comp3-base branch).
+            - source: /releases/e2e-cdn-comp3-rhel10-x86_64.qcow2
+              arch: amd64
+              os: linux
+          contentGateway:
+            # Same CGW product as the other components.
+            productName: "Konflux Release E2E test product"
+            productCode: "KonfluxReleaseE2E"
+            productVersionName: "1.0"
+            contentType: "disk-image"
+          staged:
+            # Same Pulp repo as comp1 — disk images land alongside binaries in e2e testing.
+            destination: "konflux-release-e2e-1_DOT_0-for-rhel-10-x86_64-files"
+            version: "1.0"
+            files:
+              - source: /releases/e2e-cdn-comp3-rhel10-x86_64.qcow2
+                filename: "e2e-cdn-comp3-1.0-{{ release_timestamp }}-rhel10-x86_64.qcow2"
+                arch: amd64
+                os: linux
+          pushSourceContainer: false
     releaseNotes:
       product_id:
         - 10681

--- a/integration-tests/push-artifacts-to-cdn/resources/tenant/component3.yaml
+++ b/integration-tests/push-artifacts-to-cdn/resources/tenant/component3.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-oci-ta", "bundle": "latest"}'
+  name: ${component3_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component3_name}
+  secret: pipelines-as-code-secret-${component3_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component3_branch}
+      url: "${component3_git_url}"

--- a/integration-tests/push-artifacts-to-cdn/resources/tenant/kustomization.yaml
+++ b/integration-tests/push-artifacts-to-cdn/resources/tenant/kustomization.yaml
@@ -1,1 +1,14 @@
-../../../push-rpms-to-pulp/resources/tenant/kustomization.yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - component2.yaml
+  - component3.yaml
+  - sa.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/push-artifacts-to-cdn/test.env
+++ b/integration-tests/push-artifacts-to-cdn/test.env
@@ -41,6 +41,19 @@ export component2_git_url=https://github.com/${component2_repo_name}
 export component2_github_org=${component_github_org}
 export component2_type=${component_type}
 
+# Component 3: disk image (contentType: disk-image), pushed to both Pulp and CGW.
+# Base branch in e2e-base for component 3 (pushes to Pulp + CGW, same as component 1).
+# This branch must contain a Dockerfile and one disk image file:
+#   /releases/e2e-cdn-comp3-rhel10-x86_64.qcow2 (small QCOW2, os: linux only)
+export component3_name=${component_type}-comp3-${uuid}
+export component3_branch=${component3_name}
+export component3_base_branch=push-artifacts-to-cdn-comp3-base
+export component3_base_repo_name=${component_base_repo_name}
+export component3_repo_name=${component_repo_name}
+export component3_git_url=https://github.com/${component3_repo_name}
+export component3_github_org=${component_github_org}
+export component3_type=${component_type}
+
 export tenant_collector_sa_name=push-artifacts-cdn-rp-${uuid}
 export release_plan_name=push-artifacts-cdn-rp-${uuid}
 

--- a/integration-tests/push-artifacts-to-cdn/test.sh
+++ b/integration-tests/push-artifacts-to-cdn/test.sh
@@ -2,8 +2,8 @@
 # --- Global Script Variables (Defaults) ---
 CLEANUP="true"
 
-# Tell the framework to manage two components: component (Pulp+CGW) and component2 (CGW only).
-PTSV_COMPONENTS="component component2"
+# component (Pulp+CGW, binary), component2 (CGW only, binary), component3 (Pulp+CGW, disk-image).
+PTSV_COMPONENTS="component component2 component3"
 
 # --- Snapshot and Release Management ---
 

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -296,6 +296,7 @@ spec:
             value: tasks/managed/populate-release-notes/populate-release-notes.yaml
       runAfter:
         - verify-conforma
+        - collect-task-params
     - name: check-data-keys
       params:
         - name: dataPath
@@ -406,8 +407,8 @@ spec:
         - name: quayURL
           value: "$(params.quayURL)"
       runAfter:
-        - verify-conforma
         - embargo-check
+        - verify-conforma
     - name: create-advisory
       params:
         - name: releasePlanAdmissionPath

--- a/tasks/internal/create-advisory-task/README.md
+++ b/tasks/internal/create-advisory-task/README.md
@@ -17,6 +17,6 @@ request.
 | advisory_secret_name           | The name of the secret that contains the advisory creation metadata                                    | No       | -             |
 | errata_secret_name             | The name of the secret that contains the errata service account metadata                               | No       | -             |
 | internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |
-| contentType                    | The contentType of the release artifact. One of [image|binary|generic|rpm]                             | Yes      | image         |
+| contentType                    | The contentType of the release artifact. One of [image|binary|generic|rpm|disk-image]                  | Yes      | image         |
 | caTrustConfigMapName           | The name of the ConfigMap to read CA bundle data from                                                  | Yes      | trusted-ca    |
 | caTrustConfigMapKey            | The name of the key in the ConfigMap that contains the CA bundle data                                  | Yes      | ca-bundle.crt |

--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -40,7 +40,7 @@ spec:
       description: Name of the PipelineRun that called this task
     - name: contentType
       type: string
-      description: The contentType of the release artifact. One of [image|binary|generic|rpm]
+      description: The contentType of the release artifact. One of [image|binary|generic|rpm|disk-image]
       default: "image"
     - name: caTrustConfigMapName
       type: string

--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -179,7 +179,7 @@ spec:
 
   steps:
     - name: push-artifacts-to-cdn
-      image: quay.io/konflux-ci/release-service-utils@sha256:67bb57a671d7e1b8d51ee07cefcca4ac46db02b8c3a9ee8fad60fb9365aab324
+      image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
       securityContext:
         runAsUser: 1001
       computeResources:

--- a/tasks/managed/create-advisory/create-advisory.yaml
+++ b/tasks/managed/create-advisory/create-advisory.yaml
@@ -186,28 +186,24 @@ spec:
           exit 0
         fi
 
-        # Try to extract the first contentType if it exists
-        content_type=$(jq -r '.mapping.components[]? |
-          (.contentGateway?.contentType // .contentType) // empty' "$DATA_FILE" | head -n1)
+        # Check whether any component requires PURL updates (binary/generic/disk-image).
+        # A release can have mixed content types (e.g. binary + disk-image), so we look across
+        # all components rather than stopping at the first one.
+        has_checksum_content_type=$(jq -r '[.mapping.components[]? |
+          (.contentGateway?.contentType // .contentType) // empty] |
+          map(select(test("^(binary|generic|disk-image)$"))) | first // empty' "$DATA_FILE")
 
-        # If no contentType is found, check if this is a github release
-        if [ -z "$content_type" ]; then
+        if [ -z "${has_checksum_content_type}" ]; then
           github_field=$(jq -r '.github // empty' "$DATA_FILE")
           if [[ -n "$github_field" ]]; then
             echo "Github release. Skipping update-purl."
             exit 0
           fi
-          echo "Content type is not a generic artifact, skipping update-purl"
+          echo "No binary/generic/disk-image content type found, skipping update-purl"
           exit 0
         fi
 
-        # Only binary/generic/disk-image need PURL updates with checksums
-        if [[ ! "$content_type" =~ ^(binary|generic|disk-image)$ ]]; then
-          echo "Content type '$content_type'. Skipping update-purl."
-          exit 0
-        fi
-
-        echo "Processing $content_type artifacts for PURL updates..."
+        echo "Processing artifacts for PURL updates..."
 
         # If all artifacts already have real (non-placeholder) PURLs, skip update-purl entirely.
         # This handles content types (e.g. Python wheels) where PURLs are populated upstream
@@ -244,7 +240,7 @@ spec:
 
         if [ -z "$CHECKSUM_MAP_PARAM" ] || [ "$CHECKSUM_MAP_PARAM" = "null" ] \
             || [ "$CHECKSUM_MAP_PARAM" = "empty" ]; then
-          echo "Error: checksum map is required for content type '$content_type' but was not provided."
+          echo "Error: checksum map is required for content type '${has_checksum_content_type}' but was not provided."
           exit 1
         fi
 
@@ -283,6 +279,17 @@ spec:
 
         COMPONENTS=$(jq -c '.mapping.components[]' "$DATA_FILE")
 
+        # Build a name → staged.files lookup from the snapshot.  apply-mapping substitutes
+        # {{ release_timestamp }} (and other template vars) in the snapshot's components but
+        # does NOT write those substitutions back to the data file.  Reading staged.files from
+        # DATA_FILE would produce filenames like "foo-{{ release_timestamp }}-x86_64.iso" which
+        # Jinja2 would then render as empty, giving "foo--x86_64.iso" in the advisory.
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        SNAPSHOT_STAGED=$(jq -c \
+          'reduce .components[] as $c ({}; .[$c.name] = ($c.staged.files // []))' \
+          "$SNAPSHOT_FILE")
+
+        UPDATED_ENTRIES_DISK=()
         UPDATED_ENTRIES=()
 
         while IFS= read -r component; do
@@ -297,6 +304,17 @@ spec:
               continue
             fi
 
+            # Resolve content type per component so mixed releases (e.g. binary + disk-image)
+            # are each processed through the correct code path.
+            component_content_type=$(jq -r \
+              '(.contentGateway?.contentType // .contentType) // empty' <<< "$component")
+            # Default content type when not specified is "image" (container), which does not
+            # require PURL updates here. Skip components without a recognised PURL content type.
+            if [[ ! "${component_content_type}" =~ ^(binary|generic|disk-image)$ ]]; then
+              echo "Component ${COMPONENT_NAME} content type '${component_content_type}'. Skipping."
+              continue
+            fi
+
             # Get all advisory entries that match this component
             MATCHING_ENTRIES=$(jq -c --arg name "$COMPONENT_NAME" \
               '.releaseNotes.content.artifacts[] | select(.component == $name)' "$DATA_FILE")
@@ -306,29 +324,94 @@ spec:
               continue
             fi
 
-            while IFS= read -r entry; do
+            if [ "${component_content_type}" = "disk-image" ]; then
+              # For disk-images, generate one advisory entry per file in staged.files[].
+              # Multiple files can share the same os+arch (e.g. ISO + QCOW2 both linux/amd64),
+              # so iterating over advisory entries (one per os+arch) would produce malformed PURLs.
+              # Instead, use the first advisory entry as a metadata template and expand it per file.
+              TEMPLATE_ENTRY=$(echo "$MATCHING_ENTRIES" | head -1)
+              # When a component has both contentGateway (Developer Portal) and staged (Customer
+              # Portal/CDN), CGW is used as the canonical download_url in the PURL. If only
+              # staged is present, the CDN URL is used instead.
+              HAS_CGW=$(jq -r 'if ((.contentGateway // {}) | length) > 0 then "true" else "false" end' \
+                <<< "$component")
+              if [ "$HAS_CGW" = "true" ]; then
+                DOWNLOAD_URL="$CGW_BASE_URL"
+              else
+                DOWNLOAD_URL="$CDN_BASE_URL"
+              fi
+
+              # Fail loudly instead of silently leaving placeholder PURLs in place if the
+              # snapshot has no staged.files[] for this component (e.g. snapshot/mapping
+              # mismatch), since the loop below would otherwise just do nothing.
+              STAGED_FILE_COUNT=$(jq -r --arg name "$COMPONENT_NAME" \
+                '(.[$name] // []) | length' <<< "$SNAPSHOT_STAGED")
+              if [ "$STAGED_FILE_COUNT" -eq 0 ]; then
+                echo "Error: disk-image component ${COMPONENT_NAME} has releaseNotes.content.artifacts" \
+                  "entries but no staged.files[] in the snapshot" >&2
+                exit 1
+              fi
+
+              # Use process substitution so the loop body is never entered when jq returns
+              # no output (a here-string would feed one empty line and corrupt subsequent jq calls).
+              while IFS= read -r staged_file; do
+                FILENAME=$(jq -r '.filename // empty' <<< "$staged_file")
+                if [ -z "${FILENAME}" ] || [ "${FILENAME}" = "null" ]; then
+                  echo "Error: staged.files[].filename is required for disk-image" \
+                    "component ${COMPONENT_NAME}" >&2
+                  exit 1
+                fi
+                FILENAME_BASENAME=$(basename "$FILENAME")
+
+                # Derive arch from filename (same logic as populate-release-notes)
+                FILE_ARCH="unknown"
+                if [[ "$FILENAME_BASENAME" == *"aarch64"* ]]; then
+                  FILE_ARCH="aarch64"
+                elif [[ "$FILENAME_BASENAME" == *"x86_64"* ]]; then
+                  FILE_ARCH="x86_64"
+                fi
+                FILE_OS="linux"  # Default for disk images
+
+                CHECKSUM=$(jq -r --arg component "$COMPONENT_NAME" --arg filename "$FILENAME_BASENAME" \
+                  '.[] | select(.component == $component) | .files[$filename] // empty' \
+                  <<< "$CHECKSUM_MAP_JSON")
+                if [ -z "$CHECKSUM" ]; then
+                  echo "Warning: No checksum found for $COMPONENT_NAME/$FILENAME_BASENAME in manifest" >&2
+                fi
+
+                PURL="pkg:generic/$COMPONENT_NAME@$VERSION_NAME"
+                QUERY_PARAMS=()
+                # Add filename first - this uniquely identifies the file
+                if [ -n "$FILENAME_BASENAME" ]; then
+                  QUERY_PARAMS+=("filename=$FILENAME_BASENAME")
+                fi
+                if [ -n "$CHECKSUM" ]; then
+                  QUERY_PARAMS+=("checksum=$CHECKSUM")
+                fi
+                if [ -n "$DOWNLOAD_URL" ]; then
+                  QUERY_PARAMS+=("download_url=$DOWNLOAD_URL")
+                fi
+                if [ "${#QUERY_PARAMS[@]}" -gt 0 ]; then
+                  PURL="${PURL}?$(IFS=\&; echo "${QUERY_PARAMS[*]}")"
+                fi
+
+                UPDATED_ENTRY=$(jq -c \
+                  --arg purl "$PURL" --arg arch "$FILE_ARCH" --arg os "$FILE_OS" \
+                  '.purl = $purl | .architecture = $arch | .os = $os' <<< "$TEMPLATE_ENTRY")
+                UPDATED_ENTRIES_DISK+=("$UPDATED_ENTRY")
+              done < <(jq -c --arg name "$COMPONENT_NAME" '.[$name][]?' <<< "$SNAPSHOT_STAGED")
+            else
+              while IFS= read -r entry; do
                 ARCH=$(jq -r '.architecture' <<< "$entry")
                 OS=$(jq -r '.os' <<< "$entry")
 
-                if [ "$content_type" = "disk-image" ]; then
-                  # For disk-images, we need to match the filename from the populate-release-notes step
-                  # with the staged.files[].filename that has the same architecture
-                  FILENAME=$(jq -r --arg arch "$ARCH" \
-                    '.staged.files[] | select(.filename | contains($arch)) | .filename' <<< "$component")
-
-                  if [ -z "$FILENAME" ] || [ "$FILENAME" = "null" ]; then
-                    echo "Warning: No filename found for arch $ARCH in component $COMPONENT_NAME" >&2
-                    continue
-                  fi
-                else
-                  # Binary/generic files have arch/os matching, falling back to staged.files
-                  # for teams that use the CDN staged structure instead of a top-level files array
-                  FILENAME=$(jq -r --arg arch "$ARCH" --arg os "$OS" \
-                    '((.files // []) as $f
-                       | if ($f|length) > 0 then $f else (.staged.files // []) end)[]
-                       | select(.arch == $arch and .os == $os) | .source' \
-                    <<< "$component")
-                fi
+                # Binary/generic files have arch/os matching, falling back to staged.files
+                # for teams that use the CDN staged structure instead of a top-level files array
+                FILENAME=$(jq -r --arg arch "$ARCH" --arg os "$OS" \
+                  '((.files // []) as $f
+                     | if ($f|length) > 0 then $f else (.staged.files // []) end)[]
+                     | select(.arch == $arch and .os == $os) | .source' \
+                  <<< "$component")
 
                 FILENAME_BASENAME=$(basename "$FILENAME")
                 # Apply Windows archive conversion (.tar.gz -> .zip) when looking up checksum
@@ -336,17 +419,19 @@ spec:
                 if [ "$OS" = "windows" ] && [[ "$FILENAME_BASENAME" == *.tar.gz ]]; then
                   FILENAME_BASENAME="${FILENAME_BASENAME%.tar.gz}.zip"
                 fi
-                
+
                 CHECKSUM=$(jq -r --arg component "$COMPONENT_NAME" --arg filename "$FILENAME_BASENAME" \
-                  '.[] | select(.component == $component) | .files[$filename] // empty' <<< "$CHECKSUM_MAP_JSON")
+                  '.[] | select(.component == $component) | .files[$filename] // empty' \
+                  <<< "$CHECKSUM_MAP_JSON")
                 if [ -z "$CHECKSUM" ]; then
                   echo "Warning: No checksum found for $COMPONENT_NAME/$FILENAME_BASENAME in manifest" >&2
                 fi
 
-                # Determine download URL based on portal (using environment-aware base URLs)
-                # - If .contentGateway: Developer Portal (CGW)
-                # - If only .staged (no .contentGateway): Customer Portal (CDN)
-                HAS_CGW=$(jq -r '.contentGateway | length > 0' <<< "$component")
+                # When a component has both contentGateway (Developer Portal) and staged (Customer
+                # Portal/CDN), CGW is used as the canonical download_url in the PURL. If only
+                # staged is present, the CDN URL is used instead.
+                HAS_CGW=$(jq -r 'if ((.contentGateway // {}) | length) > 0 then "true" else "false" end' \
+                  <<< "$component")
                 if [ "$HAS_CGW" = "true" ]; then
                   DOWNLOAD_URL="$CGW_BASE_URL"
                 else
@@ -371,30 +456,55 @@ spec:
 
                 UPDATED_ENTRY=$(jq -c --arg purl "$PURL" '.purl = $purl' <<< "$entry")
                 UPDATED_ENTRIES+=("$UPDATED_ENTRY")
-            done <<< "$MATCHING_ENTRIES"
+              done <<< "$MATCHING_ENTRIES"
+            fi
 
         done <<< "$COMPONENTS"
 
-        # Merge updated advisory entries back into releaseNotes.content.artifacts in the DATA_FILE
-        # Also deduplicate entries by component|architecture|os to handle cases where
-        # multiple files have the same arch/os (e.g., binary + ISO for same arch)
-        if [ "${#UPDATED_ENTRIES[@]}" -eq 0 ]; then
+        if [ "${#UPDATED_ENTRIES_DISK[@]}" -eq 0 ] && [ "${#UPDATED_ENTRIES[@]}" -eq 0 ]; then
           echo "No advisory entries were updated."
           exit 0
         fi
 
-        ENTRIES_JOINED=$(IFS=,; echo "${UPDATED_ENTRIES[*]}")
-        UPDATED_MAP=$(jq -nc --argjson updated "[$ENTRIES_JOINED]" '
-          reduce $updated[] as $item ({}; . + {($item.component + "|" + $item.architecture + "|" + $item.os): $item})
-        ')
-        # Update entries AND deduplicate: convert to map (dedup by key), then back to array
-        jq --argjson updated "$UPDATED_MAP" '
-          .releaseNotes.content.artifacts |= (
-            map(($updated[(.component + "|" + .architecture + "|" + .os)] // .))
-            | reduce .[] as $item ({}; . + {($item.component + "|" + $item.architecture + "|" + $item.os): $item})
-            | [.[]]
-          )
-        ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
+        # Apply disk-image replacements: drop existing entries for updated components and
+        # substitute the new per-file expanded entries. Cannot deduplicate by component|arch|os
+        # because multiple files (e.g. ISO + QCOW2) legitimately share the same arch/os.
+        DISK_COMPONENTS_JSON="[]"
+        if [ "${#UPDATED_ENTRIES_DISK[@]}" -gt 0 ]; then
+          ENTRIES_JOINED_DISK=$(IFS=,; echo "${UPDATED_ENTRIES_DISK[*]}")
+          DISK_COMPONENTS_JSON=$(jq -c '[.[].component] | unique' <<< "[$ENTRIES_JOINED_DISK]")
+          jq --argjson updated "[$ENTRIES_JOINED_DISK]" '
+            ($updated | map(.component) | unique) as $updated_components |
+            .releaseNotes.content.artifacts |= (
+              map(select(.component | IN($updated_components[]) | not)) + $updated
+            )
+          ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
+        fi
+
+        # Merge binary/generic updated entries back into releaseNotes.content.artifacts.
+        # Deduplicate by component|architecture|os to handle cases where multiple files share the
+        # same arch/os (e.g. binary + ISO for same arch). Disk-image components are excluded from
+        # this pass (and re-appended untouched) because they were already correctly expanded above
+        # and can legitimately have multiple entries sharing the same component|architecture|os
+        # (e.g. ISO + QCOW2) -- deduplicating them here would drop all but one file's PURL/checksum.
+        if [ "${#UPDATED_ENTRIES[@]}" -gt 0 ]; then
+          ENTRIES_JOINED=$(IFS=,; echo "${UPDATED_ENTRIES[*]}")
+          UPDATED_MAP=$(jq -nc --argjson updated "[$ENTRIES_JOINED]" '
+            reduce $updated[] as $item ({}; . + {($item.component + "|" + $item.architecture + "|" + $item.os): $item})
+          ')
+          jq --argjson updated "$UPDATED_MAP" --argjson diskComponents "$DISK_COMPONENTS_JSON" '
+            (.releaseNotes.content.artifacts | map(select(.component | IN($diskComponents[])))) as $diskItems |
+            (.releaseNotes.content.artifacts | map(select(.component | IN($diskComponents[]) | not))) as $otherItems |
+            .releaseNotes.content.artifacts = (
+              (
+                $otherItems
+                | map(($updated[(.component + "|" + .architecture + "|" + .os)] // .))
+                | reduce .[] as $item ({}; . + {($item.component + "|" + $item.architecture + "|" + $item.os): $item})
+                | [.[]]
+              ) + $diskItems
+            )
+          ' "$DATA_FILE" > /tmp/data.tmp && mv /tmp/data.tmp "$DATA_FILE"
+        fi
     - name: run-script
       image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images-multi-file.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images-multi-file.yaml
@@ -2,11 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-advisory-disk-image-secrets
+  name: test-create-advisory-update-purl-disk-images-multi-file
 spec:
   description: |
-    Verify that for disk-image content types the task uses staging secrets when
-    intention is 'staging'.
+    Assert that the update-purl step generates one advisory artifact entry per staged file
+    for a disk-image component that has multiple files (e.g. ISO + QCOW2) under the same
+    os/architecture. This covers the case where a single component ships multiple disk image
+    formats, all for linux/x86_64, and each must receive its own correct PURL entry.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -56,7 +58,7 @@ spec:
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
-              set -eux
+              set -exo pipefail
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
 
@@ -69,45 +71,44 @@ spec:
                   "namespace": "default"
                 },
                 "spec": {
-                  "applications": ["rhel-ai-app"],
+                  "applications": ["test-app"],
                   "policy": "policy",
                   "pipeline": {
                     "pipelineRef": {
                       "resolver": "git",
                       "params": [
-                        {
-                          "name": "url",
-                          "value": "github.com"
-                        },
-                        {
-                          "name": "revision",
-                          "value": "main"
-                        },
-                        {
-                          "name": "pathInRepo",
-                          "value": "pipeline.yaml"
-                        }
+                        {"name": "url", "value": "github.com"},
+                        {"name": "revision", "value": "main"},
+                        {"name": "pathInRepo", "value": "pipeline.yaml"}
                       ]
                     }
                   },
-                  "serviceAccountName": "sa"
-                },
-                "origin": "rhel-ai-tenant"
+                  "serviceAccountName": "sa",
+                  "origin": "test-tenant"
+                }
               }
               EOF
 
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << 'EOF'
               {
-                "application": "rhel-ai-app",
+                "application": "test-app",
                 "components": [
                   {
-                    "name": "intel-bootc-iso-disk-image-1-5",
-                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image",
+                    "name": "multi-file-disk-image",
+                    "repository": "quay.io/test/multi-file-disk-image",
                     "staged": {
                       "files": [
                         {
-                          "filename": "rhel-ai-intel-1.5.1-1749643937-x86_64.iso.gz",
-                          "source": "install.iso.gz"
+                          "filename": "test-product-1.0.0-1234567890-x86_64-boot.iso.gz",
+                          "source": "/releases/install.iso.gz",
+                          "os": "linux",
+                          "arch": "amd64"
+                        },
+                        {
+                          "filename": "test-product-1.0.0-1234567890-x86_64-kvm.qcow2",
+                          "source": "/releases/disk.qcow2",
+                          "os": "linux",
+                          "arch": "amd64"
                         }
                       ]
                     }
@@ -116,28 +117,38 @@ spec:
               }
               EOF
 
+              # Single component with two staged.files[] entries — both linux/amd64.
+              # populate-release-notes emits one artifact entry (linux/x86_64); update-purl
+              # must expand it into two entries (one per file) with correct PURLs.
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "mapping": {
                   "components": [
                     {
-                      "name": "intel-bootc-iso-disk-image-1-5",
+                      "name": "multi-file-disk-image",
                       "staged": {
-                        "destination": "rhelai-1_DOT_5-for-rhel-9-x86_64-isos",
-                        "version": "1.5.1",
+                        "destination": "test-product-1_DOT_0-for-rhel-9-x86_64-files",
+                        "version": "1.0.0",
                         "files": [
                           {
-                            "filename": "rhel-ai-intel-1.5.1-1749643937-x86_64.iso.gz",
-                            "source": "install.iso.gz"
+                            "filename": "test-product-1.0.0-1234567890-x86_64-boot.iso.gz",
+                            "source": "/releases/install.iso.gz",
+                            "os": "linux",
+                            "arch": "amd64"
+                          },
+                          {
+                            "filename": "test-product-1.0.0-1234567890-x86_64-kvm.qcow2",
+                            "source": "/releases/disk.qcow2",
+                            "os": "linux",
+                            "arch": "amd64"
                           }
                         ]
                       },
                       "contentGateway": {
                         "contentType": "disk-image",
-                        "productName": "Binary_RL_Red Hat Enterprise Linux AI",
-                        "productCode": "RHELAI",
-                        "productVersionName": "1.5.1",
-                        "filePrefix": "rhel-ai-intel-1.5.1"
+                        "productCode": "TestProduct",
+                        "productName": "Test Product",
+                        "productVersionName": "1.0.0"
                       }
                     }
                   ]
@@ -147,30 +158,33 @@ spec:
                     "artifacts": [
                       {
                         "architecture": "x86_64",
-                        "component": "intel-bootc-iso-disk-image-1-5",
+                        "component": "multi-file-disk-image",
                         "os": "linux",
                         "purl": "placeholder"
                       }
                     ]
                   }
                 },
+                "cdn": {
+                  "env": "qa"
+                },
                 "sign": {
                   "configMapName": "cm"
-                },
-                "intention": "staging"
+                }
               }
               EOF
 
-              # Create checksum_map mock data file (will be read by oras mock)
               jq -nc '[
                 {
-                  "component": "intel-bootc-iso-disk-image-1-5",
+                  "component": "multi-file-disk-image",
                   "files": {
-                    "rhel-ai-intel-1.5.1-1749643937-x86_64.iso.gz": "sha256:dummychecksum123456"
+                    "test-product-1.0.0-1234567890-x86_64-boot.iso.gz":
+                      "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222",
+                    "test-product-1.0.0-1234567890-x86_64-kvm.qcow2":
+                      "sha256:1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff1111aaaa2222bbbb"
                   }
                 }
               ]' > "$(params.dataDir)/mock_checksum_map.json"
-              # Output mock OCI reference (oras mock will use the file above)
               echo -n "mock-registry/checksum-map@sha256:mock" | tee "$(results.checksum_map.path)"
           - name: create-trusted-artifact
             ref:
@@ -261,33 +275,50 @@ spec:
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
-              set -ex
+              set -exo pipefail
 
-              # Count the number of InternalRequests
-              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+              artifacts=$(jq -c '.releaseNotes.content.artifacts' "${DATA_FILE}")
 
-              if [ "$requestsCount" -ne 1 ]; then
-                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+              # Expect two artifact entries: one per staged file, both for the same component.
+              artifact_count=$(echo "${artifacts}" | jq 'length')
+              if [ "${artifact_count}" != "2" ]; then
+                echo "Expected 2 artifact entries (one per file), got ${artifact_count}"
+                echo "artifacts: ${artifacts}"
                 exit 1
               fi
 
-              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+              iso_checksum="sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222"
+              qcow2_checksum="sha256:1111aaaa2222bbbb3333cccc4444dddd5555eeee6666ffff1111aaaa2222bbbb"
+              cgw_base="https://developers.qa.redhat.com/products"
 
-              # For disk-image content types with intention=staging, expect standard staging secrets
-              advisory_secret_name=$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name')
-              if [ "$advisory_secret_name" != "create-advisory-stage-secret" ]; then
-                echo "InternalRequest has the wrong advisory_secret_name parameter"
-                echo "$internalRequest" | jq
+              iso_file="test-product-1.0.0-1234567890-x86_64-boot.iso.gz"
+              qcow2_file="test-product-1.0.0-1234567890-x86_64-kvm.qcow2"
+              base_purl="pkg:generic/multi-file-disk-image@1.0.0"
+
+              expectedIsoPurl="${base_purl}?filename=${iso_file}&checksum=${iso_checksum}&download_url=${cgw_base}"
+              expectedQcow2Purl="${base_purl}?filename=${qcow2_file}&checksum=${qcow2_checksum}&download_url=${cgw_base}"
+
+              isoFilter='.[] | select(.purl | contains("iso.gz")) | .purl'
+              isoPurl=$(echo "${artifacts}" | jq -r "${isoFilter}")
+              qcow2Filter='.[] | select(.purl | contains("qcow2")) | .purl'
+              qcow2Purl=$(echo "${artifacts}" | jq -r "${qcow2Filter}")
+
+              if [ "${isoPurl}" != "${expectedIsoPurl}" ]; then
+                echo "Unexpected PURL for iso disk-image"
+                echo "got:      ${isoPurl}"
+                echo "expected: ${expectedIsoPurl}"
                 exit 1
               fi
 
-              errata_secret_name=$(echo "$internalRequest" | jq -r '.spec.params.errata_secret_name')
-              if [ "$errata_secret_name" != "errata-stage-service-account" ]; then
-                echo "InternalRequest has the wrong errata_secret_name parameter"
-                echo "$internalRequest" | jq
+              if [ "${qcow2Purl}" != "${expectedQcow2Purl}" ]; then
+                echo "Unexpected PURL for qcow2 disk-image"
+                echo "got:      ${qcow2Purl}"
+                echo "expected: ${expectedQcow2Purl}"
                 exit 1
               fi
 
+              echo "All checks passed: two per-file advisory entries with correct PURLs"
   finally:
     - name: cleanup
       taskSpec:
@@ -296,6 +327,6 @@ spec:
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
             script: |
               #!/usr/bin/env bash
-              set -eux
+              set -exo pipefail
 
               kubectl delete internalrequests --all

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-disk-images.yaml
@@ -102,11 +102,27 @@ spec:
                 "components": [
                   {
                     "name": "intel-bootc-iso-disk-image-1-5",
-                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image"
+                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image",
+                    "staged": {
+                      "files": [
+                        {
+                          "filename": "rhel-ai-intel-1.5.1-1749643937-x86_64.iso.gz",
+                          "source": "install.iso.gz"
+                        }
+                      ]
+                    }
                   },
                   {
                     "name": "intel-bootc-qcow2-disk-image-1-5",
-                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image"
+                    "repository": "quay.io/redhat-prod/rhel-ai----disk-image",
+                    "staged": {
+                      "files": [
+                        {
+                          "filename": "rhel-ai-intel-1.5.1-1749643939-x86_64-kvm.qcow2",
+                          "source": "disk.qcow2"
+                        }
+                      ]
+                    }
                   }
                 ]
               }

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-mixed-cgw.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-mixed-cgw.yaml
@@ -136,7 +136,8 @@ spec:
                             "arch": "amd64",
                             "os": "windows"
                           }
-                        ]
+                        ],
+                        "contentType": "binary"
                       },
                       {
                         "name": "cli-tool-b",

--- a/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-mixed-content-types.yaml
+++ b/tasks/managed/create-advisory/tests/test-create-advisory-update-purl-mixed-content-types.yaml
@@ -2,11 +2,16 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-create-advisory-disk-image-secrets
+  name: test-create-advisory-update-purl-mixed-content-types
 spec:
   description: |
-    Verify that for disk-image content types the task uses staging secrets when
-    intention is 'staging'.
+    Assert that update-purl correctly routes mixed content-type releases where one
+    component is disk-image and another is binary. Prior to this fix a single global
+    content_type was sampled from the first component, so in a mixed release the
+    second component's type was ignored and both went through the same (wrong) code path.
+    This test verifies that each component is independently routed to the correct path:
+    - disk-image: iterates snapshot staged.files, derives arch from filename, replace write-back
+    - binary: iterates advisory entries, looks up file by arch/os, map-merge write-back
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -69,76 +74,91 @@ spec:
                   "namespace": "default"
                 },
                 "spec": {
-                  "applications": ["rhel-ai-app"],
+                  "applications": ["mixed-app"],
                   "policy": "policy",
                   "pipeline": {
                     "pipelineRef": {
                       "resolver": "git",
                       "params": [
-                        {
-                          "name": "url",
-                          "value": "github.com"
-                        },
-                        {
-                          "name": "revision",
-                          "value": "main"
-                        },
-                        {
-                          "name": "pathInRepo",
-                          "value": "pipeline.yaml"
-                        }
+                        {"name": "url", "value": "github.com"},
+                        {"name": "revision", "value": "main"},
+                        {"name": "pathInRepo", "value": "pipeline.yaml"}
                       ]
-                    }
+                    },
+                    "serviceAccountName": "sa"
                   },
-                  "serviceAccountName": "sa"
-                },
-                "origin": "rhel-ai-tenant"
+                  "origin": "mixed-tenant"
+                }
               }
               EOF
 
+              # Snapshot: disk-image component needs staged.files for SNAPSHOT_STAGED lookup;
+              # binary component does not use snapshot staged files in update-purl.
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" << 'EOF'
               {
-                "application": "rhel-ai-app",
+                "application": "mixed-app",
                 "components": [
                   {
-                    "name": "intel-bootc-iso-disk-image-1-5",
+                    "name": "rhel-ai-iso-disk-image",
                     "repository": "quay.io/redhat-prod/rhel-ai----disk-image",
                     "staged": {
                       "files": [
                         {
-                          "filename": "rhel-ai-intel-1.5.1-1749643937-x86_64.iso.gz",
+                          "filename": "rhel-ai-1.5.0-20250115-x86_64.iso.gz",
                           "source": "install.iso.gz"
                         }
                       ]
                     }
+                  },
+                  {
+                    "name": "cli-tool",
+                    "repository": "quay.io/redhat-prod/cli-tool"
                   }
                 ]
               }
               EOF
 
+              # Data file: disk-image component has contentGateway (CGW download_url);
+              # binary component has no contentGateway (CDN download_url).
               cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
               {
                 "mapping": {
                   "components": [
                     {
-                      "name": "intel-bootc-iso-disk-image-1-5",
+                      "name": "rhel-ai-iso-disk-image",
                       "staged": {
                         "destination": "rhelai-1_DOT_5-for-rhel-9-x86_64-isos",
-                        "version": "1.5.1",
+                        "version": "1.5.0",
                         "files": [
                           {
-                            "filename": "rhel-ai-intel-1.5.1-1749643937-x86_64.iso.gz",
+                            "filename": "rhel-ai-1.5.0-20250115-x86_64.iso.gz",
                             "source": "install.iso.gz"
                           }
                         ]
                       },
                       "contentGateway": {
                         "contentType": "disk-image",
-                        "productName": "Binary_RL_Red Hat Enterprise Linux AI",
+                        "productName": "Red Hat Enterprise Linux AI",
                         "productCode": "RHELAI",
-                        "productVersionName": "1.5.1",
-                        "filePrefix": "rhel-ai-intel-1.5.1"
+                        "productVersionName": "1.5.0",
+                        "filePrefix": "rhel-ai-1.5.0"
                       }
+                    },
+                    {
+                      "name": "cli-tool",
+                      "staged": {
+                        "destination": "cli-tool-destination",
+                        "version": "2.1.0"
+                      },
+                      "contentType": "binary",
+                      "files": [
+                        {
+                          "filename": "cli-tool-linux",
+                          "source": "cli-tool-linux-amd64.tar.gz",
+                          "arch": "amd64",
+                          "os": "linux"
+                        }
+                      ]
                     }
                   ]
                 },
@@ -147,7 +167,13 @@ spec:
                     "artifacts": [
                       {
                         "architecture": "x86_64",
-                        "component": "intel-bootc-iso-disk-image-1-5",
+                        "component": "rhel-ai-iso-disk-image",
+                        "os": "linux",
+                        "purl": "placeholder"
+                      },
+                      {
+                        "architecture": "amd64",
+                        "component": "cli-tool",
                         "os": "linux",
                         "purl": "placeholder"
                       }
@@ -156,21 +182,26 @@ spec:
                 },
                 "sign": {
                   "configMapName": "cm"
-                },
-                "intention": "staging"
+                }
               }
               EOF
 
-              # Create checksum_map mock data file (will be read by oras mock)
               jq -nc '[
                 {
-                  "component": "intel-bootc-iso-disk-image-1-5",
+                  "component": "rhel-ai-iso-disk-image",
                   "files": {
-                    "rhel-ai-intel-1.5.1-1749643937-x86_64.iso.gz": "sha256:dummychecksum123456"
+                    "rhel-ai-1.5.0-20250115-x86_64.iso.gz":
+                      "sha256:d1sk1ma9ec0a1234567890abcdef1234567890abcdef1234567890abcdef1234"
+                  }
+                },
+                {
+                  "component": "cli-tool",
+                  "files": {
+                    "cli-tool-linux-amd64.tar.gz":
+                      "sha256:b1nar7c0a1234567890abcdef1234567890abcdef1234567890abcdef12345678"
                   }
                 }
               ]' > "$(params.dataDir)/mock_checksum_map.json"
-              # Output mock OCI reference (oras mock will use the file above)
               echo -n "mock-registry/checksum-map@sha256:mock" | tee "$(results.checksum_map.path)"
           - name: create-trusted-artifact
             ref:
@@ -263,31 +294,67 @@ spec:
               #!/usr/bin/env bash
               set -ex
 
-              # Count the number of InternalRequests
-              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+              DATA_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+              artifacts=$(jq -c '.releaseNotes.content.artifacts' "$DATA_FILE")
 
-              if [ "$requestsCount" -ne 1 ]; then
-                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+              # Exactly 2 artifacts — one per component. The disk-image replace write-back must
+              # not collapse entries and the binary map-merge must not duplicate entries.
+              artifactCount=$(echo "$artifacts" | jq 'length')
+              if [ "$artifactCount" -ne 2 ]; then
+                echo "Expected 2 artifacts, got $artifactCount"
+                echo "$artifacts" | jq
                 exit 1
               fi
 
-              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+              # disk-image: has contentGateway → CGW download URL; arch derived from filename
+              diskImageBase="pkg:generic/rhel-ai-iso-disk-image@1.5.0"
+              diskImageQuery="filename=rhel-ai-1.5.0-20250115-x86_64.iso.gz"
+              diskImageQuery="${diskImageQuery}&checksum=sha256:d1sk1ma9ec0a1234567890abcdef1234567890abcdef1234567890abcdef1234"
+              diskImageQuery="${diskImageQuery}&download_url=https://developers.redhat.com/products"
+              expectedDiskImagePurl="${diskImageBase}?${diskImageQuery}"
 
-              # For disk-image content types with intention=staging, expect standard staging secrets
-              advisory_secret_name=$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name')
-              if [ "$advisory_secret_name" != "create-advisory-stage-secret" ]; then
-                echo "InternalRequest has the wrong advisory_secret_name parameter"
-                echo "$internalRequest" | jq
+              # binary: no contentGateway → CDN download URL
+              binaryBase="pkg:generic/cli-tool@2.1.0"
+              binaryQuery="filename=cli-tool-linux-amd64.tar.gz"
+              binaryQuery="${binaryQuery}&checksum=sha256:b1nar7c0a1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+              binaryQuery="${binaryQuery}&download_url=https://access.redhat.com/downloads"
+              expectedBinaryPurl="${binaryBase}?${binaryQuery}"
+
+              diskImagePurl=$(echo "$artifacts" | \
+                jq -r '.[] | select(.component == "rhel-ai-iso-disk-image") | .purl')
+              binaryPurl=$(echo "$artifacts" | \
+                jq -r '.[] | select(.component == "cli-tool") | .purl')
+
+              echo "Disk-image PURL: $diskImagePurl"
+              echo "Binary PURL:     $binaryPurl"
+
+              if [ "$diskImagePurl" != "$expectedDiskImagePurl" ]; then
+                echo "Unexpected disk-image PURL"
+                echo "Expected: $expectedDiskImagePurl"
+                echo "Got:      $diskImagePurl"
                 exit 1
               fi
 
-              errata_secret_name=$(echo "$internalRequest" | jq -r '.spec.params.errata_secret_name')
-              if [ "$errata_secret_name" != "errata-stage-service-account" ]; then
-                echo "InternalRequest has the wrong errata_secret_name parameter"
-                echo "$internalRequest" | jq
+              if [ "$binaryPurl" != "$expectedBinaryPurl" ]; then
+                echo "Unexpected binary PURL"
+                echo "Expected: $expectedBinaryPurl"
+                echo "Got:      $binaryPurl"
                 exit 1
               fi
 
+              # Verify disk-image arch was derived from filename (x86_64), not inherited
+              diskImageArch=$(echo "$artifacts" | \
+                jq -r '.[] | select(.component == "rhel-ai-iso-disk-image") | .architecture')
+              if [ "$diskImageArch" != "x86_64" ]; then
+                echo "Expected disk-image architecture x86_64, got $diskImageArch"
+                exit 1
+              fi
+
+              echo "All assertions passed"
+              echo "✓ disk-image routed through per-file staged.files path (CGW download URL)"
+              echo "✓ binary routed through per-advisory-entry path (CDN download URL)"
+              echo "✓ both components got correct checksums from checksum_map"
+              echo "✓ artifact count correct — no collapse or duplication"
   finally:
     - name: cleanup
       taskSpec:

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -132,7 +132,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils@sha256:67bb57a671d7e1b8d51ee07cefcca4ac46db02b8c3a9ee8fad60fb9365aab324
+      image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
       computeResources:
         limits:
           memory: 512Mi


### PR DESCRIPTION
    - push-artifacts-to-cdn pipeline: update release-service-utils
      image from utils PR 833
    - create-advisory-task: add disk-image to contentType allowlist,
      routing it to .content.artifacts
    - create-advisory: fix PURL generation for disk images - generate
      one entry per staged file instead of per os+arch advisory entry
    - create-advisory: fix dedup for disk-image artifacts - replace
      entries rather than map-merge to retain multiple files per
      component

Will be merged with
http://github.com/konflux-ci/release-service-utils/pull/833
    
    Assisted-by: Cursor AI


## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
