### PR TITLE
feat: add multi-arch image lint check

### DIFF
--- a/.github/scripts/tkn_check_multiarch_image.sh
+++ b/.github/scripts/tkn_check_multiarch_image.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Fails if any release-service-utils image digest in CHANGED_FILES
+# points to a single-arch manifest instead of a multi-arch manifest list.
+
+set -euo pipefail
+
+fail=0
+
+echo "Checking that release-service-utils images are multi-arch manifests"
+
+is_multiarch() {
+  ref="$1"
+
+  if ! raw=$(skopeo inspect --raw "docker://${ref}" 2>&1); then
+    echo "ERROR: failed to inspect ${ref}"
+    echo "  ${raw}"
+    grep -rl "${ref}" ${CHANGED_FILES} 2>/dev/null | sed 's/^/  /'
+    return 1
+  fi
+
+  media_type=$(jq -r '.mediaType // empty' <<< "${raw}")
+
+  # Konflux uses Buildah which produces OCI spec manifests only
+  if [[ "${media_type}" == "application/vnd.oci.image.index.v1+json" ]]; then
+    echo "OK: ${ref} is multi-arch"
+    return 0
+  fi
+
+  echo "ERROR: ${ref} must be a multi-arch manifest, got: ${media_type}"
+  # show which files reference this digest
+  grep -rl "${ref}" ${CHANGED_FILES} 2>/dev/null | sed 's/^/  /'
+  return 1
+}
+
+# Collect unique image references across all changed YAML files
+digests=$(
+  for file in ${CHANGED_FILES}; do
+    if [[ "${file}" == *.yaml ]]; then
+      grep -oP "quay\.io/konflux-ci/release-service-utils@sha256:[a-f0-9]+" "${file}" 2>/dev/null || true
+    fi
+  done | sort -u
+)
+
+if [[ -z "${digests}" ]]; then
+  echo "No image references found in changed files"
+  exit 0
+fi
+
+for ref in ${digests}; do
+  if ! is_multiarch "${ref}"; then
+    fail=1
+  fi
+done
+
+exit ${fail}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -226,6 +226,23 @@ jobs:
             echo "AGENTS.md has $lines non-empty lines (max 60)"
             exit 1
           fi
+  check-multiarch-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout files
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - name: Get changed files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96   # v47.0.6
+        id: changed-files
+        with:
+          files: |
+            **/*.yaml
+      - name: Check release-service-utils images are multi-arch
+        if: |
+          steps.changed-files.outputs.any_changed == 'true'
+        run: .github/scripts/tkn_check_multiarch_image.sh
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
   check-renovate-config-file:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,7 @@ Before a pull request can be merged:
 
 Most tasks in this repo use the release-service-utils image defined in [the release-service-utils repo](https://github.com/konflux-ci/release-service-utils).
 When referencing this image, the image URL must be in digest form, for example: `quay.io/konflux-ci/release-service-utils@sha256:...`, where `sha256:...` is the image digest.
+The digest must point to a multi-arch manifest list and not a single-arch image for the release-service-utils image.
 
 This repo uses [MintMaker](https://konflux-ci.dev/docs/mintmaker/user/) to automatically update images referenced in tasks, stepactions, and pipelines. The MintMaker configuration is defined in [renovate.json](renovate.json).
 
@@ -145,7 +146,7 @@ Running `.github/scripts/check_readme.sh` locally is recommended to find these e
 If you wish to update a task, pipeline, or task/pipeline parameter description, do **not** manually change the README.md file.
 
 Instead, you should change the descriptions in the `yaml` file associated with the task/pipeline, and then run `.github/scripts/readme_generator.sh`
-with the changed task/pipeline directories as arguments. This is because the task/pipeline `yaml` file is considered the source of truth for each 
+with the changed task/pipeline directories as arguments. This is because the task/pipeline `yaml` file is considered the source of truth for each
 task/pipeline README.md file. If you manually change the README.md file without updating the yaml, `check_readme.sh` will fail and `readme_generator.sh`
 will overwrite your changes. You should never have to update the README.md file manually.
 
@@ -334,7 +335,7 @@ source .env.testing
 
 # Run tests
 ./scripts/run-local-tests.sh                              # Auto-detect changes
-./scripts/run-local-tests.sh --pr-mode                    # Test PR changes  
+./scripts/run-local-tests.sh --pr-mode                    # Test PR changes
 ./scripts/run-local-tests.sh tasks/managed/add-fbc-contribution  # Specific task
 ```
 

--- a/integration-tests/pipelines/e2e-tests-kind-quay-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-kind-quay-pipeline.yaml
@@ -207,7 +207,7 @@ spec:
               secretName: $(params.cluster-access-secret)
         steps:
           - name: run-test
-            image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+            image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
             env:
               - name: KUBECONFIG
                 value: /tmp/cluster-kubeconfig/kubeconfig

--- a/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-periodic-pipeline.yaml
@@ -33,7 +33,7 @@ spec:
           - name: CONTAINER_IMAGE
         steps:
           - name: get-container-image
-            image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+            image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
             env:
               - name: SNAPSHOT
                 value: $(params.SNAPSHOT)

--- a/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
@@ -15,7 +15,7 @@ spec:
       default: ''
       type: string
       description: |
-        The pipeline that is used by the test suite. 
+        The pipeline that is used by the test suite.
         If empty, use the PIPELINE_TEST_SUITE as the pipeline to be used
     - name: VAULT_PASSWORD_SECRET_NAME
       default: 'vault-password-secret'
@@ -46,7 +46,7 @@ spec:
           - name: PR_GIT_REVISION
         steps:
           - name: get-container-image
-            image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+            image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
             env:
               - name: SNAPSHOT
                 value: $(params.SNAPSHOT)
@@ -145,11 +145,11 @@ spec:
               string_has_word() {
                   local search_word="$1"
                   local search_string="$2"
-                  
+
                   # Add spaces around both strings to ensure word boundaries
                   search_string=" ${search_string} "
                   search_word=" ${search_word} "
-                  
+
                   if [[ "${search_string}" == *"${search_word}"* ]]; then
                       return 0  # Word found
                   else
@@ -165,7 +165,7 @@ spec:
                 successcount=0
                 failurecount=0
                 # After the tests finish, record the overall result in the RESULT variable
-                if [ "$err" -eq 0 ] ; then   
+                if [ "$err" -eq 0 ] ; then
                   RESULT="SUCCESS"
                   successcount=1
                 elif [ "$err" -eq 99 ] ; then
@@ -337,7 +337,7 @@ spec:
               #
               # shellcheck source=/dev/null
               . "/home/e2e/tests/lib/test-functions.sh"
-              
+
               # delete GH repo
               "/home/e2e/tests/scripts/delete-repository.sh" "${component_repo_name:?}"
 

--- a/integration-tests/pipelines/rh-advisories-large-snapshot-pipeline.yaml
+++ b/integration-tests/pipelines/rh-advisories-large-snapshot-pipeline.yaml
@@ -45,7 +45,7 @@ spec:
         steps:
           - name: get-container-image
             # yamllint disable-next-line rule:line-length
-            image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+            image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
             computeResources:
               requests:
                 cpu: 50m

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -78,7 +78,7 @@ spec:
         readOnly: true
   steps:
     - name: perform-updates
-      image: quay.io/konflux-ci/release-service-utils@sha256:e852a62497c4537059bb1f4c3ddf5c1a813b2b22bd9f4bb826cffb36af7d5f65
+      image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
       securityContext:
         runAsUser: 1001
       computeResources:


### PR DESCRIPTION
## Describe your changes
Add CI lint check to verify that all release-service-utils image digests point to multi-arch manifest lists not single-arch images.

This helps keep MintMaker updates in sync across arch. When MintMaker bumps a digest a single-arch reference can silently diverge from the multi-arch one.

Also fixes existing single-arch digest references found in the repo.

Assisted-by: Claude
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
