### PR TITLE
feat(RELEASE-2425): add debug-e2e agent skill

### DIFF
--- a/.agents/skills/debug-e2e/SKILL.md
+++ b/.agents/skills/debug-e2e/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: debug-e2e
+description: Debug failing e2e tests on a PR.
+disable-model-invocation: true
+---
+
+## Prerequisites
+
+Required tools: `jq`, `gh`, `kubectl` (or `oc`), `kubectl-ka` (KubeArchive plugin)
+
+Before starting, verify all required tools are installed:
+
+```sh
+for cmd in jq gh kubectl; do command -v "${cmd}" &>/dev/null || echo "MISSING:${cmd}"; done
+kubectl plugin list 2>/dev/null | grep -q kubectl-ka || echo "MISSING:kubectl-ka"
+```
+
+If any tool is missing, stop and tell the user which ones are missing. For `kubectl-ka`, link to: https://konflux.pages.redhat.com/docs/users/faq/kubearchive.html
+
+$ARGUMENTS is a GitHub PR URL (e.g. `https://github.com/konflux-ci/release-service-catalog/pull/2328`).
+
+## Steps
+
+### 1. Fetch failed e2e checks
+
+```sh
+scripts/get-failed-e2e-checks.sh $ARGUMENTS
+```
+
+This outputs a JSON array. Each element has these fields:
+- `name` — the check name
+- `pipelinerun` — the PipelineRun name (e.g. `collector-e2e-test-rlx2d`)
+- `pipelinerun_url` — direct link to the Konflux UI
+- `namespace` — the namespace (e.g. `rhtap-release-2-tenant`)
+- `tasks[]` — array of tasks with `task`, `passed`, `duration`, `logs_url`
+
+### 2. For each failed check, fetch the failing TaskRuns
+
+Use the `pipelinerun` and `namespace` fields from step 1. Try `kubectl get` first (live cluster), and if it returns empty results, fall back to `kubectl ka get` (KubeArchive):
+
+```sh
+kubectl get taskrun -n <namespace> \
+    -l tekton.dev/pipelineRun=<pipelinerun> \
+    -o json | jq '[
+      .items[]
+      | (.status.results // [] | map(select(.name == "TEST_OUTPUT")) | first // null) as $test
+      | {
+          name: .metadata.name,
+          task: .metadata.labels["tekton.dev/pipelineTask"],
+          pod: .status.podName,
+          test_output: ($test.value | fromjson? // null)
+        }
+      | select(.test_output.result == "FAILURE")
+    ]'
+```
+
+If the above returns an empty array or errors, retry with `kubectl ka get` instead of `kubectl get` (the resources may have been archived). Once any `kubectl ka` fallback succeeds, use `kubectl ka` directly for all subsequent cluster calls in this session (TaskRun fetches, log fetches, etc.).
+
+Important: TaskRun conditions will show `Succeeded` even for test failures because the test script traps errors and always exits 0. The actual result is in the `TEST_OUTPUT` result (`result: "FAILURE"`).
+
+### 3. Fetch logs from each failed TaskRun's pod
+
+Use the `pod` and `namespace` from step 2. 
+
+```sh
+kubectl logs -n <namespace> <pod> -c step-run-test
+```
+
+The `-c step-run-test` flag is required. Tekton pods have multiple containers and the test output is in the `step-run-test` container.
+
+### 4. Summarize
+
+Provide a table with the following structure:
+
+```
+| Test Name | Failure Cause | Konflux UI Link |
+|-----------|---------------|-----------------|
+| <short test name> | <one-line failure cause> | <pipelinerun_url> |
+```
+
+- Use the full `https://...` URL in the Konflux UI Link column.
+- After the table, provide a root cause analysis summarizing the failure patterns. Include relevant log snippets (key error messages, timeout lines, or stack traces) that show exactly why the pipeline failed. Group tests that share the same root cause together.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/scripts/get-failed-e2e-checks.sh
+++ b/scripts/get-failed-e2e-checks.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PR_URL="${1:-}"
+
+if [[ -z "${PR_URL}" ]]; then
+    echo "Usage: $0 <PR_URL>" >&2
+    echo "Example: $0 https://github.com/konflux-ci/release-service-catalog/pull/2328" >&2
+    exit 1
+fi
+
+if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI is required" >&2
+    exit 1
+fi
+
+OWNER_REPO=$(echo "${PR_URL}" | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/.*|\1|')
+PR_NUM=$(echo "${PR_URL}" | sed -E 's|.*/pull/([0-9]+).*|\1|')
+
+if [[ -z "${OWNER_REPO}" || -z "${PR_NUM}" ]]; then
+    echo "Error: could not parse PR URL: ${PR_URL}" >&2
+    exit 1
+fi
+
+SHA=$(gh api "repos/${OWNER_REPO}/pulls/${PR_NUM}" --jq '.head.sha')
+
+FAILED_IDS=$(gh api "repos/${OWNER_REPO}/commits/${SHA}/check-runs" \
+    --paginate \
+    --jq '.check_runs[] | select(.name | contains("e2e-test")) | select(.conclusion == "failure") | .id')
+
+if [[ -z "${FAILED_IDS}" ]]; then
+    echo "[]"
+    exit 0
+fi
+
+parse_check_output() {
+    local RAW_JSON="${1}"
+    echo "${RAW_JSON}" | jq '
+        .output_text as $text |
+
+        # Extract pipelinerun URL from: <a href="...pipelinerun/NAME">NAME</a>
+        ($text | capture("href=\"(?<url>[^\"]*pipelinerun/[^\"]+)\">(?<name>[^<]+)</a>")
+            // {url: null, name: null}) as $plr |
+
+        # Extract namespace from URL path: /ns/NAMESPACE/pipelinerun/
+        ($plr.url | if . then capture("/ns/(?<ns>[^/]+)/") // {ns: null} else {ns: null} end) as $ns |
+
+        # Parse the markdown task table rows into objects
+        [
+            $text
+            | split("\n")[]
+            | select(startswith("| <a "))
+            | capture("href=\"(?<logs_url>[^\"]+)\">(?<task>[^<]+)</a>\\s*\\|\\s*(?<duration>[^|]+)\\|[^|]*\\|\\s*(?<status>[^|]+)")
+            | .duration |= ltrimstr(" ") | .duration |= rtrimstr(" ")
+            | .status |= ltrimstr(" ") | .status |= rtrimstr(" ")
+            | .passed = (.status | contains("heavy_check_mark"))
+        ] as $tasks |
+
+        {
+            id,
+            name,
+            conclusion,
+            started_at,
+            completed_at,
+            html_url,
+            pipelinerun: $plr.name,
+            pipelinerun_url: $plr.url,
+            namespace: $ns.ns,
+            tasks: $tasks
+        }
+    '
+}
+
+RESULTS="["
+FIRST=true
+while IFS= read -r CHECK_ID; do
+    if [[ "${FIRST}" == "true" ]]; then
+        FIRST=false
+    else
+        RESULTS+=","
+    fi
+    RAW=$(gh api "repos/${OWNER_REPO}/check-runs/${CHECK_ID}" \
+        --jq '{
+            id,
+            name,
+            conclusion,
+            started_at,
+            completed_at,
+            html_url,
+            output_text: .output.text
+        }')
+    RESULTS+=$(parse_check_output "${RAW}")
+done <<< "${FAILED_IDS}"
+RESULTS+="]"
+
+echo "${RESULTS}" | jq .


### PR DESCRIPTION
## Describe your changes
The skill can be manually invoked by an agent using the /debug-e2e command. It accepts a PR link from the catalog repo as the only argument  for the command, and provides a root cause analysis for the failed e2e checks for that PR.

## Relevant Jira
https://redhat.atlassian.net/browse/RELEASE-2425

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
