### PR TITLE
fix: retry kubectl create on ResourceQuota conflict

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -346,11 +346,31 @@ create_kubernetes_resources() {
 
     echo "Building and applying tenant resources..."
     kustomize build "$tmpDir/tenant" | envsubst > "$tmpDir/tenant-resources.yaml"
-    kubectl create -f "$tmpDir/tenant-resources.yaml"
+    local max_retries=5
+    local attempt
+    for attempt in $(seq 1 "${max_retries}"); do
+        if kubectl create -f "$tmpDir/tenant-resources.yaml"; then
+            break
+        fi
+        if [ "${attempt}" -eq "${max_retries}" ]; then
+            log_error "kubectl create tenant resources failed after ${max_retries} attempts"
+        fi
+        echo "Retrying kubectl create tenant resources (attempt ${attempt}/${max_retries})..."
+        sleep "$((1 + RANDOM % 3))"
+    done
 
     echo "Building and applying managed resources..."
     kustomize build "$tmpDir/managed" | envsubst > "$tmpDir/managed-resources.yaml"
-    kubectl apply -f "$tmpDir/managed-resources.yaml"
+    for attempt in $(seq 1 "${max_retries}"); do
+        if kubectl apply -f "$tmpDir/managed-resources.yaml"; then
+            break
+        fi
+        if [ "${attempt}" -eq "${max_retries}" ]; then
+            log_error "kubectl apply managed resources failed after ${max_retries} attempts"
+        fi
+        echo "Retrying kubectl apply managed resources (attempt ${attempt}/${max_retries})..."
+        sleep "$((1 + RANDOM % 3))"
+    done
 
     echo "Kubernetes resources applied."
 }


### PR DESCRIPTION
## Describe your changes

Concurrent test suites share a namespace and can race on the "konflux" ResourceQuota when creating tenant resources. Kubernetes uses optimistic locking on the quota object, so a concurrent update causes a transient Conflict error. Retry up to 5 times with a 2-second backoff to handle this.

Here's the failed test run: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-release-2-tenant/applications/release-service-catalog-staging/taskruns/konflux-e2e-release-catalog-staging-6p9gg-run-test/logs

```
releaseplan.appstudio.redhat.com/push-to-addons-registry-rp-6537358b created
Error from server (Conflict): error when creating "/tmp/tmp.aeZ7YZ3mWl/tenant-resources.yaml": Operation cannot be fulfilled on resourcequotas "konflux": the object has been modified; please apply your changes to the latest version and try again
/home/e2e/tests/run-test.sh: ERROR: Command 'kubectl create -f "$tmpDir/tenant-resources.yaml"' failed at line 1 - exited with status 1
Performing cleanup...
```

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
