### PR TITLE
test(RELEASE-2315): add missing component2 resource

### DIFF
--- a/integration-tests/push-to-external-registry-idempotent/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-external-registry-idempotent/resources/managed/rpa.yaml
@@ -23,6 +23,13 @@ spec:
             - url: quay.io/hacbs-release-tests/${component_name}
               tags:
                 - '{{ git_short_sha }}'
+        - name: ${component2_name}
+          componentTags:
+            - 'latest'
+          repositories:
+            - url: quay.io/hacbs-release-tests/${component2_name}
+              tags:
+                - '{{ git_short_sha }}'
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/integration-tests/push-to-external-registry-idempotent/resources/tenant/component2.yaml
+++ b/integration-tests/push-to-external-registry-idempotent/resources/tenant/component2.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '${PTSV_BUILD_PIPELINE_VALUE}'
+  name: ${component2_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component2_name}
+  secret: pipelines-as-code-secret-${component_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component2_branch}
+      url: "${component2_git_url}"

--- a/integration-tests/push-to-external-registry-idempotent/resources/tenant/kustomization.yaml
+++ b/integration-tests/push-to-external-registry-idempotent/resources/tenant/kustomization.yaml
@@ -1,1 +1,12 @@
-../../../push-to-external-registry/resources/tenant/kustomization.yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${tenant_namespace}
+resources:
+  - application.yaml
+  - component.yaml
+  - component2.yaml
+  - sa-rolebinding.yaml
+  - rp.yaml
+  - secrets/tenant-secrets.yaml

--- a/integration-tests/push-to-external-registry-idempotent/test.sh
+++ b/integration-tests/push-to-external-registry-idempotent/test.sh
@@ -22,64 +22,84 @@ were_all_components_filtered() {
     is_task_skipped "${release_name}" "push-snapshot"
 }
 
-# Verify a single release has valid artifacts and image can be pulled
+# Verify a release has valid artifacts for all components and images can be pulled
 verify_single_release() {
     local release_name=$1
     echo "Verifying Release contents for ${release_name}..."
 
     local release_json
     release_json=$(get_release_json "${release_name}")
-    if [ -z "$release_json" ]; then
+    if [ -z "${release_json}" ]; then
         log_error "Could not retrieve Release JSON for ${release_name}"
     fi
 
     local failures=0
-    local image_url image_arch image_shasum
+    local expected_count
+    expected_count=$(echo "${PTSV_COMPONENTS}" | wc -w)
 
-    image_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
-    image_arch=$(jq -r '.status.artifacts.images[0]?.arches[0] // ""' <<< "${release_json}")
-    image_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
+    local image_count
+    image_count=$(jq -r '.status.artifacts.images | length' <<< "${release_json}")
 
-    echo "Checking Image URL..."
-    if [ -n "${image_url}" ]; then
-        echo "✅️ image_url: ${image_url}"
+    echo "Checking image count (expected ${expected_count} components)..."
+    if [ "${image_count}" -ge "${expected_count}" ]; then
+        echo "✅️ Found ${image_count} image entries (expected at least ${expected_count})"
     else
-        echo "🔴 image_url was empty"
+        echo "🔴 Found only ${image_count} image entries, expected at least ${expected_count}"
         failures=$((failures+1))
     fi
 
-    echo "Checking Image Arch..."
-    if [ -n "${image_arch}" ]; then
-        echo "✅️ image_arch: ${image_arch}"
-    else
-        echo "🔴 image_arch was empty"
-        failures=$((failures+1))
-    fi
+    echo ""
+    echo "Verifying each image artifact..."
+    for ((i = 0; i < image_count; i++)); do
+        local image_url image_arch image_shasum
+        image_url=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.urls[0] // ""' <<< "${release_json}")
+        image_arch=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.arches[0] // ""' <<< "${release_json}")
+        image_shasum=$(jq -r --argjson idx "${i}" '.status.artifacts.images[$idx]?.shasum // ""' <<< "${release_json}")
 
-    echo "Checking Image Shasum..."
-    if [ -n "${image_shasum}" ]; then
-        echo "✅️ image_shasum: ${image_shasum}"
-    else
-        echo "🔴 image_shasum was empty"
-        failures=$((failures+1))
-    fi
+        echo "Image ${i}:"
+        if [ -n "${image_url}" ]; then
+            echo "  ✅️ url: ${image_url}"
+        else
+            echo "  🔴 url was empty"
+            failures=$((failures+1))
+        fi
 
-    echo "Verifying image pullability with skopeo..."
-    set +e
-    "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
-        "${image_url}" "${image_shasum}" \
-        "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
-    skopeo_return_code=$?
-    set -e
-    if [ "${skopeo_return_code}" -ne 0 ]; then
-        failures=$((failures+1))
-    fi
+        if [ -n "${image_arch}" ]; then
+            echo "  ✅️ arch: ${image_arch}"
+        else
+            echo "  🔴 arch was empty"
+            failures=$((failures+1))
+        fi
+
+        if [ -n "${image_shasum}" ]; then
+            echo "  ✅️ shasum: ${image_shasum}"
+        else
+            echo "  🔴 shasum was empty"
+            failures=$((failures+1))
+        fi
+
+        if [ -n "${image_url}" ] && [ -n "${image_shasum}" ]; then
+            echo "  Verifying image pullability with skopeo..."
+            set +e
+            "${SUITE_DIR}/../scripts/skopeo-verify-image.sh" \
+                "${image_url}" "${image_shasum}" \
+                "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+            local skopeo_return_code=$?
+            set -e
+            if [ "${skopeo_return_code}" -ne 0 ]; then
+                echo "  🔴 skopeo verification failed"
+                failures=$((failures+1))
+            else
+                echo "  ✅️ image is pullable"
+            fi
+        fi
+    done
 
     if [ "${failures}" -gt 0 ]; then
         echo "🔴 Release verification FAILED with ${failures} failure(s)!"
         return 1
     else
-        echo "✅️ All release checks passed."
+        echo "✅️ All release checks passed for ${image_count} image(s)."
         return 0
     fi
 }
@@ -166,28 +186,38 @@ EOF
         log_error "Second release should have filtered all components, but push-snapshot ran"
     fi
 
-    # Verify artifact consistency
+    # Verify artifact consistency across ALL images (multi-component support)
     echo ""
     echo "Verifying artifact consistency..."
     local second_release_json
     second_release_json=$(get_release_json "${second_release_name}")
 
+    # Extract sorted list of all image shasums for comparison
     local artifacts_1 artifacts_2
-    artifacts_1=$(jq -S '.status.artifacts.images[0].shasum // "null"' <<< "${first_release_json}")
-    artifacts_2=$(jq -S '.status.artifacts.images[0].shasum // "null"' <<< "${second_release_json}")
+    artifacts_1=$(jq -S '[.status.artifacts.images[]?.shasum // empty] | sort' <<< "${first_release_json}")
+    artifacts_2=$(jq -S '[.status.artifacts.images[]?.shasum // empty] | sort' <<< "${second_release_json}")
+
+    local artifact_count_1 artifact_count_2
+    artifact_count_1=$(jq -r 'length' <<< "${artifacts_1}")
+    artifact_count_2=$(jq -r 'length' <<< "${artifacts_2}")
 
     # Second release may have no artifacts if all components were filtered
-    if [ "${artifacts_2}" == "\"null\"" ] || [ "${artifacts_2}" == "null" ]; then
+    if [ "${artifact_count_2}" -eq 0 ]; then
         echo "✅ Second release has no artifacts (expected - all components filtered, push-snapshot skipped)"
-        echo "   First release pushed: ${artifacts_1}"
+        echo "   First release pushed ${artifact_count_1} image(s)"
         echo "   Second release skipped push (idempotent)"
     elif [ "${artifacts_1}" == "${artifacts_2}" ]; then
-        echo "✅ Both releases report identical artifact digests"
+        echo "✅ Both releases report identical artifact digests for all ${artifact_count_1} image(s)"
     else
-        echo "First release artifacts: ${artifacts_1}"
-        echo "Second release artifacts: ${artifacts_2}"
-        log_error "Releases report different artifacts: ${artifacts_1} vs ${artifacts_2}"
+        echo "First release artifacts (${artifact_count_1}):"
+        jq -r '.[]' <<< "${artifacts_1}" | while read -r shasum; do echo "  - ${shasum}"; done
+        echo "Second release artifacts (${artifact_count_2}):"
+        jq -r '.[]' <<< "${artifacts_2}" | while read -r shasum; do echo "  - ${shasum}"; done
+        log_error "Releases report different artifacts"
     fi
+
+    local component_count
+    component_count=$(echo "${PTSV_COMPONENTS}" | wc -w)
 
     echo ""
     echo "════════════════════════════════════════════════════════════════════"
@@ -195,8 +225,8 @@ EOF
     echo "════════════════════════════════════════════════════════════════════"
     echo ""
     echo "Summary:"
-    echo "  • First release pushed 1 component"
-    echo "  • Second release filtered component (already released)"
+    echo "  • First release pushed ${component_count} component(s)"
+    echo "  • Second release filtered all components (already released)"
     echo "  • Artifact consistency: Verified"
     echo "  • Idempotent behavior: ✅ CONFIRMED"
     echo ""


### PR DESCRIPTION
## Describe your changes
PR #2343 (https://github.com/konflux-ci/release-service-catalog/pull/2343) added `component2_*` variables to `test.env` but did not include the corresponding Kubernetes resources, causing CI failures when `PTSV_COMPONENTS` includes `component2`.

## Relevant Jira
[RELEASE-2315](https://redhat.atlassian.net/browse/RELEASE-2315)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`


[RELEASE-2315]: https://redhat.atlassian.net/browse/RELEASE-2315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ