### PR TITLE
chore(CALUNGA-375): replace deprecated buildah-task with release-service-utils

### DIFF
--- a/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+++ b/tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
@@ -114,7 +114,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: get-image-urls
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:
         limits:
           memory: 64Mi


### PR DESCRIPTION
The buildah-task image is deprecated and no longer maintained by the
Konflux Build team. Replaced with release-service-utils.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
