### PR TITLE
chore: pin release-service-automations actions to latest SHA

### DIFF
--- a/.github/workflows/pr-ai-labeler.yaml
+++ b/.github/workflows/pr-ai-labeler.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR using shared action
-        uses: konflux-ci/release-service-automations/pr-ai-labeler@e8ce558575d626c6be6e897c0f3244af558e8c09  # main
+        uses: konflux-ci/release-service-automations/pr-ai-labeler@5f659d076b62341c25efe6883cc561094e51f7fb  # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-assigner.yaml
+++ b/.github/workflows/pr-assigner.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign reviewers using shared action
-        uses: konflux-ci/release-service-automations/pr-assigner@e8ce558575d626c6be6e897c0f3244af558e8c09  # main
+        uses: konflux-ci/release-service-automations/pr-assigner@5f659d076b62341c25efe6883cc561094e51f7fb  # main
         with:
           event-type: ${{ github.event.action }}
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Describe your changes

Update konflux-ci/release-service-automations references from e8ce558 to 5f659d0 in pr-ai-labeler and pr-assigner workflows.

Generated-by: Claude

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
