### PR TITLE
test(RELEASE-2319): assert advisory URL in release-to-github e2e

### DIFF
--- a/integration-tests/release-to-github-idempotent/test.sh
+++ b/integration-tests/release-to-github-idempotent/test.sh
@@ -119,6 +119,16 @@ verify_release_contents() {
     else
         log_error "GitHub release URL was empty in first release"
     fi
+
+    # Verify first release advisory URL
+    local first_advisory_url
+    first_advisory_url="$(jq -r '.status.artifacts.advisory.url // ""' <<< "${first_release_json}" 2>/dev/null || true)"
+    echo "Checking advisory URL..."
+    if [ -n "${first_advisory_url}" ]; then
+        echo "✅ advisory_url: ${first_advisory_url}"
+    else
+        log_error "advisory_url was empty in first release"
+    fi
     echo "✅ First release verified successfully"
 
     # Capture asset list from the first release for later comparison
@@ -187,6 +197,19 @@ EOF
         second_failures=$((second_failures + 1))
     fi
 
+    # Verify second release has a non-empty advisory URL
+    # Note: Unlike the RH advisories pipeline, release-to-github creates a new advisory for each release
+    # (no already-released advisory filter), so the URLs may differ between runs.
+    local second_advisory_url
+    second_advisory_url="$(jq -r '.status.artifacts.advisory.url // ""' <<< "${second_release_json}" 2>/dev/null || true)"
+    echo "Second release advisory URL: ${second_advisory_url}"
+    if [ -n "${second_advisory_url}" ]; then
+        echo "✅ Second release has advisory URL: ${second_advisory_url}"
+    else
+        echo "🔴 advisory_url was empty in second release"
+        second_failures=$((second_failures + 1))
+    fi
+
     # Verify create-github-release detected the existing release and skipped creation
     echo "Checking that create-github-release detected existing release..."
     local create_release_logs
@@ -245,6 +268,7 @@ EOF
     echo "  • Second release: detected existing release → skipped creation (no duplicate)"
     echo "  • Second release: sign-base64-blob re-signed (expected — fresh workspace per run)"
     echo "  • GitHub release URL consistent across both runs: ${first_url}"
+    echo "  • Advisory URLs present in both releases"
     echo "  • No duplicate GitHub release created"
     echo "  • GitHub release assets identical across both runs (no extra files uploaded)"
     echo ""

--- a/integration-tests/release-to-github/test.sh
+++ b/integration-tests/release-to-github/test.sh
@@ -31,8 +31,10 @@ verify_release_contents() {
 
       local failures=0
       local url
+      local advisory_url
 
       url=$(jq -r '.status.artifacts."github-release".url // ""' <<< "${release_json}")
+      advisory_url="$(jq -r '.status.artifacts.advisory.url // ""' <<< "${release_json}" 2>/dev/null || true)"
       echo "Checking url: ${url}..."
       if [ -n "${url}" ]; then
         # get tag from URL
@@ -49,6 +51,14 @@ verify_release_contents() {
         fi
       else
         echo "🔴 url was empty!"
+        failures=$((failures+1))
+      fi
+
+      echo "Checking advisory URL..."
+      if [ -n "${advisory_url}" ]; then
+        echo "✅️ advisory_url: ${advisory_url}"
+      else
+        echo "🔴 advisory_url was empty!"
         failures=$((failures+1))
       fi
 


### PR DESCRIPTION
## Describe your changes
The current release-to-github e2e test does not verify whether an advisory was actually created, meaning a silent failure in create-advisory would go undetected. This change extends verify_release_contents() in both release-to-github and release-to-github-idempotent tests to assert that status.artifacts.advisory.url is non-empty after a release completes. The idempotent test additionally verifies that the advisory URL remains consistent across both release runs.

## Relevant Jira
[RELEASE-2319](https://redhat.atlassian.net/browse/RELEASE-2319)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`

Assisted-by: Claude


[RELEASE-2319]: https://redhat.atlassian.net/browse/RELEASE-2319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ