### PR TITLE
fix: narrow duplicate MR search scope in process-file-updates

### DIFF
--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -293,7 +293,8 @@ spec:
         page=1
         openMRList=""
         while true; do
-            mrPage=$(glab mr list -R "${UPSTREAM_REPO}" --search "Konflux release" \
+            mrPage=$(glab mr list -R "${UPSTREAM_REPO}" \
+                --search "[Konflux release] $(params.componentGroup)" \
                 --per-page 100 --page $page | grep "^!" || true)
             # add "$mrPage" == '' check for unit testing
             if [ -z "$mrPage" ] || [ "$mrPage" == '' ] ; then

--- a/tasks/internal/process-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/process-file-updates-task/tests/mocks.sh
@@ -42,7 +42,10 @@ function glab() {
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
     echo "https://some.gitlab/test/one-update.git/-/merge_request/1"
   elif [[ "$*" == *"mr list"* ]]; then
-    if [[ "$*" == *"page 1" ]] && [[ "${gitRepo}" == "replace-idempotent" ]]; then
+    # Search must be scoped by componentGroup (e.g. "[Konflux release] <componentGroup>"),
+    # not the broad "Konflux release" that matches all open MRs
+    if [[ "$*" == *"page 1" ]] && [[ "${gitRepo}" == "replace-idempotent" ]] \
+        && [[ "$*" == *"[Konflux release]"* ]]; then
       	echo '!1'
     else
       echo ''


### PR DESCRIPTION
## Describe your changes
The duplicate MR detection was searching all open MRs matching "Konflux release", causing git protocol errors when the repo accumulated 4000+ MRs. Narrow the search to include the specific componentGroup. 

Assisted-by: Claude Code

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
