### PR TITLE
fix(RELEASE-2760): publish-index-image error handling and preGA

### DIFF
--- a/tasks/managed/publish-index-image/publish-index-image.yaml
+++ b/tasks/managed/publish-index-image/publish-index-image.yaml
@@ -160,11 +160,11 @@ spec:
 
           publishingImages=("${targetIndex}")
           publishingSources=("${sourceIndex}")
-          # only publish the extra tag when it does not contain a timestamp already
-          # which is the case for pre-ga and hotfix
-          if [ "${targetIndex}" != "${targetIndexWithTimestamp}" ]; then
+          # only publish the extra timestamped tag for GA releases.
+          # pre-ga and hotfix targets already contain a timestamp, so skip.
+          if [ "${targetIndex}" != "${targetIndexWithTimestamp}" ] && \
+             ! [[ "${targetIndex}" =~ [0-9]{10}$ ]]; then
             publishingImages+=("${targetIndexWithTimestamp}")
-            # Use resolved digest for timestamped tag to avoid race with parallel IIB builds
             publishingSources+=("${sourceIndexResolved}")
           fi
 
@@ -194,7 +194,7 @@ spec:
                   --task-timeout "$taskTimeout" \
                   -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
                   | tee "$IR_RESULT_FILE" || \
-                  (grep "^\[" "$IR_RESULT_FILE" | jq . && exit 1)
+                  { grep "^\[" "$IR_RESULT_FILE" | jq . ; exit 1; }
 
               internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_RESULT_FILE")
               echo "done (${internalRequest})"
@@ -202,15 +202,15 @@ spec:
               # get the internal request status
               internalRequestJson="$(kubectl get internalrequest "${internalRequest}" -o json | jq -c)"
  
-              status="$(jq '.status.conditions[].status' <<< "$internalRequestJson")"
+              status="$(jq -r '.status.conditions[].status' <<< "${internalRequestJson}")"
               if [ "$status" = "False" ]; then
-                errorMessage="$(jq '.status.conditions[].message' <<< "$internalRequestJson")"
+                errorMessage="$(jq -r '.status.conditions[].message' <<< "${internalRequestJson}")"
                 echo "ERROR: Publish to ${publishingImages[$x]} failed"
                 echo "errorMessage: $errorMessage"
                 exit 1
               fi
 
-              results=$(jq '.status.results' <<< "$internalRequestJson")
+              results="$(jq '.status.results' <<< "${internalRequestJson}")"
               requestMessage=$(echo "${results}" | jq -r '.requestMessage // ""')
 
               if echo "${requestMessage}" | grep -qi "error"; then

--- a/tasks/managed/publish-index-image/tests/test-publish-index-image-prega.yaml
+++ b/tasks/managed/publish-index-image/tests/test-publish-index-image-prega.yaml
@@ -1,0 +1,232 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-publish-index-image-prega
+spec:
+  description: Test that preGA releases only publish one image (target already has timestamp)
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "fbc": {
+                  "publishingCredentials": "test-credentials"
+                }
+              }
+              EOF
+              cat > "$(params.dataDir)/internal-requests-results.json" << EOF
+              {
+                "components": [
+                  {
+                    "fbc_fragment": "registry.io/image0@sha256:0000",
+                    "target_index": "quay.io/scoheb/fbc-target-index-testing:v4.13-preGA-product-v2-1785741945",
+                    "target_index_with_timestamp": "quay.io/scoheb/fbc-target-index-testing:v4.13-preGA-product-v2-1785741945",
+                    "ocp_version": "v4.13",
+                    "index_image": "redhat.com/rh-stage/iib:01",
+                    "index_image_resolved": "redhat.com/rh-stage/iib@sha256:abcdefghijk",
+                    "image_digests": [
+                      "quay.io/a",
+                      "quay.io/b"
+                    ],
+                    "completion_time": "2026-07-03T07:30:52.000000Z",
+                    "iibLog": "Dummy IIB Log"
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: publish-index-image
+      params:
+        - name: internalRequestResultsFile
+          value: "internal-requests-results.json"
+        - name: retries
+          value: 2
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -euxo pipefail
+
+              # preGA target already ends with a timestamp, so only 1 IR should be created
+              irCount="$(kubectl get internalrequest --no-headers | wc -l)"
+              if [ "${irCount}" != "1" ]; then
+                echo "Expected 1 InternalRequest for preGA, got ${irCount}"
+                kubectl get internalrequest
+                exit 1
+              fi
+
+              internalRequest="$(kubectl get internalrequest --no-headers \
+                -o jsonpath='{.items[0].metadata.name}')"
+
+              pipeline="$(kubectl get internalrequest "${internalRequest}" -o \
+                jsonpath="{.spec.pipeline.pipelineRef.params[2].value}")"
+
+              params="$(kubectl get internalrequest "${internalRequest}" -o jsonpath="{.spec.params}")"
+
+              if [ "${pipeline}" != \
+                "pipelines/internal/publish-index-image-pipeline/publish-index-image-pipeline.yaml" ]; then
+                echo "pipeline does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.retries' <<< "${params}")" != "2" ]; then
+                echo "number of retries does not match"
+                exit 1
+              fi
+
+              sourceIndex="$(jq -r '.sourceIndex' <<< "${params}")"
+              if [ "${sourceIndex}" != "redhat.com/rh-stage/iib:01" ]; then
+                echo "sourceIndex does not match"
+                echo "Expected: redhat.com/rh-stage/iib:01"
+                echo "Got: ${sourceIndex}"
+                exit 1
+              fi
+
+              targetIndex="$(jq -r '.targetIndex' <<< "${params}")"
+              expectedTarget="quay.io/scoheb/fbc-target-index-testing:v4.13-preGA-product-v2-1785741945"
+              if [ "${targetIndex}" != "${expectedTarget}" ]; then
+                echo "targetIndex does not match"
+                echo "Expected: ${expectedTarget}"
+                echo "Got: ${targetIndex}"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.targetOcpVersion' <<< "${params}")" != "v4.13" ]; then
+                echo "targetOcpVersion does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitUrl' <<< "${params}")" != "http://localhost" ]; then
+                echo "taskGitUrl does not match"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.taskGitRevision' <<< "${params}")" != "main" ]; then
+                echo "taskGitRevision does not match"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              kubectl delete internalrequests --all


### PR DESCRIPTION
Fix three broken failure-detection paths:
- exit 1 in subshell (...) only killed the subshell, replaced with brace group
- jq without -r returned quoted "False", so the status comparison never matched
- jq without -r on error message included JSON quotes

Skip duplicate publish for preGA/hotfix: targets
already ending with a 10-digit timestamp no longer get an extra timestamped publish. Add preGA test
asserting only one InternalRequest is created.

Assisted-by: Claude

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
