### PR TITLE
fix: use multi-platform build pipeline for addons comp2

### DIFF
--- a/integration-tests/push-to-addons-registry/resources/tenant/component2.yaml
+++ b/integration-tests/push-to-addons-registry/resources/tenant/component2.yaml
@@ -6,6 +6,7 @@ metadata:
     git-provider: github
     build.appstudio.openshift.io/request: configure-pac
     image.redhat.com/generate: '{"visibility": "public"}'
+    build.appstudio.openshift.io/pipeline: '{"name": "docker-build-multi-platform-oci-ta", "bundle": "latest"}'
   name: ${component2_name}
   labels:
     originating-tool: "${originating_tool}"


### PR DESCRIPTION
## Summary
- `push-to-addons-registry` e2e was failing because `component2`'s image
  came back amd64-only, a plain Docker manifest instead of an OCI image
  index, tripping the arch/skopeo checks in `test.sh`.
- Root cause (confirmed via KubeArchive on stone-stg-rh01): `component2.yaml`
  was missing the `build.appstudio.openshift.io/pipeline` annotation that
  `component.yaml` has, so it defaulted to the single-arch
  `docker-build-oci-ta` pipeline instead of `docker-build-multi-platform-oci-ta`.
  The test's `build-platforms: [linux/amd64, linux/arm64]` param patch is a
  no-op against that pipeline since it has no per-platform matrix logic.
- Adds the same annotation `component.yaml` already has, so both components
  in the multi-component test build multi-arch as intended.

## Test plan
- [ ] Re-run the `push-to-addons-registry` e2e test in staging and confirm
      both images report `amd64 arm64` arches and pass skopeo verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)