### PR TITLE
fix: clarify error handling note in agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ Test locally first. Use `--pr-mode` for pre-merge validation. Check `test-result
 - **jq flags**: `-r` for raw output, `-c` for compact, `-e` to exit non-zero on false/null
 - **Tekton results**: `echo -n "value" > "$(results.name.path)"` — always `-n` to avoid trailing newlines
 - **curl**: use `--retry 3`, `-s` for silent, `--fail-with-body` for error handling; pipe to `jq -r` for parsing
-- **Error handling**: trap EXIT to write success/failure to results; always `exit 0` (let Tekton results carry status)
+- **Error handling**: internal tasks MUST always `exit 0` and write success/failure to `$(results.result.path)`.
+  Use a `trap EXIT` handler or write the result explicitly at each exit point. A non-zero exit prevents Tekton
+  from setting results that the calling managed task needs. Managed and collector tasks can use non-zero exit codes as appropriate to signal errors
 - **Secrets**: `set +x` before using sensitive values, re-enable after; read from mounted files, not env vars
 - **Cleanup**: `mktemp` + `trap 'rm -f "${TEMP_FILE}"' EXIT`; use `pushd`/`popd` for directory changes
 


### PR DESCRIPTION
## Describe your changes
The previous wording implied all tasks should trap EXIT and always exit 0, which is only true for internal tasks. Managed and collector tasks should exit non-zero on failure.

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
