### PR TITLE
KONFLUX-6210 enforce containerfirst label verification by default in …

### DIFF
--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -183,7 +183,7 @@ spec:
               {"resultIndex": 1, "key": ".sign.cosignSecretName", "default": ""},
               {"resultIndex": 2, "key": ".pyxis.secret"},
               {"resultIndex": 3, "key": ".pyxis.server", "default": "production"},
-              {"resultIndex": 4, "key": ".enforceContainerFirstSecurityLabels", "default": "false"},
+              {"resultIndex": 4, "key": ".enforceContainerFirstSecurityLabels", "default": "true"},
               {"resultIndex": 5, "key": ".jira.jiraAdvisorySecret", "default": "konflux-advisory-jira-secret"}
             ]
         - name: taskGitUrl


### PR DESCRIPTION
…development

## Describe your changes
Enabling containerfirst label verification by default in the rh-advisories pipeline

## Relevant Jira
KONFLUX-6210

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
