### PR TITLE
fix: use e2e signing key configMap

### DIFF
--- a/integration-tests/push-artifacts-to-cdn/README.md
+++ b/integration-tests/push-artifacts-to-cdn/README.md
@@ -72,7 +72,7 @@ Most are shared permanent secrets used by production pipelines.
 
 | ConfigMap Name | Purpose |
 |---------------|---------|
-| `hacbs-signing-pipeline-config-redhatrelease2` | Signing pipeline config; must contain `data.SIG_KEY_NAME` |
+| `hacbs-signing-pipeline-config-staging-e2e` | Signing pipeline config; must contain `data.SIG_KEY_NAME` or `data.SIG_KEY_NAMES` |
 
 ### CGW Product (stage)
 

--- a/integration-tests/push-artifacts-to-cdn/resources/managed/rpa.yaml
+++ b/integration-tests/push-artifacts-to-cdn/resources/managed/rpa.yaml
@@ -92,7 +92,7 @@ spec:
       description: "Integration test release for the push-artifacts-to-cdn pipeline"
       solution: "Update to Konflux Release E2E test product 1.0"
     sign:
-      configMapName: "hacbs-signing-pipeline-config-redhatrelease2"
+      configMapName: "hacbs-signing-pipeline-config-staging-e2e"
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -179,7 +179,18 @@ spec:
         AUTHOR=$(jq -r '.status.attribution.author' "$(params.dataDir)/$(params.releasePath)")
         if [[ "${AUTHOR}" == "null" ]] ; then echo "No author found in Release.Status. Failing..." ; exit 1 ; fi
         configMapName=$(jq -er '.sign.configMapName' "${DATA_FILE}")
-        signingKeyName=$(kubectl get configmap "$configMapName" -o jsonpath="{.data.SIG_KEY_NAME}")
+        configMapJson=$(kubectl get "configmap/${configMapName}" -o json)
+        # Some configmaps (e.g. e2e/staging ones) only define a comma-separated
+        # SIG_KEY_NAMES list rather than a single SIG_KEY_NAME. Use the first entry,
+        # matching the SIG_KEY_NAMES parsing convention used by rh-sign-image/sign-index-image.
+        jqquery='(.data // {})|if has("SIG_KEY_NAME") then .SIG_KEY_NAME
+        elif has("SIG_KEY_NAMES") then (.SIG_KEY_NAMES|split(",")|.[0]|gsub("^\\s+|\\s+$";""))
+        else "" end'
+        signingKeyName=$(jq -r "$jqquery" <<< "${configMapJson}")
+        if [[ -z "${signingKeyName}" ]] ; then
+          echo "No SIG_KEY_NAME or SIG_KEY_NAMES found in configmap ${configMapName}. Failing..."
+          exit 1
+        fi
         RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/push-artifacts-results.json"
         FILES=$(jq -c '{"artifacts": [.components[].staged?.files[]?.filename]}' <<< "$snapshot")
         echo "$FILES" > "$RESULTS_FILE"

--- a/tasks/managed/push-artifacts-to-cdn/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/push-artifacts-to-cdn/tests/pre-apply-task-hook.sh
@@ -52,7 +52,7 @@ cat > "/tmp/configmap.json" << EOF
     "namespace": "default"
   },
   "data": {
-    "SIG_KEY_ID": "testKey"
+    "SIG_KEY_NAME": "testKey"
   }
 }
 EOF

--- a/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-signing-key-names-fallback.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/tests/test-push-artifacts-to-cdn-signing-key-names-fallback.yaml
@@ -1,0 +1,239 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-artifacts-to-cdn-signing-key-names-fallback
+spec:
+  description: |
+    Run the push-artifacts-to-cdn task with a signing configmap that only defines
+    the plural SIG_KEY_NAMES list (no singular SIG_KEY_NAME) and ensure the task
+    falls back to using the first entry in that list.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:b62e2fef45c84259c60c7097f5a572a4c32f957ffeee3eed53eb0b7d560e5234
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl create configmap test-config-map-sig-key-names \
+                --from-literal=SIG_KEY_NAMES="e2eTestKey, anotherKey"
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              mkdir "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "artifacts",
+                "components": [
+                  {
+                    "name": "nvidia-disk-image",
+                    "containerImage": "quay.io/workload/tenant/disk-image/nvidia@sha256:123456",
+                    "repository": "repo1"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "contentGateway": {
+                  "productName": "Konflux test product",
+                  "productCode": "KTestProduct",
+                  "productVersionName": "KTestProduct 1",
+                  "components": [
+                    {
+                      "name": "test-component",
+                      "description": "Red Hat OpenShift Local Sandbox Test",
+                      "label": "Checksum File Sandbox Test"
+                    }
+                  ]
+                },
+                "cdn": {
+                  "env": "production"
+                },
+                "sign": {
+                  "configMapName": "test-config-map-sig-key-names"
+                }
+              }
+              EOF
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release_plan_admission.json" << EOF
+              {
+                "spec": {
+                  "pipeline": {
+                    "pipelineRef": {
+                      "resolver": "git",
+                      "params": [
+                        {
+                          "name": "url",
+                          "value": "https://localhost.git"
+                        },
+                        {
+                          "name": "revision",
+                          "value": "main"
+                        },
+                        {
+                          "name": "pathInRepo",
+                          "value": "pipelines/abc/abc.yaml"
+                        }
+                      ]
+                    },
+                    "serviceAccountName": "release-service-account"
+                  }
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/release.json" << EOF
+              {
+                "status": {
+                  "attribution": {
+                    "author": "JohnDoe"
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-artifacts-to-cdn
+      params:
+        - name: releasePath
+          value: $(context.pipelineRun.uid)/release.json
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot_spec.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: releasePlanAdmissionPath
+          value: $(context.pipelineRun.uid)/release_plan_admission.json
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:b62e2fef45c84259c60c7097f5a572a4c32f957ffeee3eed53eb0b7d560e5234
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check that the signingKeyName param used the first entry from the
+              # configmap's comma-separated plural SIG_KEY_NAMES list, since no
+              # singular SIG_KEY_NAME was defined
+              if [ "$(jq -r '.spec.params.signingKeyName' <<< "$internalRequest")" != "e2eTestKey" ]; then
+                echo "InternalRequest has the wrong signingKeyName parameter"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:b62e2fef45c84259c60c7097f5a572a4c32f957ffeee3eed53eb0b7d560e5234
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all
+              kubectl delete configmap test-config-map-sig-key-names --ignore-not-found


### PR DESCRIPTION
The push-artifacts-to-cdn e2e RPA referenced the production redhatrelease2 signing configmap. The e2e service account is not authorized to sign with that key, causing rpm-sign to fail with a 401 on every checksum-signing attempt.

Point the e2e RPA at the existing staging-e2e signing configmap instead, and add a fallback in the managed task so a configmap defining the plural SIG_KEY_NAMES list (used by e2e/staging configs) is read correctly when the singular SIG_KEY_NAME field is absent. Behavior for existing configmaps that only set SIG_KEY_NAME is unchanged.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
