### PR TITLE
chore: allow one space before YAML comments for MintMaker pins

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -8,6 +8,8 @@ rules:
     spaces: consistent
   comments:
     require-starting-space: true
+    # MintMaker/Renovate pin digests with a single space before "# <ref>"
+    min-spaces-from-content: 1
   document-start:
     present: true
   empty-lines:


### PR DESCRIPTION
## Describe your changes

Relax yamllint `comments.min-spaces-from-content` from the default of 2 to 1 so MintMaker/Renovate digest pins stop failing CI.
MintMaker writes action pins with a single space before the ref comment, e.g.:
```
yaml

- uses: konflux-ci/renovate-config-validator-action@1891cfb… # main
```
yamllint then fails with too few spaces before comment (comments).

This showed up on [#2261](https://github.com/konflux-ci/release-service-catalog/pull/2261) (yamllint was the only failing check). Sean suggested relaxing the rule rather than ignoring .github/workflows/;

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
