### PR TITLE
feat(ISV-7321): use direct-sign-index-image in fbc-release pipeline

### DIFF
--- a/integration-tests/fbc-release/test.sh
+++ b/integration-tests/fbc-release/test.sh
@@ -95,7 +95,7 @@ configure_test_matrix() {
     
     # These conditions are additive - multiple patterns can match and enable their respective tests
     
-    if [[ "$changed_files" =~ tasks/managed/sign-index-image ]] || \
+    if [[ "$changed_files" =~ tasks/managed/direct-sign-index-image ]] || \
        [[ "$changed_files" =~ tasks/managed/rh-sign-image-cosign ]] || \
        [[ "$changed_files" =~ pipelines/internal/simple-signing-pipeline ]] || \
        [[ "$changed_files" =~ tasks/internal/request-and-upload-signature ]]; then

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -395,7 +395,7 @@ spec:
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:
         - verify-access-to-resources
-    - name: sign-index-image
+    - name: direct-sign-index-image
       retries: 3
       taskRef:
         resolver: "git"
@@ -405,12 +405,10 @@ spec:
           - name: revision
             value: $(params.taskGitRevision)
           - name: pathInRepo
-            value: tasks/managed/sign-index-image/sign-index-image.yaml
+            value: tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
-        - name: releasePlanAdmissionPath
-          value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: requester
           value: $(tasks.extract-requester-from-release.results.output-result)
         - name: pipelineRunUid
@@ -534,7 +532,7 @@ spec:
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
-          value: "$(tasks.sign-index-image.results.sourceDataArtifact)"
+          value: "$(tasks.direct-sign-index-image.results.sourceDataArtifact)"
         - name: dataDir
           value: $(params.dataDir)
         - name: trustedArtifactsDebug
@@ -548,7 +546,7 @@ spec:
           operator: in
           values: ["true"]
       runAfter:
-        - sign-index-image
+        - direct-sign-index-image
         - rh-sign-index-image-cosign
     - name: collect-index-images
       taskRef:


### PR DESCRIPTION
## Describe your changes
Replace sign-index-image with direct-sign-index-image in fbc-release pipeline. Remove the releasePlanAdmissionPath param not used by the new task and update any references of the old task. The new task added in #2315 calls direct signing pipeline instead of the old Radas/UMB solution.

Co-authored-by: Claude Opus 4.6

## Relevant Jira
ISV-7321

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
