### PR TITLE
DO NOT MERGE: test opm render with utils PR #838 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+FROM quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-3d034906778d1d196c81e16cf9b78b77a9217a35
 
 ARG TKN_VERSION=0.40.0
 ARG KUSTOMIZE_VERSION=5.6.0

--- a/integration-tests/scripts/opm-render-cached.sh
+++ b/integration-tests/scripts/opm-render-cached.sh
@@ -89,8 +89,28 @@ opm_render_cached() {
     fi
 
     echo "  Rendering: ${image_ref}..." >&2
-    if ! opm render "${image_ref}" > "${cache_file}" 2>&1; then
-        echo "🔴 opm render failed for: ${image_ref}" >&2
+    echo "  DEBUG: opm path=$(command -v opm) version=$(opm version 2>&1 | head -1)" >&2
+    echo "  DEBUG: DOCKER_CONFIG=${DOCKER_CONFIG:-unset}" >&2
+    echo "  DEBUG: cache_file=${cache_file}" >&2
+    if [ -n "${DOCKER_CONFIG:-}" ] && [ -f "${DOCKER_CONFIG}/config.json" ]; then
+        echo "  DEBUG: config.json exists ($(wc -c < "${DOCKER_CONFIG}/config.json") bytes)" >&2
+    else
+        echo "  DEBUG: config.json NOT found at ${DOCKER_CONFIG:-unset}/config.json" >&2
+    fi
+
+    opm render "${image_ref}" > "${cache_file}" 2>&1
+    local opm_exit=$?
+
+    if [ $opm_exit -ne 0 ]; then
+        echo "🔴 opm render failed for: ${image_ref} (exit code: ${opm_exit})" >&2
+        if [ $opm_exit -gt 128 ]; then
+            echo "  Killed by signal: $((opm_exit - 128)) (e.g. 9=SIGKILL/OOM, 11=SIGSEGV)" >&2
+        fi
+        local file_size=0
+        if [ -f "${cache_file}" ]; then
+            file_size=$(wc -c < "${cache_file}")
+        fi
+        echo "  Cache file size: ${file_size} bytes" >&2
         echo "  Error (first 10 lines):" >&2
         head -10 "${cache_file}" | sed 's/^/    /' >&2
         rm -f "${cache_file}"

--- a/integration-tests/scripts/verify-fbc-index-content.sh
+++ b/integration-tests/scripts/verify-fbc-index-content.sh
@@ -29,6 +29,15 @@ echo "🔍 Verifying published FBC index content"
 echo "  target_index:  ${target_index}"
 echo "  fbc_fragment:  ${fbc_fragment}"
 echo "  cache_dir:     ${OPM_CACHE_DIR}"
+echo "  DEBUG: hostname=$(hostname 2>/dev/null || echo unknown)"
+echo "  DEBUG: uname=$(uname -m 2>/dev/null || echo unknown)"
+echo "  DEBUG: opm=$(command -v opm 2>/dev/null || echo 'NOT FOUND')"
+if command -v opm &>/dev/null; then
+    echo "  DEBUG: opm version=$(opm version 2>&1 | head -1)"
+    echo "  DEBUG: opm file type=$(file "$(command -v opm)" 2>/dev/null | head -1)"
+fi
+echo "  DEBUG: policy.json exists=$(test -f /etc/containers/policy.json && echo YES || echo NO)"
+echo "  DEBUG: memory=$(cat /proc/meminfo 2>/dev/null | grep MemAvailable | head -1 || echo 'N/A')"
 
 setup_registry_auth "${managed_secrets_yaml}" || {
     echo "🔴 Cannot set up registry credentials — unable to verify published index"


### PR DESCRIPTION
## Summary

**DO NOT MERGE — experiment only.**

This draft PR reproduces the `opm render` silent failure observed in the `release-service-utils` FBC e2e test ([PR #838](https://github.com/konflux-ci/release-service-utils/pull/838)).

### What this does

- **Dockerfile**: Swaps the base utils image to the one built from utils PR #838 (`on-pr-3d034906778d1d196c81e16cf9b78b77a9217a35`) so the e2e test runner uses the same opm binary that failed
- **opm-render-cached.sh**: Adds enhanced diagnostics — exit code, signal info (OOM/SIGSEGV detection), opm version, auth config state, cache file size
- **verify-fbc-index-content.sh**: Adds environment diagnostics — hostname, architecture, opm binary type, policy.json presence, available memory

### Why

The utils FBC e2e failed with `opm render` producing **zero output** (empty error). We could not reproduce locally — opm v1.50.0 always produces proper error messages in every scenario we tested. This PR aims to capture the exact failure conditions in the e2e environment.

### Expected outcome

If the FBC e2e fails again, the enhanced logs will tell us:
- Whether opm was killed by a signal (OOM/segfault) vs exited normally
- The exact opm version and binary type in use
- Whether auth credentials were properly configured
- Available memory at the time of failure

Made with [Cursor](https://cursor.com)