### PR TITLE
Add embargo-check task to push-disk-images-to-cdn pipeline

### DIFF
--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -176,7 +176,8 @@ spec:
         - name: keysToExtract
           value: |
             [
-              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"}
+              {"resultIndex": 0, "key": ".conforma.workerCount", "default": "4"},
+              {"resultIndex": 1, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"}
             ]
         - name: taskGitUrl
           value: "$(params.taskGitUrl)"
@@ -289,6 +290,69 @@ spec:
         resolver: git
       runAfter:
         - apply-mapping
+    - name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.check-data-keys.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: jiraSecretName
+          value: "$(tasks.collect-task-params.results.extractedValues[1])"
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/populate-release-notes/populate-release-notes.yaml
+        resolver: git
+      runAfter:
+        - check-data-keys
+        - collect-task-params
+    - name: embargo-check
+      params:
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.populate-release-notes.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: jiraSecretName
+          value: "$(tasks.collect-task-params.results.extractedValues[1])"
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+      taskRef:
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/embargo-check/embargo-check.yaml
+        resolver: git
+      runAfter:
+        - populate-release-notes
     - name: push-disk-images
       retries: 3
       timeout: "5h00m0s"
@@ -317,7 +381,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.check-data-keys.results.sourceDataArtifact)"
+          value: "$(tasks.embargo-check.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -327,7 +391,7 @@ spec:
         - name: taskGitRevision
           value: $(params.taskGitRevision)
       runAfter:
-        - check-data-keys
+        - embargo-check
         - verify-conforma
     - name: update-cr-status
       params:


### PR DESCRIPTION
## Summary

- Add the `embargo-check` task to the `push-disk-images-to-cdn` pipeline, matching what `rh-advisories` already has
- Without this check, releases with embargoed CVEs in the release notes can be pushed to CDN without being caught
- The task runs after `check-data-keys` and before `push-disk-images`, gating artifact distribution on CVE embargo validation

## Changes

- Added `jiraAdvisorySecret` extraction to `collect-task-params`
- Added `embargo-check` task between `check-data-keys` and `push-disk-images`
- Updated `push-disk-images` to chain `sourceDataArtifact` from `embargo-check`

Signed-off-by: Jose Angel Morena <jmorenas@redhat.com>