### PR TITLE
docs(RELEASE-2455): note standalone scripts convention for tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This is the Release Service Catalog - a collection of Tekton resources (Tasks, P
 - **Commits**: Conventional commits enforced by gitlint, scope is a Jira ticket ID: `feat(JIRA-1234): message`, `fix(JIRA-1234): message`
 - **YAML style**: 120-char max, consistent indentation, `---` document start, max 1 empty line
 - **Tekton tasks**: Trusted Artifacts tasks with non-`release-service-utils` images MUST set `stepTemplate.securityContext.runAsUser: 1001`; all tasks SHOULD specify compute resource requirements
+- **New tasks**: implement logic as a standalone script (usually Python) in the [release-service-utils repo](https://github.com/konflux-ci/release-service-utils), referenced via `command`, rather than inline `script` shell code — see [RELEASE-2455](https://redhat.atlassian.net/browse/RELEASE-2455)
 - **Vault files** (`.*vault.*\.(yaml|yml)$`): MUST be encrypted with `ansible-vault` before commit
 - **READMEs** under `tasks/` and `pipelines/`: auto-generated, do not edit by hand
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,20 @@ This repo uses [MintMaker](https://konflux-ci.dev/docs/mintmaker/user/) to autom
 All other images should be referenced the same way as the release-service-utils image, by digest. For example: `registry.access.redhat.com/ubi8/ubi@sha256:c94bc309b197f9fc465052123ead92bf50799ba72055bd040477ded`.
 This allows MintMaker to automatically manage and update image digests.
 
+### Adding New Tasks
+
+When adding a new task, its logic should be implemented as a standalone script (usually Python) defined in the
+[release-service-utils repo](https://github.com/konflux-ci/release-service-utils), rather than written inline in
+the task's `script` field. The task step should then reference the script via `command`, for example:
+
+```yaml
+command: ["/home/scripts/python/tasks/managed/my_new_script.py"]
+```
+
+This makes the logic easier to unit test, reuse, and maintain outside of the Tekton YAML. This is part of an
+ongoing effort to convert existing tasks as well, tracked in
+[RELEASE-2455](https://redhat.atlassian.net/browse/RELEASE-2455).
+
 ### Compute Resources
 
 All steps in the [managed](tasks/managed) and [internal](tasks/internal) tasks have `computeResources` defined. This is because the namespace in which these run is often under a very high load.


### PR DESCRIPTION
## Describe your changes

New tasks should implement logic as standalone scripts in the release-service-utils image rather than inline shell, per the epic to convert managed tasks to use standalone scripts.

Assisted-by: Claude Code

## Relevant Jira

RELEASE-2455

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
