### PR TITLE
fix(ISV-7116): update utils image in direct signing tasks

### DIFF
--- a/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
@@ -167,7 +167,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: direct-sign-index-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:a2c2fbf89bced4c0421f6a2237f467a94fa38c0b722e4c32368c4d291dbc7323
+      image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -148,7 +148,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail

--- a/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
@@ -174,7 +174,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:a2c2fbf89bced4c0421f6a2237f467a94fa38c0b722e4c32368c4d291dbc7323
+      image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/managed/rh-direct-sign-image/tests/python_mocks/pyxis.py
+++ b/tasks/managed/rh-direct-sign-image/tests/python_mocks/pyxis.py
@@ -8,3 +8,7 @@ def graphql_query(
     graphql_api: str, body: dict[str, Any], allow_not_found: bool = False
 ) -> dict[str, Any]:
     return {"find_signatures": {"data": [], "error": None}}
+
+
+def _get_session(retry_allowed_methods: Any = None) -> None:
+    return None

--- a/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail
@@ -161,7 +161,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail


### PR DESCRIPTION
## Summary

- Update `release-service-utils` image SHA to `b42578b8eda9853aaac89353d184358abfff8e117c95ab6981658a0f04bf7d32` in `rh-direct-sign-image` and `direct-sign-index-image` tasks and their tests
- Picks up the fix from [konflux-ci/release-service-utils#913](https://github.com/konflux-ci/release-service-utils/pull/913) which adds POST retry support for Pyxis GraphQL calls in the direct signing scripts