### PR TITLE
feat(RELEASE-2332): multi-component push-to-addons-registry e2e

### DIFF
--- a/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
@@ -17,7 +17,14 @@ spec:
             replacements:
               - key: .indexImage
                 replacement: >-
-                  |indexImage:.*|indexImage: {{ .components[] | 
+                  |indexImage:.*|indexImage: {{ .components[0] |
+                  (.repository + "@" + (.containerImage | split ("@"))[-1]) }}|
+          - path: addons/test-product/addonimagesets/stage/my-addon-2.yaml
+            seed: 'indexImage: \nname: my-addon-2\nrelatedImages: []'
+            replacements:
+              - key: .indexImage
+                replacement: >-
+                  |indexImage:.*|indexImage: {{ .components[1] |
                   (.repository + "@" + (.containerImage | split ("@"))[-1]) }}|
         repo: 'https://gitlab.cee.redhat.com/rhtap-release/managed-tenants-stage/'
         upstream_repo: 'https://gitlab.cee.redhat.com/rhtap-release/managed-tenants-stage/'
@@ -26,6 +33,12 @@ spec:
         - name: ${component_name}
           repositories:
             - url: quay.io/hacbs-release-tests/osd-addons/e2e-component-index
+              tags:
+                - '{{ git_short_sha }}'
+          pushSourceContainer: false
+        - name: ${component2_name}
+          repositories:
+            - url: quay.io/hacbs-release-tests/osd-addons/e2e-component2-index
               tags:
                 - '{{ git_short_sha }}'
           pushSourceContainer: false

--- a/integration-tests/push-to-addons-registry/resources/tenant/component2.yaml
+++ b/integration-tests/push-to-addons-registry/resources/tenant/component2.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    git-provider: github
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+  name: ${component2_name}
+  labels:
+    originating-tool: "${originating_tool}"
+spec:
+  application: ${application_name}
+  componentName: ${component2_name}
+  secret: pipelines-as-code-secret-${component_name}
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      revision: ${component2_branch}
+      url: "${component2_git_url}"

--- a/integration-tests/push-to-addons-registry/resources/tenant/kustomization.yaml
+++ b/integration-tests/push-to-addons-registry/resources/tenant/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: ${tenant_namespace}
 resources:
   - application.yaml
   - component.yaml
+  - component2.yaml
   - sa.yaml
   - sa-rolebinding.yaml
   - rp.yaml

--- a/integration-tests/push-to-addons-registry/resources/tenant/rp.yaml
+++ b/integration-tests/push-to-addons-registry/resources/tenant/rp.yaml
@@ -3,7 +3,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   labels:
-    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/auto-release: 'false'
     release.appstudio.openshift.io/standing-attribution: 'true'
     release.appstudio.openshift.io/releasePlanAdmission: "${release_plan_admission_name}"
     originating-tool: "${originating_tool}"

--- a/integration-tests/push-to-addons-registry/test.env
+++ b/integration-tests/push-to-addons-registry/test.env
@@ -23,7 +23,18 @@ export component_github_org=hacbs-release-tests
 export component_base_branch=push-to-addons-registry-base
 export component_repo_name=${component_github_org}/${component_name}
 export component_base_repo_name=${component_github_org}/e2e-base
-export component_git_url=https://github.com/$component_repo_name
+export component_git_url=https://github.com/${component_repo_name}
+
+export component2_type=${component_type}
+export component2_github_org=${component_github_org}
+export component2_name=${component_type}-comp2-${uuid}
+export component2_branch=${component2_name}
+export component2_base_branch=${component_base_branch}
+export component2_base_repo_name=${component_base_repo_name}
+export component2_repo_name=${component_repo_name}
+export component2_git_url=https://github.com/${component2_repo_name}
+
+export PTSV_COMPONENTS="component component2"
 
 export tenant_sa_name=push-to-addons-registry-sa-${uuid}
 export release_plan_name=push-to-addons-registry-rp-${uuid}

--- a/integration-tests/push-to-addons-registry/test.sh
+++ b/integration-tests/push-to-addons-registry/test.sh
@@ -1,21 +1,8 @@
 # --- Global Script Variables (Defaults) ---
 CLEANUP="true"
-NO_CVE="true" # Default to true
+NO_CVE="true"
 # GitHub API curl retries (override in CI/local: export GITHUB_API_CURL_RETRY=5)
 GITHUB_API_CURL_RETRY="${GITHUB_API_CURL_RETRY:-3}"
-
-# Variables that will be set by functions and used globally:
-# component_branch, component_base_branch, component_repo_name (from test.env or similar)
-# managed_namespace, tenant_namespace, application_name, component_name (from test.env or similar)
-# managed_sa_name (from test.env or similar)
-# GITHUB_TOKEN, VAULT_PASSWORD_FILE (from test.env)
-# SCRIPT_DIR (where run-test.sh is located)
-# LIB_DIR (where lib/ is located)
-# tmpDir (set by create_kubernetes_resources)
-# component_pr, pr_number (set by wait_for_component_initialization)
-# SHA (set by merge_github_pr)
-# component_push_plr_name (set by wait_for_plr_to_appear)
-# RELEASE_NAME, RELEASE_NAMESPACE (set and exported by wait_for_release)
 
 # GET a GitHub API JSON resource; prints the response body on success, returns 1 on curl/HTTP error.
 # Args: token url detail_msg fallback_msg (used when curl fails, with/without .message from body)
@@ -151,62 +138,205 @@ patch_component_source_before_merge() {
   echo "✅️ Successfully patched component PaC templates for multi-arch."
 }
 
-# Function to verify Release contents
-# Relies on global variables: RELEASE_NAMES, RELEASE_NAMESPACE, SCRIPT_DIR, managed_namespace, managed_sa_name, NO_CVE
+# --- Snapshot and Release Management ---
+
+wait_for_releases() {
+    local snapshot_name
+    snapshot_name=$(wait_for_multi_component_snapshot)
+    if [ -z "${snapshot_name}" ]; then
+        echo "Could not find multi-component snapshot"
+        exit 1
+    fi
+
+    local release_name="push-addons-multi-${uuid}"
+
+    cat <<EOF | kubectl apply -f -
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: ${release_name}
+  namespace: ${tenant_namespace}
+  labels:
+    originating-tool: "${originating_tool}"
+    test-run-uuid: "${uuid}"
+spec:
+  snapshot: ${snapshot_name}
+  releasePlan: ${release_plan_name}
+EOF
+
+    export RELEASE_NAME=${release_name}
+    export RELEASE_NAMESPACE=${tenant_namespace}
+    "${SUITE_DIR}/../scripts/wait-for-release.sh"
+
+    export RELEASE_NAMES="${release_name}"
+}
+
+# --- Release Verification ---
+
 verify_release_contents() {
+    echo "Verifying Release contents for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}..."
+    local release_json
+    release_json=$(kubectl get release/"${RELEASE_NAME}" -n "${RELEASE_NAMESPACE}" -ojson)
+    if [ -z "${release_json}" ]; then
+        log_error "Could not retrieve Release JSON for ${RELEASE_NAME}"
+    fi
 
-    local failed_releases
-    for RELEASE_NAME in ${RELEASE_NAMES};
-    do
-      echo "Verifying Release contents for ${RELEASE_NAME} in namespace ${RELEASE_NAMESPACE}..."
-      local release_json
-      release_json=$(kubectl get release/"${RELEASE_NAME}" -n "${RELEASE_NAMESPACE}" -ojson)
-      if [ -z "$release_json" ]; then
-          log_error "Could not retrieve Release JSON for ${RELEASE_NAME}"
-      fi
+    local failures=0
 
-      local failures=0
-      local mergerequest_url released_status
+    local released_status
+    released_status=$(jq -r '([.status.conditions[]? | select(.type=="Released") | .status] | first) // ""' <<< "${release_json}")
 
-      mergerequest_url=$(jq -r '.status.artifacts.merge_requests[0]?.url? // ""' <<< "${release_json}")
-      released_status=$(jq -r '([.status.conditions[]? | select(.type=="Released") | .status] | first) // ""' <<< "${release_json}")
-
-      echo "Release fields under validation:"
-      echo "  Released: ${released_status}"
-      echo "  mergerequest_url: ${mergerequest_url}"
-
-      echo "Checking Released=True..."
-      if [ "${released_status}" = "True" ]; then
+    echo "Checking Released=True..."
+    if [ "${released_status}" = "True" ]; then
         echo "✅️ Released=True"
-      else
+    else
         echo "🔴 Released was not True (found: '${released_status}')"
         failures=$((failures+1))
-      fi
+    fi
 
-      echo "Checking mergerequest_url..."
-      if [ -n "${mergerequest_url}" ]; then
-        echo "✅️ mergerequest_url: ${mergerequest_url}"
-      else
-        echo "🔴 mergerequest_url was empty!"
+    echo ""
+    echo "Checking for 2 image entries with distinct URLs and shasums..."
+
+    local image_count
+    image_count=$(jq -r '.status.artifacts.images | length' <<< "${release_json}")
+
+    echo "Found ${image_count} image entries in status.artifacts.images"
+    if [ "${image_count}" -ge 2 ]; then
+        echo "✅️ Found ${image_count} image entries (expected at least 2)"
+    else
+        echo "🔴 Found only ${image_count} image entries, expected at least 2"
         failures=$((failures+1))
-      fi
+    fi
 
-      # Verify container images using shared helper
-      local failed_releases=""
-      check_container_images
+    local image0_url image0_shasum image1_url image1_shasum
+    image0_url=$(jq -r '.status.artifacts.images[0]?.urls[0] // ""' <<< "${release_json}")
+    image0_shasum=$(jq -r '.status.artifacts.images[0]?.shasum // ""' <<< "${release_json}")
+    image1_url=$(jq -r '.status.artifacts.images[1]?.urls[0] // ""' <<< "${release_json}")
+    image1_shasum=$(jq -r '.status.artifacts.images[1]?.shasum // ""' <<< "${release_json}")
 
-      if [ "${failures}" -gt 0 ]; then
-        echo "🔴 Test has FAILED with ${failures} failure(s)!"
-        failed_releases="${RELEASE_NAME} ${failed_releases}"
-      else
-        echo "✅️ All release checks passed. Success!"
-      fi
+    echo "Image 0: url=${image0_url}, shasum=${image0_shasum}"
+    echo "Image 1: url=${image1_url}, shasum=${image1_shasum}"
+
+    if [ -n "${image0_url}" ] && [ -n "${image1_url}" ]; then
+        echo "✅️ Both image URLs are non-empty"
+    else
+        echo "🔴 One or both image URLs are empty"
+        failures=$((failures+1))
+    fi
+
+    if [ -n "${image0_shasum}" ] && [ -n "${image1_shasum}" ]; then
+        echo "✅️ Both image shasums are non-empty"
+    else
+        echo "🔴 One or both image shasums are empty"
+        failures=$((failures+1))
+    fi
+
+    if [ "${image0_url}" != "${image1_url}" ]; then
+        echo "✅️ Image URLs are distinct"
+    else
+        echo "🔴 Image URLs are identical: ${image0_url}"
+        failures=$((failures+1))
+    fi
+
+    if [ "${image0_shasum}" != "${image1_shasum}" ]; then
+        echo "✅️ Image shasums are distinct"
+    else
+        echo "🔴 Image shasums are identical: ${image0_shasum}"
+        failures=$((failures+1))
+    fi
+
+    echo ""
+    echo "Verifying arches and skopeo pullability for each image..."
+
+    for i in 0 1; do
+        local img_url img_shasum img_arches
+        img_url=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.urls[0] // ""' <<< "${release_json}")
+        img_shasum=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.shasum // ""' <<< "${release_json}")
+        img_arches=$(jq -r --argjson idx "$i" '(.status.artifacts.images[$idx]?.arches // [])
+          | map((tostring | split("/") | .[-1]))
+          | unique
+          | join(" ")' <<< "${release_json}")
+
+        echo ""
+        echo "Image ${i}: url=${img_url}, shasum=${img_shasum}, arches=${img_arches}"
+
+        if [ -z "${img_url}" ] || [ -z "${img_shasum}" ]; then
+            echo "🔴 Image ${i}: missing url or shasum, skipping remaining checks"
+            failures=$((failures+1))
+            continue
+        fi
+
+        if [ "$i" -eq 0 ]; then
+            echo "Checking image ${i} arches include amd64 and arm64..."
+            if [[ " ${img_arches} " == *" amd64 "* && " ${img_arches} " == *" arm64 "* ]]; then
+                echo "✅️ Image ${i} has required arches: ${img_arches}"
+            else
+                echo "🔴 Image ${i} missing required arches (need: amd64 and arm64), found: '${img_arches}'"
+                failures=$((failures+1))
+            fi
+        else
+            echo "Checking image ${i} arches include amd64..."
+            if [[ " ${img_arches} " == *" amd64 "* ]]; then
+                echo "✅️ Image ${i} has required arch: ${img_arches}"
+            else
+                echo "🔴 Image ${i} missing required arch (need: amd64), found: '${img_arches}'"
+                failures=$((failures+1))
+            fi
+        fi
+
+        echo "Checking image ${i} shasum is valid..."
+        if [[ "${img_shasum}" == sha256:* ]]; then
+            echo "✅️ Image ${i} shasum: ${img_shasum}"
+        else
+            echo "🔴 Image ${i} shasum missing or invalid: '${img_shasum}'"
+            failures=$((failures+1))
+        fi
+
+        echo "Verifying image ${i} pullability with skopeo..."
+        if [[ "${img_shasum}" == sha256:* ]]; then
+            set +e
+            if [ "$i" -eq 0 ]; then
+                "${SCRIPT_DIR}/scripts/skopeo-verify-image.sh" \
+                    "${img_url}" "${img_shasum}" \
+                    "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" \
+                    "amd64 arm64"
+            else
+                "${SCRIPT_DIR}/scripts/skopeo-verify-image.sh" \
+                    "${img_url}" "${img_shasum}" \
+                    "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml"
+            fi
+            local skopeo_rc=$?
+            set -e
+            if [ "${skopeo_rc}" -ne 0 ]; then
+                echo "🔴 Image ${i} skopeo verification failed"
+                failures=$((failures+1))
+            else
+                echo "✅️ Image ${i} is pullable"
+            fi
+        else
+            echo "🔴 Skipping skopeo check for image ${i}: shasum not sha256:*"
+            failures=$((failures+1))
+        fi
     done
 
-    if [ -n "${failed_releases}" ]; then
-      echo "🔴 Releases FAILED: ${failed_releases}"
-      exit 1
+    echo ""
+    echo "Checking mergerequest_url..."
+
+    local mergerequest_url
+    mergerequest_url=$(jq -r '.status.artifacts.merge_requests[0].url // ""' <<< "${release_json}")
+
+    if [ -n "${mergerequest_url}" ]; then
+        echo "✅️ mergerequest_url: ${mergerequest_url}"
     else
-      echo "✅️ Success!"
+        echo "🔴 mergerequest_url was empty!"
+        failures=$((failures+1))
+    fi
+
+    echo ""
+    if [ "${failures}" -gt 0 ]; then
+        echo "🔴 Test has FAILED with ${failures} failure(s)!"
+        exit 1
+    else
+        echo "✅️ All multi-component release checks passed. Success!"
     fi
 }


### PR DESCRIPTION
## Describe your changes
Convert the single-component test to a 2-component test so apply-mapping's multi-component code path is executed. 

Assisted-by: Claude Code
## Relevant Jira
https://redhat.atlassian.net/browse/RELEASE-2332

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
