### PR TITLE
fix(RELEASE-2459): clean up orphaned ImageRepository objects in test cleanup

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -220,6 +220,23 @@ cleanup_resources() {
         echo "Skipping Release CR cleanup: uuid or tenant_namespace not set" | tee -a "${cleanup_log_file}"
     fi
 
+    # Clean up ImageRepository objects created by the image controller for test components.
+    # These may have no ownerReferences, so they may not be cascade-deleted with the Component.
+    # Relies on PTSV_COMPONENTS so any component a suite adds is covered automatically.
+    if [ -n "$tenant_namespace" ]; then
+        for component in ${PTSV_COMPONENTS}; do
+            local _v="${component}_name"
+            local comp="${!_v}"
+            if [ -n "$comp" ]; then
+                echo "Deleting ImageRepository for component ${comp}..." | tee -a "${cleanup_log_file}"
+                kubectl delete imagerepository -n "${tenant_namespace}" \
+                    -l "appstudio.redhat.com/component=${comp}" \
+                    --ignore-not-found >> "${cleanup_log_file}" 2>&1 || \
+                    echo "Warning: Failed to delete ImageRepository for component ${comp}" | tee -a "${cleanup_log_file}"
+            fi
+        done
+    fi
+
     if [ -n "$advisory_yaml_dir" ] && [ -d "$advisory_yaml_dir" ]; then
         echo "Removing advisory YAML directory..." | tee -a "${cleanup_log_file}"
         rm -rf "${advisory_yaml_dir}" >> "${cleanup_log_file}" 2>&1


### PR DESCRIPTION
## Describe your changes

ImageRepository objects are created by the image controller when a
Component is created, but may not have ownerReferences set (e.g.
when the controller hasn't processed them yet). In that case they
are not cascade-deleted with the Component and accumulate over
time. Delete them explicitly by the appstudio.redhat.com/component
label during test cleanup.

Build the component list by iterating PTSV_COMPONENTS, matching the
pattern already used elsewhere in this file for per-component
actions, so any suite that adds a component gets ImageRepository
cleanup automatically.

Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1783954641826689?thread_ts=1783934004.709589&cid=C04PZ7H0VA8

## Relevant Jira

RELEASE-2459

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
