### PR TITLE
test(RELEASE-2744): check cosign2 idempotency behavior pre-switch

### DIFF
--- a/integration-tests/rh-advisories-idempotent/resources/managed/rpa.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/managed/rpa.yaml
@@ -9,6 +9,9 @@ spec:
   applications:
     - ${application_name}
   data:
+    # Skip idempotency filtering so the second release still runs every task
+    # (including sign) instead of short-circuiting on the already-released check
+    skipFilter: true
     jira:
       jiraAdvisorySecret: advisory-jira-secret-${component_name}
     cgw:

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -205,7 +205,9 @@ spec:
         }
         echopid(){
             pid=$(jobpid)
-            echo "${pid}: $*"
+            # Written to stderr so it never leaks into a caller's $(...) capture,
+            # e.g. run_cosign's stdout is captured as cosign's own JSON output.
+            echo "${pid}: $*" >&2
         }
         run_cosign () { # Expected arguments are [digest_reference, tag_reference]
             attempt=0
@@ -240,10 +242,13 @@ spec:
               COSIGN_REKOR_ARGS+=("--insecure-ignore-tlog=true")
           fi
           verify_output=$(run_cosign verify "${COSIGN_REKOR_ARGS[@]}" --key "$PUBLIC_KEY_FILE" "$reference")
-          found_signatures=$(echo "$verify_output" | jq -j '['\
+          if ! found_signatures=$(echo "$verify_output" | jq -j '['\
         '.[]|select(.critical.image."docker-manifest-digest"| contains("'"$digest"'"))'\
         '|select(.critical.identity."docker-reference" == "'"$identity"'")'\
-        ']|length')
+        ']|length'); then
+            echopid "ERROR: cosign verify output for ${reference} was not valid JSON: ${verify_output}"
+            exit 1
+          fi
           echo "$found_signatures"
         }
         function check_and_sign() {


### PR DESCRIPTION
## Purpose

Diagnostic-only PR, not intended to merge. Investigating whether
cosign2 (pre-cosign3-switch) correctly detects existing signatures
on a release retry, to isolate whether the `crypto/rsa` Rekor
verification error observed on cosign3 (see RELEASE-2744) is
cosign3-specific or a pre-existing environment/Rekor-server issue.

## Changes

- Adapt the observability fix from the cosign3 branch (echopid to
  stderr, fail loudly on a genuine jq parse failure) onto this
  branch's pre-switch `check_existing_signatures` function. This is
  intentionally minimal - it does not change any signing/skip
  decision logic, only makes failures visible instead of silent.
- Set `skipFilter: true` on the `rh-advisories-idempotent` RPA so
  the second (retry) release runs every task, including
  `rh-sign-image-cosign`, instead of short-circuiting at the
  already-released filter check.

## Plan

Run e2e, then compare the `rh-sign-image-cosign` task logs from the
first release and the retry release against what we already
observed with cosign3.

Do not merge - revert before landing anything from this branch.

Assisted-by: Claude Code