### PR TITLE
fix: use literal results path in pipeline script params

### DIFF
--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -390,7 +390,7 @@ spec:
             NAME=$(echo $(params.release) | cut -d '/' -f 2)
 
             AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
-            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+            -o=jsonpath='{.status.attribution.author}' | tee /tekton/results/output-result)
 
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:

--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -239,7 +239,7 @@ spec:
             NAME=$(echo $(params.release) | cut -d '/' -f 2)
 
             AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
-            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+            -o=jsonpath='{.status.attribution.author}' | tee /tekton/results/output-result)
 
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -436,7 +436,7 @@ spec:
             NAME=$(echo $(params.release) | cut -d '/' -f 2)
 
             AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
-            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+            -o=jsonpath='{.status.attribution.author}' | tee /tekton/results/output-result)
 
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -255,7 +255,7 @@ spec:
             NAME=$(echo $(params.release) | cut -d '/' -f 2)
 
             AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
-            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+            -o=jsonpath='{.status.attribution.author}' | tee /tekton/results/output-result)
 
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:

--- a/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
@@ -254,7 +254,7 @@ spec:
             NAME=$(echo $(params.release) | cut -d '/' -f 2)
 
             AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
-            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+            -o=jsonpath='{.status.attribution.author}' | tee /tekton/results/output-result)
 
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -252,7 +252,7 @@ spec:
             NAME=$(echo $(params.release) | cut -d '/' -f 2)
 
             AUTHOR=$(kubectl get release ${NAME} -n ${NAMESPACE} \
-            -o=jsonpath='{.status.attribution.author}' | tee $(results.output-result.path))
+            -o=jsonpath='{.status.attribution.author}' | tee /tekton/results/output-result)
 
             if [[ ${AUTHOR} == "" ]] ; then exit 1 ; fi
       runAfter:

--- a/pipelines/managed/rh-rpm-advisories/rh-rpm-advisories.yaml
+++ b/pipelines/managed/rh-rpm-advisories/rh-rpm-advisories.yaml
@@ -264,8 +264,8 @@ spec:
             script: |
               #!/bin/bash
               echo "create-advisory"
-              echo -n "" > "$(results.advisory_url.path)"
-              echo -n "" > "$(results.advisory_internal_url.path)"
+              echo -n "" > "/tekton/results/advisory_url"
+              echo -n "" > "/tekton/results/advisory_internal_url"
   finally:
     - name: cleanup-internal-requests
       taskRef:


### PR DESCRIPTION
## Describe your changes

Tekton's pipeline validation now rejects $(results.) references
in pipeline task params since "results" is not a valid pipeline-
level variable prefix. Replace with the literal /tekton/results/
path to avoid the validation while keeping the same behavior.

Note that this is meant as a quick fix. Proper fix will come in https://redhat.atlassian.net/browse/RELEASE-2716

## Relevant Jira

RELEASE-2716

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
