### PR TITLE
test: fix retry on MC ITS PLR

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -559,7 +559,10 @@ wait_for_plrs_to_appear() {
     local start_time=$(date +%s)
     local current_time
     local elapsed_time
-    declare -gA appeared_plrs=()
+    # Only declare appeared_plrs if it doesn't exist (preserve existing entries during retry)
+    if [ -z "${appeared_plrs+x}" ]; then
+        declare -gA appeared_plrs=()
+    fi
     local count=$(echo "$PTSV_COMPONENTS" | wc -w)
 
     echo -n "Waiting for PipelineRun to appear"


### PR DESCRIPTION
Fix retrying PLR on multicomponent ITS
appeared_plrs shouldn't be reset if it exists

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
