### PR TITLE
test: fix YAML quoting for auto-release labels in fbc-release test

### DIFF
--- a/integration-tests/fbc-release/resources/tenant/rp.yaml
+++ b/integration-tests/fbc-release/resources/tenant/rp.yaml
@@ -3,7 +3,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: "${release_plan_happy_auto_release}"
+    release.appstudio.openshift.io/auto-release: ${release_plan_happy_auto_release}
     release.appstudio.openshift.io/standing-attribution: 'true'
     release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_happy_name}"
     originating-tool: "${originating_tool}"
@@ -16,7 +16,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: "${release_plan_hotfix_auto_release}"
+    release.appstudio.openshift.io/auto-release: ${release_plan_hotfix_auto_release}
     release.appstudio.openshift.io/standing-attribution: 'true'
     release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_hotfix_name}"
     originating-tool: "${originating_tool}"
@@ -29,7 +29,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: "${release_plan_prega_auto_release}"
+    release.appstudio.openshift.io/auto-release: ${release_plan_prega_auto_release}
     release.appstudio.openshift.io/standing-attribution: 'true'
     release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_prega_name}"
     originating-tool: "${originating_tool}"
@@ -42,7 +42,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: "${release_plan_staged_auto_release}"
+    release.appstudio.openshift.io/auto-release: ${release_plan_staged_auto_release}
     release.appstudio.openshift.io/standing-attribution: 'true'
     release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_staged_name}"
     originating-tool: "${originating_tool}"
@@ -55,7 +55,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: "${release_plan_optin_auto_release}"
+    release.appstudio.openshift.io/auto-release: ${release_plan_optin_auto_release}
     release.appstudio.openshift.io/standing-attribution: 'true'
     release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_optin_name}"
     originating-tool: "${originating_tool}"
@@ -68,7 +68,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: "${release_plan_multi_optin_auto_release}"
+    release.appstudio.openshift.io/auto-release: ${release_plan_multi_optin_auto_release}
     release.appstudio.openshift.io/standing-attribution: 'true'
     release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_multi_optin_name}"
     originating-tool: "${originating_tool}"

--- a/integration-tests/fbc-release/test.env
+++ b/integration-tests/fbc-release/test.env
@@ -87,11 +87,11 @@ export release_plan_admission_optin_name=fbc-release-optin-rpa-${uuid}
 export release_plan_admission_multi_optin_name=fbc-release-multi-optin-rpa-${uuid}
 
 # All ReleasePlans set to manual triggering
-export release_plan_happy_auto_release=\"false\"
-export release_plan_hotfix_auto_release=\"false\"
-export release_plan_prega_auto_release=\"false\"
-export release_plan_staged_auto_release=\"false\"
-export release_plan_optin_auto_release=\"false\"
-export release_plan_multi_optin_auto_release=\"false\"
+export release_plan_happy_auto_release='"false"'
+export release_plan_hotfix_auto_release='"false"'
+export release_plan_prega_auto_release='"false"'
+export release_plan_staged_auto_release='"false"'
+export release_plan_optin_auto_release='"false"'
+export release_plan_multi_optin_auto_release='"false"'
 
 export PTSV_COMPONENTS="component component2 optin_component optin_component_1 optin_component_2"


### PR DESCRIPTION
## Describe your changes

Fix invalid YAML generation for `auto-release` labels in fbc-release
ReleasePlan resources that caused `kubectl create` to fail with
"cannot unmarshal bool into Go struct field" errors.

The combination of escaped quotes in `test.env` and quoted variables in
`rp.yaml` produced invalid YAML after `envsubst` substitution.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
