### PR TITLE
chore: bump Conforma version to 2026-08-11 release

### DIFF
--- a/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
@@ -212,7 +212,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "f20c7a8c15a71c9462b11e5a28f8907a29c7075a"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/e2e/e2e.yaml
+++ b/pipelines/managed/e2e/e2e.yaml
@@ -119,7 +119,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/fbc-release/fbc-release.yaml
+++ b/pipelines/managed/fbc-release/fbc-release.yaml
@@ -246,7 +246,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -252,7 +252,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
+++ b/pipelines/managed/push-artifacts-to-storage/push-artifacts-to-storage.yaml
@@ -215,7 +215,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -242,7 +242,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
+++ b/pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml
@@ -248,7 +248,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
+++ b/pipelines/managed/push-oot-kmods/push-oot-kmods.yaml
@@ -318,7 +318,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -215,7 +215,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
+++ b/pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml
@@ -341,7 +341,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
+++ b/pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml
@@ -276,7 +276,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
+++ b/pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml
@@ -277,7 +277,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
@@ -314,7 +314,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/release-to-github/release-to-github.yaml
+++ b/pipelines/managed/release-to-github/release-to-github.yaml
@@ -239,7 +239,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
+++ b/pipelines/managed/release-to-mrrc/release-to-mrrc.yaml
@@ -216,7 +216,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/release-to-nrrc/release-to-nrrc.yaml
+++ b/pipelines/managed/release-to-nrrc/release-to-nrrc.yaml
@@ -216,7 +216,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -380,7 +380,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-helm-chart-to-registry-redhat-io/rh-push-helm-chart-to-registry-redhat-io.yaml
@@ -338,7 +338,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -343,7 +343,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -309,7 +309,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rh-rpm-advisories/rh-rpm-advisories.yaml
+++ b/pipelines/managed/rh-rpm-advisories/rh-rpm-advisories.yaml
@@ -235,7 +235,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:

--- a/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/managed/rhtap-service-push/rhtap-service-push.yaml
@@ -285,7 +285,7 @@ spec:
           - name: url
             value: https://github.com/conforma/tekton-catalog
           - name: revision
-            value: "2c1963225e8563194a8dce7f659c71bd866da426"
+            value: "38002d483c4b405e78806ed2d8c9f4c01e91e429"
           - name: pathInRepo
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:


### PR DESCRIPTION
## Describe your changes

Updates verify-conforma-konflux-ta task reference across all managed pipelines to conforma/tekton-catalog@38002d483c4b.

Release changelog: https://github.com/conforma/infra-deployments-ci/blob/main/releases/2026-08-11T17%3A36%3A11/changelog.md

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Signed-off-by: jstuart@redhat.com

gitlint-ignore: B1
(cherry picked from commit cf08e94364eda97026b5424c4a9344129d96292e)

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
