### PR TITLE
fix: increase repo init timeout in e2e

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -381,7 +381,7 @@ fetch_component_build_status_annotation() {
 _wait_for_component_initialization() {
     echo "Waiting for component ${_component_name} in namespace ${tenant_namespace} to be initialized..."
 
-    local max_attempts=60  # 10 minutes with 10-second intervals
+    local max_attempts=60  # 20 minutes with 20-second intervals
     local attempt=1
     local component_annotations=""
     local initialization_success=false
@@ -392,8 +392,8 @@ _wait_for_component_initialization() {
       if ! component_annotations=$(fetch_component_build_status_annotation "${_component_name}"); then
         log_warning "Could not reach component ${_component_name} (kubectl get failed); retrying..."
         if [ $attempt -lt $max_attempts ]; then
-          echo "Waiting 10 seconds before retry..."
-          sleep 10
+          echo "Waiting 20 seconds before retry..."
+          sleep 20
         fi
         attempt=$((attempt + 1))
         continue
@@ -412,8 +412,8 @@ _wait_for_component_initialization() {
             break
         else
             log_warning "Could not get component PR from annotations: ${component_annotations}"
-            echo "Waiting 10 seconds before retry..."
-            sleep 10
+            echo "Waiting 20 seconds before retry..."
+            sleep 20
         fi
 
 
@@ -422,8 +422,8 @@ _wait_for_component_initialization() {
 
         # Wait before retrying (except on the last attempt)
         if [ $attempt -lt $max_attempts ]; then
-          echo "Waiting 10 seconds before retry..."
-          sleep 10
+          echo "Waiting 20 seconds before retry..."
+          sleep 20
         fi
       fi
 


### PR DESCRIPTION
## Describe your changes

When the cluster is under load, the initialization of components can take longer than the current 10 minute timeout.

Today, the stage catalog test run failed on this for many tests. Upon investigation of one of the components, it took just over 20 minutes. Let's increase this to 20 minutes for now (by increasing the interval from 10 to 20 seconds).

Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1783942221338389?thread_ts=1783934004.709589&cid=C04PZ7H0VA8

## Relevant Jira

[KFLUXSPRT-8419](https://redhat.atlassian.net/browse/KFLUXSPRT-8419)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`


[KFLUXSPRT-8419]: https://redhat.atlassian.net/browse/KFLUXSPRT-8419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ