### PR TITLE
fix(RELEASE-2753): use data.json fbc key for index detection

### DIFF
--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -224,6 +224,7 @@ spec:
         # Default to false
         includeLayers="$(jq -r ".pyxis.includeLayers // false" "${DATA_FILE}")"
         appendTags="$(jq -r ".pyxis.appendTags // false" "${DATA_FILE}")"
+        IS_FBC="$(jq -e '.fbc' "${DATA_FILE}" > /dev/null 2>&1 && echo "true" || echo "false")"
 
         # Function to process a single component in parallel
         process_component() {
@@ -271,7 +272,7 @@ spec:
                 # The digest may differ between SOURCE and TARGET registries after
                 # publish-index-image, and floating tags can be overwritten by parallel
                 # IIB builds. Tag-based inspection always resolves correctly on TARGET.
-                if [[ "${REPOSITORY}" =~ /(preview-operator-index|redhat-operator-index)$ ]]; then
+                if [[ "${IS_FBC}" == "true" ]]; then
                     FIRST_TAG=$(jq -r '.tags[0]' <<< "${REPOSITORY_OBJECT}")
                     PULLSPEC="${REPOSITORY}:${FIRST_TAG}"
                 else

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fbc-tag-inspection.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-fbc-tag-inspection.yaml
@@ -1,0 +1,185 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-pyxis-image-fbc-tag-inspection
+spec:
+  description: >
+    Run the create-pyxis-image task with an FBC data.json to verify that
+    tag-based inspection (repo:tag) is used instead of digest-based (repo@digest).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/mapped_snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "source@sha256:mydigest",
+                    "repositories": [
+                      {
+                        "url": "registry.io/image1",
+                        "tags": [
+                          "v4.12",
+                          "v4.12-1678118351"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
+              {
+                "fbc": {
+                  "publishingCredentials": "test-credentials"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: create-pyxis-image
+      params:
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: server
+          value: stage
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+        - name: rhPush
+          value: "true"
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/mydata.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # Verify skopeo was called with tag-based pullspec (not digest-based)
+              if grep -q 'docker://registry.io/image1@sha256:mydigest' \
+                "$(params.dataDir)/mock_skopeo.txt"; then
+                echo "Error: FBC image should use tag-based inspection, not digest-based."
+                echo "Actual skopeo calls:"
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              if ! grep -q 'docker://registry.io/image1:v4.12' \
+                "$(params.dataDir)/mock_skopeo.txt"; then
+                echo "Error: FBC image should be inspected by first tag (v4.12)."
+                echo "Actual skopeo calls:"
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+      runAfter:
+        - run-task


### PR DESCRIPTION
Replace fragile regex heuristic on repository names with a
check for the fbc key in data.json.
    
Add test to verify create-pyxis-image uses tag-based
pullspec when data.json contains an fbc key. Also quote
the IS_FBC command substitution.
    
Signed-Off-By: Leandro Mendes <lmendes@redhat.com>
Assisted-by: Claude

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
