### PR TITLE
fix: skopeo inspect retry-times for ITS

### DIFF
--- a/integration-tests/rh-push-helm-chart-to-registry-redhat-io/test.sh
+++ b/integration-tests/rh-push-helm-chart-to-registry-redhat-io/test.sh
@@ -113,14 +113,14 @@ verify_release_contents() {
         "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" | base64 -d > "${DOCKER_CONFIG}/config.json"
 
     # Helm OCI artifacts require --raw (mediaType is application/vnd.cncf.helm.config.v1+json)
-    if skopeo inspect --tls-verify=true --raw "docker://${COMPLETE_PULLSPEC}" 2>/dev/null | \
+    if skopeo inspect --tls-verify=true --raw --retry-times 3 "docker://${COMPLETE_PULLSPEC}" 2>/dev/null | \
         jq -e '.config.mediaType == "application/vnd.cncf.helm.config.v1+json"' &>/dev/null; then
         echo "✅️ Helm OCI artifact '$COMPLETE_PULLSPEC' verified with skopeo inspect --raw."
-    elif skopeo inspect --tls-verify=true "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
+    elif skopeo inspect --tls-verify=true --retry-times 3 "docker://${COMPLETE_PULLSPEC}" &>/dev/null; then
         echo "✅️ Image '$COMPLETE_PULLSPEC' can be inspected with skopeo inspect."
     else
         echo "🔴 Failed to inspect '$COMPLETE_PULLSPEC' as Helm OCI artifact or container image."
-        skopeo inspect --tls-verify=true --raw "docker://${COMPLETE_PULLSPEC}" | head -c 500 || true
+        skopeo inspect --tls-verify=true --raw --retry-times 3 "docker://${COMPLETE_PULLSPEC}" | head -c 500 || true
         failures=$((failures+1))
     fi
 

--- a/integration-tests/rh-push-to-external-registry/test.sh
+++ b/integration-tests/rh-push-to-external-registry/test.sh
@@ -61,7 +61,7 @@ verify_release_contents() {
         "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" | base64 -d > "${AUTH_FILE}"
 
     for arch in amd64 arm64; do
-        if skopeo inspect --authfile "${AUTH_FILE}" --override-arch "${arch}" --tls-verify=true \
+        if skopeo inspect --authfile "${AUTH_FILE}" --override-arch "${arch}" --tls-verify=true --retry-times 3 \
                 "docker://${image_pullspec}" > /dev/null 2>&1; then
             echo "✅️ skopeo inspect --override-arch ${arch} succeeded for ${image_pullspec}"
         else

--- a/integration-tests/scripts/verify-fbc-index-content.sh
+++ b/integration-tests/scripts/verify-fbc-index-content.sh
@@ -89,7 +89,7 @@ if command -v opm &>/dev/null; then
 
 elif command -v skopeo &>/dev/null; then
     echo "⚠️  opm not available, falling back to skopeo inspect"
-    if skopeo inspect --tls-verify=true "docker://${target_index}" &>/dev/null; then
+    if skopeo inspect --tls-verify=true --retry-times 3 "docker://${target_index}" &>/dev/null; then
         echo "✅ Published index image is pullable (skopeo inspect passed)"
     else
         echo "🔴 Published index image is NOT pullable"


### PR DESCRIPTION
Add --retry-times for all skopeo inspect calls in integration tests

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
