### PR TITLE
fix(RHELBLD-18943): resolve Koji build target to destination tag

### DIFF
--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -170,6 +170,16 @@ spec:
                 jq -r '.extra.sidetag'
         }
 
+        get_dest_tag() {
+            local dest_tag
+            dest_tag="$(koji-cmd --noauth call --json-output getBuildTarget "$1" | jq -r '.dest_tag_name')"
+            if [[ -z "${dest_tag}" || "${dest_tag}" == "null" ]]; then
+                echo "ERROR: Failed to resolve build target '$1' to a destination tag." >&2
+                exit 1
+            fi
+            echo "${dest_tag}"
+        }
+
         # Fetch the component list from data.pushOptions.components by default, if there is no such list
         # fetch from data.mapping.components.
         RELEASE_COMPONENTS=$(jq -r '
@@ -262,7 +272,7 @@ spec:
               exit 1
           fi
 
-          koji_tag=${koji_target}
+          koji_tag="$(get_dest_tag "${koji_target}")"
           # Make sure "-draft" suffix is added to the tag for draft imports,
           # but avoid modifying sidetags.
           if [[ "$draft" == "true" && "$koji_tag" != *-draft ]]; then

--- a/tasks/managed/push-rpm-to-koji/tests/mocks.sh
+++ b/tasks/managed/push-rpm-to-koji/tests/mocks.sh
@@ -49,7 +49,11 @@ EOF
 
 function koji() {
     echo "koji $*" >> "$(params.dataDir)/koji_calls.txt"
-    if [[ "$*" == *CGInitBuild*\"test-foo\"* ]]; then
+    if [[ "$*" == *getBuildTarget*-sidetag* ]]; then
+        echo '{"dest_tag_name": "mock-target-sidetag"}'
+    elif [[ "$*" == *getBuildTarget* ]]; then
+        echo '{"dest_tag_name": "mock-target-candidate"}'
+    elif [[ "$*" == *CGInitBuild*\"test-foo\"* ]]; then
         echo '{"build_id": 111, "token": "mock-token"}'
     elif [[ "$*" == *CGInitBuild*\"test-bar\"* ]]; then
         echo '{"build_id": 222, "token": "mock-token"}'

--- a/tasks/managed/update-package-collection/tests/mocks.sh
+++ b/tasks/managed/update-package-collection/tests/mocks.sh
@@ -44,7 +44,11 @@ EOF
 
 function koji() {
     echo "koji $*" >> "$(params.dataDir)/koji_calls.txt"
-    if [[ "$*" == *getInheritanceData* ]]; then
+    if [[ "$*" == *getBuildTarget*-sidetag* ]]; then
+        echo '{"dest_tag_name": "mock-target-sidetag"}'
+    elif [[ "$*" == *getBuildTarget* ]]; then
+        echo '{"dest_tag_name": "mock-target-candidate"}'
+    elif [[ "$*" == *getInheritanceData* ]]; then
         # Only return inheritance data for mock-target collections (koji tags)
         if [[ "$*" == *mock-target* ]]; then
             echo '[{"name": "rhel-10.9-beta", "priority": 10}, {"name": "rhel-10.1-beta", "priority": 20}]'

--- a/tasks/managed/update-package-collection/update-package-collection.yaml
+++ b/tasks/managed/update-package-collection/update-package-collection.yaml
@@ -385,6 +385,16 @@ spec:
                 jq -r '.extra.sidetag'
         }
 
+        get_dest_tag() {
+            local dest_tag
+            dest_tag="$(koji-cmd --noauth call --json-output getBuildTarget "$1" | jq -r '.dest_tag_name')"
+            if [[ -z "${dest_tag}" || "${dest_tag}" == "null" ]]; then
+                echo "ERROR: Failed to resolve build target '$1' to a destination tag." >&2
+                return 1
+            fi
+            echo "${dest_tag}"
+        }
+
         verify_package_collection_is_koji_tag() {
             local collection="$1"
             local tag_info inheritance_data
@@ -476,7 +486,7 @@ spec:
 
           echo "INFO: Found Koji build target: $koji_target" >&2
 
-          koji_tag=${koji_target}
+          koji_tag="$(get_dest_tag "${koji_target}")"
           # Make sure "-draft" suffix is added to the tag for draft imports,
           # but avoid modifying sidetags.
           if [[ "$KOJI_IMPORT_DRAFT" == "true" && "$koji_tag" != *-draft ]]; then
@@ -556,8 +566,12 @@ spec:
 
           # Get package collections(includes koji_target as one of the items) and remove duplicates in one step
           pkg_collections=()
-
-          mapfile -t pkg_collections < <(get_package_collections "$component_name" "$container_image" | sort -u)
+          local pkg_collections_output
+          if ! pkg_collections_output="$(get_package_collections "$component_name" "$container_image" | sort -u)"; then
+              echo "ERROR: Failed to get package collections for component '$component_name'." >&2
+              exit 1
+          fi
+          mapfile -t pkg_collections <<< "${pkg_collections_output}"
 
           echo "INFO: All package collections (including Koji target): ${pkg_collections[*]}"
 


### PR DESCRIPTION
## Describe your changes

The push-rpm-to-koji and update-package-collection tasks used the Koji build target name directly as a tag name, which fails when they differ (e.g. target rhel-9.9.0-dup-draft has destination tag rhel-9.9.0-draft). Resolve the target to its destination tag via getBuildTarget API.

Assisted-by: Claude Code (claude-opus-4-6)

## Relevant Jira

RHELBLD-18943

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
