### PR TITLE
chore: double memory from oomkilled tasks

### DIFF
--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -69,9 +69,9 @@ spec:
       image: quay.io/konflux-ci/release-service-utils@sha256:48323c256efcb3c318762cb66b3a9cabd827a0bef2485cb91e8c7aed7d1fb1f0
       computeResources:
         limits:
-          memory: 256Mi
+          memory: 512Mi
         requests:
-          memory: 256Mi
+          memory: 512Mi
           cpu: '1'
       volumeMounts:
         - name: advisory-secret

--- a/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
+++ b/tasks/internal/publish-index-image-task/publish-index-image-task.yaml
@@ -71,9 +71,9 @@ spec:
         quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
       computeResources:
         limits:
-          memory: 64Mi
+          memory: 128Mi
         requests:
-          memory: 64Mi
+          memory: 128Mi
           cpu: 400m
       script: |
         #!/usr/bin/env bash


### PR DESCRIPTION
A investigation into the internal-services namespace found two steps that were frequently hitting OOMKills. This commit doubles the memory for each of them (step-filter-images, step-publish-index-image).

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
